### PR TITLE
Replace commonLabels with updated syntax

### DIFF
--- a/base/cloudkit-operator/kustomization.yaml
+++ b/base/cloudkit-operator/kustomization.yaml
@@ -5,14 +5,14 @@ metadata:
   name: cloudkit-operator-base
 
 resources:
-  - rbac.yaml
-  - manager.yaml
-  - crd.yaml
-  - clusterorder-crd.yaml
-  - manager-config.yaml
-  - feature-gates.yaml
-  - logging-config.yaml
-  - webhook-config.yaml
+- rbac.yaml
+- manager.yaml
+- crd.yaml
+- clusterorder-crd.yaml
+- manager-config.yaml
+- feature-gates.yaml
+- logging-config.yaml
+- webhook-config.yaml
 
 # Common annotations with naming metadata
 commonAnnotations:
@@ -20,12 +20,15 @@ commonAnnotations:
   cloudkit.io/project: operator
 
 # Common labels
-commonLabels:
-  app.kubernetes.io/name: cloudkit-operator
-  app.kubernetes.io/component: controller
-  app.kubernetes.io/part-of: cloudkit
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: cloudkit-operator
+    app.kubernetes.io/part-of: cloudkit
+
 
 images:
-  - name: quay.io/innabox/cloudkit-operator
-    newName: ghcr.io/innabox/cloudkit-operator
-    newTag: latest
+- name: quay.io/innabox/cloudkit-operator
+  newName: ghcr.io/innabox/cloudkit-operator
+  newTag: latest

--- a/base/shared/kustomization.yaml
+++ b/base/shared/kustomization.yaml
@@ -5,8 +5,8 @@ metadata:
   name: cloudkit-shared-base
 
 resources:
-  - namespace.yaml
-  - template-publisher.yaml
+- namespace.yaml
+- template-publisher.yaml
 
 # Common annotations for all CloudKit components
 commonAnnotations:
@@ -14,5 +14,7 @@ commonAnnotations:
   cloudkit.io/project: shared
 
 # Common labels for all CloudKit components
-commonLabels:
-  app.kubernetes.io/part-of: cloudkit
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/part-of: cloudkit


### PR DESCRIPTION
When deploying these manifests, kustomize would produce the warning:

> Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run
> 'kustomize edit fix' to update your Kustomization automatically.

This commit replaces `commonLabels` with the updated `labels` syntax.
