### PR TITLE
Fix request interval setting

### DIFF
--- a/base/cloudkit-operator/deployment.yaml
+++ b/base/cloudkit-operator/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               value: fulfillment-api:8000
             - name: CLOUDKIT_FULFILLMENT_TOKEN_FILE
               value: /var/run/secrets/kubernetes.io/serviceaccount/token
-            - name: CLOUDKIT_MINIMUM_REFRESH_INTERVAL
+            - name: CLOUDKIT_MINIMUM_REQUEST_INTERVAL
               value: "30s"
           image: cloudkit-operator
           imagePullPolicy: Always


### PR DESCRIPTION
Continuing our theme of fixing typos, correct the spelling of
`CLOUDKIT_MINIMUM_REQUEST_INTERVAL`.
