### PR TITLE
feat(overlay): add hypershift1 overlay for letsencrypt cert

### DIFF
--- a/overlays/hypershift1/kustomization.yaml
+++ b/overlays/hypershift1/kustomization.yaml
@@ -19,6 +19,4 @@ patches:
         duration: 2160h0m0s
         renewBefore: 360h0m0s
         dnsNames:
-          - localhost
-          - fulfillment-api
           - fulfillment-api.apps.hypershift1.nerc.mghpcc.org

--- a/overlays/hypershift1/kustomization.yaml
+++ b/overlays/hypershift1/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: innabox
+
+resources:
+  - ../../base
+
+patches:
+  - patch: |
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: fulfillment-api
+      spec:
+        issuerRef:
+          name: letsencrypt-production-dns01
+          kind: ClusterIssuer
+        duration: 2160h0m0s
+        renewBefore: 360h0m0s
+        dnsNames:
+          - localhost
+          - fulfillment-api
+          - fulfillment-api.apps.hypershift1.nerc.mghpcc.org


### PR DESCRIPTION
Why this change was necessary:
The fulfillment-service was using self-signed certificate which causes trust issues with clients
This adds proper Let's Encrypt certificate for production use, ensuring the API can be accessed securely with valid SSL certificates that browsers trust.

Key changes:
• Add new hypershift1 overlay with kustomization configuration
• Patch fulfillment-api Certificate to use letsencrypt-production-dns01 ClusterIssuer
• Configure certificate duration (2160h) and renewal (360h before expiry)
• Add DNS names for localhost, fulfillment-api, and hypershift1.nerc.mghpcc.org domain

Closes: https://github.com/innabox/issues/issues/199


PS: my first idea was this
https://github.com/innabox/managed-cluster-config/compare/main...schwesig:managed-cluster-config:20251203_199_FulfillmentLetsEncryptCert
but it would not follow the idea of @jhernand in comment https://github.com/innabox/issues/issues/199#issuecomment-3423593732