### PR TITLE
MGMT-23708: Fix deployment for CaaS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ local/
 **/dockerconfig.json
 **/*pull-secret.json
 [lL]icense.zip
+
+# Claude.md file
+CLAUDE.md
+
+# kubeconfig files
+kubeconfig.hub-access

--- a/README.md
+++ b/README.md
@@ -121,10 +121,15 @@ Use Kustomize to manage your environment-specific configurations.
    ```
 
 4. **Update Critical Configuration:**
-   You **must** update these two configuration values to match your `<project-name>`:
+   You **must** update these configuration values to match your environment:
 
    - In `kustomization.yaml`: Update the `namespace` field to `<project-name>`
    - In `prefixTransformer.yaml`: Update the `prefix` field to `<project-name>-`
+   - In `ca-trust-bundle.yaml`: Update the `values` field element
+     to `<project-name>`.
+   - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
+     value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
+     You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`
 
    These changes ensure your installation uses a unique namespace and prevents resource
    name conflicts with other OSAC installations.
@@ -136,6 +141,66 @@ Use Kustomize to manage your environment-specific configurations.
 > For more information on structuring overlays and patches, please consult the [official
 > Kustomize documentation.](https://kubectl.docs.kubernetes.io/references/kustomize/)
 
+
+### Using Custom Component Versions
+
+By default, the installer uses the latest commit from each submodule (via
+`git submodule update --init --recursive --remote`) and the latest container images
+defined in `base/kustomization.yaml`.
+
+To test a specific revision of a component, you need to:
+
+1. **Check out the desired code in the submodule:**
+
+   ```bash
+   cd base/<submodule>
+   git checkout <branch-or-commit>
+   cd ../..
+   ```
+
+2. **Build and push a custom container image:**
+
+   Build the image from the checked-out code and push it to a registry accessible by
+   your cluster.
+
+3. **Override the image in your overlay's `kustomization.yaml`:**
+
+   ```yaml
+   images:
+     - name: <component-image-name>
+       newName: <your-registry>/<your-image>
+       newTag: <your-tag>
+   ```
+
+   The component image names used in the base are:
+
+   | Component | Image name |
+   |-----------|-----------|
+   | Fulfillment Service | `fulfillment-service` |
+   | OSAC Operator | `osac-operator` |
+   | OSAC AAP | `osac-aap` |
+
+#### OSAC AAP Customization
+
+For osac-aap, in addition to the image override, you must also update the AAP
+configuration secrets in your overlay's `kustomization.yaml`:
+
+```yaml
+secretGenerator:
+- name: config-as-code-ig
+  options:
+    disableNameSuffixHash: true
+  literals:
+    - AAP_EE_IMAGE=<your-registry>/osac-aap:<your-tag>
+    - AAP_PROJECT_GIT_URI=<your-git-repo-url>
+    - AAP_PROJECT_GIT_BRANCH=<your-branch>
+```
+
+- `AAP_EE_IMAGE`: The Execution Environment image used by AAP to run automation jobs.
+  This should match the container image override above.
+- `AAP_PROJECT_GIT_URI`: The Git repository URL for the AAP project (playbooks and
+  configuration).
+- `AAP_PROJECT_GIT_BRANCH`: The Git branch to use for the AAP project.
 
 ### Obtaining an AAP License (Subscription Manifest)
 
@@ -163,7 +228,7 @@ The OSAC installer relies on external components managed as Git submodules. Befo
 running Kustomize, you must pull the manifest files into your local directory:
 
 ```bash
-$ git submodule update --init --recursive
+$ git submodule update --init --recursive --remote
 ```
 
 ### 2. Populate Local Secrets
@@ -180,6 +245,7 @@ Ensure your overlay contains the necessary secret files that are excluded from G
 The `scripts/setup.sh` script automates the entire installation process, including:
 
 - Installing prerequisite operators (cert-manager, trust-manager, Authorino, Keycloak, AAP)
+- Optionally installing LVMS (storage service), MetalLB (ingress service), Multicluster Engine (MCE + infrastructure operator), and OpenShift Virtualization (CNV)
 - Setting up the CA issuer and network attachment definitions
 - Applying the Kustomize overlay
 - Waiting for the AAP bootstrap job to complete
@@ -193,7 +259,26 @@ $ ./scripts/setup.sh
 
 # Or customize the namespace and overlay
 $ INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
+
+# Install with all optional services (storage, ingress, virtualization, MCE)
+$ EXTRA_SERVICES=true \
+    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
+
+# Or selectively enable specific services
+$ INGRESS_SERVICE=true STORAGE_SERVICE=true \
+    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
 ```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KUBECONFIG` | `~/.kube/config` | Path to the target cluster's kubeconfig file |
+| `INSTALLER_NAMESPACE` | from overlay | Target namespace for the OSAC deployment |
+| `INSTALLER_KUSTOMIZE_OVERLAY` | `development` | Kustomize overlay directory to use |
+| `EXTRA_SERVICES` | `false` | Enable all optional services (sets all below to `true`) |
+| `INGRESS_SERVICE` | `false` | Install MetalLB as the ingress/LoadBalancer service |
+| `STORAGE_SERVICE` | `false` | Install LVMS and create a default StorageClass (`lvms-vg1`) |
+| `VIRT_SERVICE` | `false` | Install OpenShift Virtualization |
+| `MCE_SERVICE` | `false` | Install Multicluster Engine and infrastructure operator |
 
 > **Note:** The script requires `fulfillment-cli` to be installed and available in your
 > `PATH` (see [Fulfillment CLI: Setup & Usage](#fulfillment-cli-setup--usage) below for
@@ -231,6 +316,28 @@ $ oc apply -k prerequisites/keycloak/
 
 # Install AAP operator
 $ oc apply -f prerequisites/aap-installation.yaml
+
+# Install MetalLB (optional - ingress/LoadBalancer service)
+$ oc apply -f prerequisites/metallb/metallb-operator.yaml
+# Wait for MetalLB operator to be ready, then apply config:
+$ oc apply -f prerequisites/metallb/metallb-config.yaml
+
+# Install LVMS (optional - storage service)
+$ oc apply -f prerequisites/lvms/lvms-operator.yaml
+# Wait for LVMS operator to be ready, then apply config:
+$ oc apply -f prerequisites/lvms/lvms-config.yaml
+# Set lvms-vg1 as default StorageClass:
+$ oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+
+# Install Multicluster Engine (optional - MCE + infrastructure operator)
+$ oc apply -f prerequisites/mce/mce-operator.yaml
+# Wait for MCE operator to be ready, then create MultiClusterEngine and AgentServiceConfig:
+$ oc apply -f prerequisites/mce/mce-config.yaml
+
+# Install OpenShift Virtualization (optional - CNV/KubeVirt)
+$ oc apply -f prerequisites/cnv/cnv-operator.yaml
+# Wait for CNV operator to be ready, then apply HyperConverged config:
+$ oc apply -f prerequisites/cnv/cnv-config.yaml
 ```
 
 > **Tip:** Wait for each operator deployment to become available before proceeding to
@@ -349,6 +456,24 @@ $ oc extract secret/osac-aap-admin-password -n <project-name> --to -
 - Username: `admin`
 - Password: (from the previous step)
 
+### Create an AAP API Token for the OSAC Operator
+
+The OSAC operator requires an API token to communicate with AAP. The `scripts/create-aap-token.sh`
+script automates this by authenticating with the AAP gateway using the admin password and
+creating a write-scoped token. The automated setup script (`setup.sh`) calls this automatically.
+
+For manual deployments, run it after the AAP bootstrap job completes:
+
+```bash
+$ INSTALLER_NAMESPACE=<project-name> ./scripts/create-aap-token.sh
+```
+
+This script will:
+- Retrieve the AAP admin password from the `osac-aap-admin-password` secret
+- Create an API token via the AAP gateway (`/api/gateway/v1/tokens/`)
+- Store the token in a `osac-aap-api-token` secret
+- Set the correct `OSAC_AAP_URL` on the operator deployment
+
 ### Using AAP Interface
 
 From the AAP web interface, you can:
@@ -357,6 +482,51 @@ From the AAP web interface, you can:
 - Manage job templates and automation workflows
 - Configure additional automation tasks
 - View inventory and host information
+
+## Tearing Down OSAC
+
+To completely remove an OSAC deployment and all its prerequisites, use the teardown script:
+
+```bash
+# Using defaults (namespace: osac-devel, overlay: development)
+$ ./scripts/teardown.sh
+
+# Or specify your namespace and overlay
+$ INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/teardown.sh
+
+# Include all optional services in teardown (must match what was used during setup)
+$ EXTRA_SERVICES=true \
+    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/teardown.sh
+
+# Or selectively match what was used during setup
+$ INGRESS_SERVICE=true STORAGE_SERVICE=true \
+    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/teardown.sh
+```
+
+The script removes resources in reverse order:
+1. StorageClass OSAC labels
+2. Kustomize overlay resources and project namespace
+3. Keycloak (before storage, since its PVCs depend on the storage class)
+4. AAP operator
+5. Multicluster Engine and AgentServiceConfig (if `MCE_SERVICE=true`)
+6. LVMS storage service (if `STORAGE_SERVICE=true`)
+7. MetalLB ingress service (if `INGRESS_SERVICE=true`)
+8. OpenShift Virtualization (if `VIRT_SERVICE=true`)
+9. Authorino operator
+10. CA issuer, trust-manager, and cert-manager
+11. Stale API services cleanup
+12. NetworkAttachmentDefinition
+13. Local `kubeconfig.hub-access` file
+
+The script waits for all namespaces to be fully deleted before completing.
+
+> **Warning:** This removes **all** prerequisite operators and their namespaces. If other
+> workloads on the cluster depend on these operators (e.g., cert-manager, MetalLB), do not
+> run this script. Instead, manually delete only the OSAC-specific resources:
+> ```bash
+> $ oc delete -k overlays/<project-name>
+> $ oc delete namespace <project-name>
+> ```
 
 ## Troubleshooting
 

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -26,7 +26,7 @@ images:
   newTag: latest
 - name: fulfillment-service
   newName: ghcr.io/osac-project/fulfillment-service
-  newTag: latest
+  newTag: main
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
   newTag: latest

--- a/overlays/development/capi-provider-role.yaml
+++ b/overlays/development/capi-provider-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: capi-provider-role
+  namespace: hardware-inventory
+rules:
+  - apiGroups:
+      - agent-install.openshift.io
+    resources:
+      - agents
+    verbs:
+      - '*'

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -17,6 +17,7 @@ labels:
 resources:
 - ../../base
 - ./ca-trust-bundle.yaml
+- ./capi-provider-role.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -42,9 +43,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:4f1ba397a8b6c9ef6fa8abe504baafceec8009db
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:latest
     - AAP_PROJECT_GIT_URI="https://github.com/osac-project/osac-aap"
-    - AAP_PROJECT_GIT_BRANCH=4f1ba39
+    - AAP_PROJECT_GIT_BRANCH=main
 
 - name: cluster-fulfillment-ig
   options:
@@ -58,12 +59,6 @@ secretGenerator:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
 
 images:
-  - name: ghcr.io/osac-project/osac-operator:latest
-    digest: sha256:831ea9f34ac727ae42870daf69754e6308b85b11fb982fe11c0dae3331281fcd
-  - name: ghcr.io/osac-project/osac-aap:latest
-    digest: sha256:01c0157b308726a576f7087328347490b70794cfef9733539bbb21fbf2b30329
-  - name: ghcr.io/osac-project/fulfillment-service:main
-    newTag: v0.0.39
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli
     newTag: "4.20.0"
@@ -87,28 +82,47 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_CLUSTER_CREATE_WEBHOOK
-          value: http://osac-eda-service:5000/create-hosted-cluster
+          name: OSAC_PROVISIONING_PROVIDER
+          value: "aap"
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_CLUSTER_DELETE_WEBHOOK
-          value: http://osac-eda-service:5000/delete-hosted-cluster
+          name: OSAC_AAP_TEMPLATE_PREFIX
+          value: osac
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_PROVISION_TEMPLATE
+          value: osac-create-virtual-network
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_URL
+          value: "https://osac-aap.osac-devel.apps.<cluster-name>.<base-domain>/api/controller"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: osac-aap-api-token
+              key: token
+              optional: true
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_INSECURE_SKIP_VERIFY
+          value: "true"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_STATUS_POLL_INTERVAL
+          value: "30s"
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: OSAC_MINIMUM_REQUEST_INTERVAL
           value: "2m"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_COMPUTE_INSTANCE_PROVISION_WEBHOOK
-          value: http://osac-eda-service:5000/create-compute-instance
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK
-          value: http://osac-eda-service:5000/delete-compute-instance
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/prerequisites/cnv/cnv-config.yaml
+++ b/prerequisites/cnv/cnv-config.yaml
@@ -11,19 +11,10 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-
-resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+# HyperConverged instance to deploy OpenShift Virtualization components
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec: {}

--- a/prerequisites/cnv/cnv-operator.yaml
+++ b/prerequisites/cnv/cnv-operator.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-cnv
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: openshift-cnv
+spec:
+  targetNamespaces:
+    - openshift-cnv
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/prerequisites/cnv/kustomization.yaml
+++ b/prerequisites/cnv/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cnv-operator.yaml
+  - cnv-config.yaml

--- a/prerequisites/lvms/kustomization.yaml
+++ b/prerequisites/lvms/kustomization.yaml
@@ -14,16 +14,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-
 resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+  - lvms-operator.yaml
+  - lvms-config.yaml

--- a/prerequisites/lvms/lvms-config.yaml
+++ b/prerequisites/lvms/lvms-config.yaml
@@ -11,19 +11,18 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-
-resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+# LVMCluster instance with a default volume group using all available disks.
+apiVersion: lvm.topolvm.io/v1alpha1
+kind: LVMCluster
+metadata:
+  name: lvms-cluster
+  namespace: openshift-storage
+spec:
+  storage:
+    deviceClasses:
+      - name: vg1
+        default: true
+        thinPoolConfig:
+          name: thin-pool-1
+          sizePercent: 90
+          overprovisionRatio: 10

--- a/prerequisites/lvms/lvms-operator.yaml
+++ b/prerequisites/lvms/lvms-operator.yaml
@@ -11,19 +11,29 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-
-resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lvms-operator
+  namespace: openshift-storage
+spec:
+  name: lvms-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/prerequisites/mce/kustomization.yaml
+++ b/prerequisites/mce/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mce-operator.yaml
+  - mce-config.yaml

--- a/prerequisites/mce/mce-config.yaml
+++ b/prerequisites/mce/mce-config.yaml
@@ -11,19 +11,27 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-
-resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+# AgentServiceConfig to deploy the infrastructure operator (assisted-service)
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+spec:
+  databaseStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+  filesystemStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20Gi
+  imageStorage:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 50Gi

--- a/prerequisites/mce/mce-operator.yaml
+++ b/prerequisites/mce/mce-operator.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multicluster-engine
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: mce
+  namespace: multicluster-engine
+spec:
+  targetNamespaces:
+    - multicluster-engine
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: multicluster-engine
+  namespace: multicluster-engine
+spec:
+  name: multicluster-engine
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/prerequisites/metallb/kustomization.yaml
+++ b/prerequisites/metallb/kustomization.yaml
@@ -14,16 +14,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-
 resources:
-- cert-manager/
-- ca-issuer.yaml
-- trust-manager.yaml
-- authorino-operator.yaml
-- keycloak
-- nfs-subdir-provisioner/overlays/lab
-- aap-installation.yaml
-- metallb/
-- lvms/
-- cnv/
-- mce/
+  - metallb-operator.yaml
+  - metallb-config.yaml

--- a/prerequisites/metallb/metallb-config.yaml
+++ b/prerequisites/metallb/metallb-config.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+# MetalLB instance
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+---
+# MetalLB IPAddressPool and L2Advertisement for CaaS LoadBalancer services.
+# Update the address range below to match your environment.
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: caas-address-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    # Replace with your environment's IP range for LoadBalancer services
+    - 192.168.100.240-192.168.100.250
+  autoAssign: false
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: caas-l2-advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - caas-address-pool

--- a/prerequisites/metallb/metallb-operator.yaml
+++ b/prerequisites/metallb/metallb-operator.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    workload.openshift.io/allowed: management
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: metallb-operator
+  namespace: metallb-system
+spec:
+  channel: stable
+  name: metallb-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -19,6 +19,22 @@ retry_until() {
     done
 }
 
+# Wait for a namespace to finish terminating if it exists in Terminating state
+# Usage: wait_for_namespace_cleanup <namespace> [timeout_seconds]
+wait_for_namespace_cleanup() {
+    local namespace="$1"
+    local timeout="${2:-300}"
+
+    if oc get namespace "${namespace}" &>/dev/null && \
+       [[ "$(oc get namespace "${namespace}" -o jsonpath='{.status.phase}')" == "Terminating" ]]; then
+        echo "Waiting for namespace ${namespace} to finish terminating..."
+        oc wait --for=delete "namespace/${namespace}" --timeout="${timeout}s" || {
+            echo "ERROR: namespace ${namespace} stuck in Terminating state. You may need to manually remove finalizers."
+            exit 1
+        }
+    fi
+}
+
 # Wait for a namespace to exist and a resource within it to match a condition
 # Usage: wait_for_resource <resource> <condition> [timeout_seconds] [namespace]
 wait_for_resource() {

--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-"osac-devel"}
+
+# Get the AAP gateway route URL
+AAP_ROUTE_HOST=$(oc get routes -n ${INSTALLER_NAMESPACE} --no-headers | awk '$1 ~ /osac-aap/ {print $2; exit}')
+AAP_URL="https://${AAP_ROUTE_HOST}"
+
+# Get the AAP admin password
+AAP_ADMIN_PASSWORD=$(oc get secret osac-aap-admin-password -n ${INSTALLER_NAMESPACE} -o jsonpath='{.data.password}' | base64 -d)
+
+# Create an API token using basic auth against the AAP gateway
+AAP_TOKEN=$(curl -sk -X POST \
+    -u "admin:${AAP_ADMIN_PASSWORD}" \
+    -H "Content-Type: application/json" \
+    -d '{"description": "osac-operator", "scope": "write"}' \
+    "${AAP_URL}/api/gateway/v1/tokens/" | jq -r '.token')
+
+if [[ -z "${AAP_TOKEN}" || "${AAP_TOKEN}" == "null" ]]; then
+    echo "Failed to create AAP API token"
+    exit 1
+fi
+
+# Store the token in a Kubernetes secret
+oc create secret generic osac-aap-api-token \
+    --from-literal=token="${AAP_TOKEN}" \
+    -n ${INSTALLER_NAMESPACE} \
+    --dry-run=client -o yaml | oc apply -f -
+
+# Set the correct AAP URL on the operator deployment (triggers rollout)
+oc set env deployment/osac-operator-controller-manager \
+    -n ${INSTALLER_NAMESPACE} \
+    OSAC_AAP_URL="${AAP_URL}/api/controller"
+
+echo "AAP API token created and stored in secret osac-aap-api-token"

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
+
+# Create hub access kubeconfig
+./scripts/create-hub-access-kubeconfig.sh
+
+# Login to fulfillment API and create hub
+FULFILLMENT_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment-api -o jsonpath='{.status.ingress[0].host}')
+fulfillment-cli login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_API_URL}
+fulfillment-cli create hub --kubeconfig=kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
+
+# Wait for computeinstancetemplate to exist
+retry_until 1200 5 '[[ -n "$(fulfillment-cli get computeinstancetemplate -o json | jq -r --arg tpl ${INSTALLER_VM_TEMPLATE} '"'"'select(.id == $tpl)'"'"' 2> /dev/null)" ]]' || {
+    echo "Timed out waiting for computeinstancetemplate to exist"
+    exit 1
+}

--- a/scripts/prepare-tenant.sh
+++ b/scripts/prepare-tenant.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
+
+# Create Tenant CR
+cat <<EOF | oc apply -f -
+apiVersion: osac.openshift.io/v1alpha1
+kind: Tenant
+metadata:
+  name: ${INSTALLER_NAMESPACE}
+  namespace: ${INSTALLER_NAMESPACE}
+spec: {}
+EOF
+
+# Label default StorageClass for the tenant
+DEFAULT_SC=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
+[[ -z "${DEFAULT_SC}" ]] && echo "ERROR: No default StorageClass found — Tenant requires a labeled SC to reach Ready" && exit 1
+oc label sc "${DEFAULT_SC}" "osac.openshift.io/tenant=${INSTALLER_NAMESPACE}" --overwrite
+
+# Wait for Tenant to be Ready
+retry_until 120 5 '[[ "$(oc get tenant ${INSTALLER_NAMESPACE} -n ${INSTALLER_NAMESPACE} -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Ready" ]]' || {
+    echo "Timed out waiting for Tenant to be Ready"
+    exit 1
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,17 @@ INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
 [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
+# EXTRA_SERVICES=true enables all optional services (storage, ingress, virtualization, MCE)
+EXTRA_SERVICES=${EXTRA_SERVICES:-"false"}
+INGRESS_SERVICE=${INGRESS_SERVICE:-${EXTRA_SERVICES}}
+STORAGE_SERVICE=${STORAGE_SERVICE:-${EXTRA_SERVICES}}
+VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
+MCE_SERVICE=${MCE_SERVICE:-${EXTRA_SERVICES}}
+
+echo "=== Setting up OSAC deployment ==="
+echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
+echo "Namespace: ${INSTALLER_NAMESPACE}"
+echo ""
 
 # Apply default network attachment definition for VMs
 cat <<EOF | oc apply -f -
@@ -23,7 +34,129 @@ spec:
   config: '{"cniVersion": "0.4.0", "name": "ovn-kubernetes", "type": "ovn-k8s-cni-overlay"}'
 EOF
 
+# Optionally install LVMS as storage service (must be before keycloak which needs a default storage class)
+if [[ "${STORAGE_SERVICE}" == "true" ]]; then
+    wait_for_namespace_cleanup openshift-storage
+    echo "Installing LVMS storage service..."
+    oc apply -f prerequisites/lvms/lvms-operator.yaml
+    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n openshift-storage | grep lvms)" ]]' 'oc apply -f prerequisites/lvms/lvms-operator.yaml || true' || {
+        echo "Timed out waiting for LVMS CSV to exist"
+        exit 1
+    }
+    LVMS_CSV=$(oc get csv --no-headers -n openshift-storage | awk '/lvms/ { print $1 }')
+    wait_for_resource clusterserviceversion/${LVMS_CSV} jsonpath='{.status.phase}'=Succeeded 300 openshift-storage
+    wait_for_resource deployment/lvms-operator condition=Available 300 openshift-storage
+
+    # Apply LVMCluster configuration (requires operator CRDs to be installed)
+    oc apply -f prerequisites/lvms/lvms-config.yaml
+
+    # Wait for the storage class to be created and set it as default
+    retry_until 300 5 '[[ -n "$(oc get sc --ignore-not-found lvms-vg1)" ]]' || {
+        echo "Timed out waiting for lvms-vg1 StorageClass to exist"
+        exit 1
+    }
+    oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+fi
+
+# Optionally install MetalLB as ingress service
+if [[ "${INGRESS_SERVICE}" == "true" ]]; then
+    wait_for_namespace_cleanup metallb-system
+    echo "Installing MetalLB ingress service..."
+    oc apply -f prerequisites/metallb/metallb-operator.yaml
+    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n metallb-system | grep metallb)" ]]' 'oc apply -f prerequisites/metallb/metallb-operator.yaml || true' || {
+        echo "Timed out waiting for MetalLB CSV to exist"
+        exit 1
+    }
+    METALLB_CSV=$(oc get csv --no-headers -n metallb-system | awk '/metallb/ { print $1 }')
+    wait_for_resource clusterserviceversion/${METALLB_CSV} jsonpath='{.status.phase}'=Succeeded 300 metallb-system
+    wait_for_resource deployment/metallb-operator-controller-manager condition=Available 300 metallb-system
+    wait_for_resource deployment/metallb-operator-webhook-server condition=Available 300 metallb-system
+
+    # Apply MetalLB CRD-based configuration (requires operator CRDs to be installed)
+    oc apply -f prerequisites/metallb/metallb-config.yaml
+fi
+
+# Optionally install Multicluster Engine and infrastructure operator
+if [[ "${MCE_SERVICE}" == "true" ]]; then
+    wait_for_namespace_cleanup multicluster-engine
+    echo "Installing Multicluster Engine..."
+    oc apply -f prerequisites/mce/mce-operator.yaml
+    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n multicluster-engine | grep multicluster-engine)" ]]' 'oc apply -f prerequisites/mce/mce-operator.yaml || true' || {
+        echo "Timed out waiting for MCE CSV to exist"
+        exit 1
+    }
+    MCE_CSV=$(oc get csv --no-headers -n multicluster-engine | awk '/multicluster-engine/ { print $1 }')
+    wait_for_resource clusterserviceversion/${MCE_CSV} jsonpath='{.status.phase}'=Succeeded 600 multicluster-engine
+
+    # Create MultiClusterEngine if one doesn't already exist (only one instance is allowed)
+    if [[ -z "$(oc get multiclusterengine --no-headers 2>/dev/null)" ]]; then
+        cat <<EOF | oc apply -f -
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec: {}
+EOF
+    fi
+
+    # Wait for MultiClusterEngine to be available
+    MCE_NAME=$(oc get multiclusterengine -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+    retry_until 600 10 '[[ "$(oc get multiclusterengine '"${MCE_NAME}"' -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Available" ]]' || {
+        echo "Timed out waiting for MultiClusterEngine to be Available"
+        exit 1
+    }
+
+    # Apply AgentServiceConfig (retry in case webhooks are not ready yet)
+    retry_until 60 5 'oc apply -f prerequisites/mce/mce-config.yaml 2>/dev/null' || {
+        echo "Failed to apply AgentServiceConfig"
+        exit 1
+    }
+
+    # Wait for AgentServiceConfig deployment (infrastructure operator)
+    echo "Waiting for infrastructure operator (assisted-service) to be ready..."
+    wait_for_resource deployment/assisted-service condition=Available 600 multicluster-engine
+fi
+
+# Optionally install OpenShift Virtualization
+if [[ "${VIRT_SERVICE}" == "true" ]]; then
+    wait_for_namespace_cleanup openshift-cnv
+    echo "Installing OpenShift Virtualization..."
+    oc apply -f prerequisites/cnv/cnv-operator.yaml
+    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n openshift-cnv | grep kubevirt-hyperconverged-operator)" ]]' 'oc apply -f prerequisites/cnv/cnv-operator.yaml || true' || {
+        echo "Timed out waiting for OpenShift Virtualization CSV to exist"
+        exit 1
+    }
+    CNV_CSV=$(oc get csv --no-headers -n openshift-cnv | awk '/kubevirt-hyperconverged-operator/ { print $1 }' | tail -1)
+    wait_for_resource clusterserviceversion/${CNV_CSV} jsonpath='{.status.phase}'=Succeeded 600 openshift-cnv
+
+    # Delete stale sub-CRs from previous installs that may block HyperConverged
+    for cr in cdi kubevirt ssp; do
+        for name in $(oc get "${cr}" -n openshift-cnv --no-headers -o name 2>/dev/null); do
+            phase=$(oc get "${name}" -n openshift-cnv -o jsonpath='{.status.phase}' 2>/dev/null)
+            if [[ "${phase}" == "Error" ]]; then
+                echo "Deleting stale ${name} in Error phase..."
+                oc delete "${name}" -n openshift-cnv --timeout=30s 2>/dev/null || \
+                    oc patch "${name}" -n openshift-cnv --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+            fi
+        done
+    done
+
+    # Apply HyperConverged CR (retry in case webhooks are not ready yet)
+    retry_until 60 5 'oc apply -f prerequisites/cnv/cnv-config.yaml 2>/dev/null' || {
+        echo "Failed to apply HyperConverged CR"
+        exit 1
+    }
+
+    # Wait for HyperConverged to be available
+    echo "Waiting for OpenShift Virtualization to be ready (this may take up to 10 minutes)..."
+    retry_until 900 10 '[[ "$(oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv -o jsonpath='"'"'{.status.conditions[?(@.type=="Available")].status}'"'"' 2>/dev/null)" == "True" ]]' || {
+        echo "Timed out waiting for HyperConverged to be Available"
+        exit 1
+    }
+fi
+
 # Apply cert-manager prerequisites and wait for it to be ready
+oc apply -k prerequisites/cert-manager
 retry_until 300 3 '[[ -n "$(oc get crd --ignore-not-found certmanagers.operator.openshift.io)" ]]' 'oc apply -k prerequisites/cert-manager || true' || {
     echo "Timed out waiting for cert-manager CRD to exist"
     exit 1
@@ -51,10 +184,12 @@ wait_for_resource clusterserviceversion/${AUTHORINO_CSV} jsonpath='{.status.phas
 wait_for_resource deployment/authorino-operator condition=Available 300 openshift-operators
 
 # Apply keycloak prerequisites and wait for it to be ready
+wait_for_namespace_cleanup keycloak
 oc apply -k prerequisites/keycloak/
 wait_for_resource deployment/keycloak-service condition=Available 600 keycloak
 
 # Apply AAP prerequisites and wait for it to be ready
+wait_for_namespace_cleanup ansible-aap
 oc apply -f prerequisites/aap-installation.yaml
 retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n ansible-aap | grep aap)" ]]' 'oc apply -f prerequisites/aap-installation.yaml || true' || {
     echo "Timed out waiting for AAP CSV to exist"
@@ -64,61 +199,27 @@ AAP_CSV=$(oc get csv --no-headers -n ansible-aap | awk '/aap/ { print $1 }')
 wait_for_resource clusterserviceversion/${AAP_CSV} jsonpath='{.status.phase}'=Succeeded 300 ansible-aap
 wait_for_resource deployment/automation-controller-operator-controller-manager condition=Available 300 ansible-aap
 
+# Wait for OSAC namespace to finish terminating if needed
+wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
+
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
 # Wait for AAP bootstrap job to complete
+echo "Waiting for AAP bootstrap job to complete (this may take up to 20 minutes)..."
 wait_for_resource job/aap-bootstrap condition=complete 1200 ${INSTALLER_NAMESPACE}
 
 # Update project context
 oc project ${INSTALLER_NAMESPACE}
 
-# Create hub access kubeconfig
-./scripts/create-hub-access-kubeconfig.sh
+# Create AAP API token for the OSAC operator
+./scripts/prepare-aap.sh
 
-# Login to fulfillment API and create hub
-FULFILLMENT_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment-api -o jsonpath='{.status.ingress[0].host}')
-fulfillment-cli login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_API_URL}
-fulfillment-cli create hub --kubeconfig=kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
+# Setup fulfillment CLI, register hub
+./scripts/prepare-fulfillment-service.sh
 
-# Wait for computeinstancetemplate to exist
-retry_until 1200 5 '[[ -n "$(fulfillment-cli get computeinstancetemplate -o json | jq -r --arg tpl ${INSTALLER_VM_TEMPLATE} '"'"'select(.id == $tpl)'"'"' 2> /dev/null)" ]]' || {
-    echo "Timed out waiting for computeinstancetemplate to exist"
-    exit 1
-}
+# Prepare tenant
+./scripts/prepare-tenant.sh
 
-# Create AAP token and configure the operator for direct AAP integration
-AAP_PASSWORD=$(oc get secret osac-aap-admin-password -n ${INSTALLER_NAMESPACE} -o jsonpath='{.data.password}' | base64 -d)
-[[ -z "${AAP_PASSWORD}" ]] && echo "ERROR: Failed to get AAP password from secret osac-aap-admin-password" && exit 1
-
-AAP_TOKEN=$(oc exec deployment/fulfillment-grpc-server -n ${INSTALLER_NAMESPACE} -- \
-    sh -c "curl -sf -X POST http://osac-aap:80/api/controller/v2/tokens/ \
-    -u admin:${AAP_PASSWORD} -H 'Content-Type: application/json' -d '{}'" | jq -r '.token')
-[[ -z "${AAP_TOKEN}" || "${AAP_TOKEN}" == "null" ]] && echo "ERROR: Failed to create AAP token" && exit 1
-
-oc set env deployment/osac-operator-controller-manager -n ${INSTALLER_NAMESPACE} \
-    OSAC_AAP_URL="http://osac-aap:80/api/controller" \
-    OSAC_AAP_TOKEN="${AAP_TOKEN}" \
-    OSAC_AAP_PROVISION_TEMPLATE="osac-create-compute-instance" \
-    OSAC_AAP_DEPROVISION_TEMPLATE="osac-delete-compute-instance"
-
-# Create Tenant CR
-cat <<EOF | oc apply -f -
-apiVersion: osac.openshift.io/v1alpha1
-kind: Tenant
-metadata:
-  name: ${INSTALLER_NAMESPACE}
-  namespace: ${INSTALLER_NAMESPACE}
-spec: {}
-EOF
-
-# Label default StorageClass for the tenant
-DEFAULT_SC=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-[[ -z "${DEFAULT_SC}" ]] && echo "ERROR: No default StorageClass found — Tenant requires a labeled SC to reach Ready" && exit 1
-oc label sc "${DEFAULT_SC}" "osac.openshift.io/tenant=${INSTALLER_NAMESPACE}" --overwrite
-
-# Wait for Tenant to be Ready
-retry_until 120 5 '[[ "$(oc get tenant ${INSTALLER_NAMESPACE} -n ${INSTALLER_NAMESPACE} -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Ready" ]]' || {
-    echo "Timed out waiting for Tenant to be Ready"
-    exit 1
-}
+echo ""
+echo "=== Setup complete ==="

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+# EXTRA_SERVICES=true enables all optional services (storage, ingress, virtualization, MCE)
+EXTRA_SERVICES=${EXTRA_SERVICES:-"false"}
+INGRESS_SERVICE=${INGRESS_SERVICE:-${EXTRA_SERVICES}}
+STORAGE_SERVICE=${STORAGE_SERVICE:-${EXTRA_SERVICES}}
+VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
+MCE_SERVICE=${MCE_SERVICE:-${EXTRA_SERVICES}}
+
+echo "=== Tearing down OSAC deployment ==="
+echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
+echo "Namespace: ${INSTALLER_NAMESPACE}"
+echo ""
+
+# Remove StorageClass label
+DEFAULT_SC=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null)
+if [[ -n "${DEFAULT_SC}" ]]; then
+    echo "Removing OSAC label from StorageClass ${DEFAULT_SC}..."
+    oc label sc "${DEFAULT_SC}" "osac.openshift.io/tenant-" 2>/dev/null || true
+fi
+
+# Delete the kustomize overlay resources
+echo "Deleting kustomize overlay resources..."
+oc delete -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}" --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete the OSAC namespace
+echo "Deleting namespace ${INSTALLER_NAMESPACE}..."
+oc delete namespace "${INSTALLER_NAMESPACE}" --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete Keycloak (before LVMS since keycloak PVCs depend on the LVMS storage class)
+echo "Deleting Keycloak..."
+oc delete -k prerequisites/keycloak/ --ignore-not-found --wait=false 2>/dev/null || true
+oc delete namespace keycloak --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete AAP operator
+echo "Deleting AAP operator..."
+oc delete -f prerequisites/aap-installation.yaml --ignore-not-found --wait=false 2>/dev/null || true
+oc delete namespace ansible-aap --ignore-not-found --wait=false 2>/dev/null || true
+
+# Optionally delete Multicluster Engine (before LVMS since AgentServiceConfig PVCs depend on storage)
+if [[ "${MCE_SERVICE}" == "true" ]]; then
+    echo "Deleting AgentServiceConfig..."
+    oc delete agentserviceconfig agent --ignore-not-found --timeout=120s 2>/dev/null || true
+    echo "Deleting MultiClusterEngine..."
+    oc delete multiclusterengine --all --ignore-not-found --timeout=120s 2>/dev/null || true
+    # Wait for MultiClusterEngine to be fully removed
+    retry_until 120 5 '[[ -z "$(oc get multiclusterengine --no-headers 2>/dev/null)" ]]' || {
+        echo "WARNING: MultiClusterEngine resources still exist, removing finalizers manually..."
+        for name in $(oc get multiclusterengine -o name 2>/dev/null); do
+            oc patch "${name}" --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+        done
+    }
+    echo "Deleting MCE operator..."
+    oc delete -f prerequisites/mce/mce-operator.yaml --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete namespace multicluster-engine --ignore-not-found --wait=false 2>/dev/null || true
+fi
+
+# Wait for namespaces with LVMS-backed PVCs to be fully deleted before removing storage
+for ns in keycloak "${INSTALLER_NAMESPACE}" multicluster-engine; do
+    if oc get namespace "${ns}" &>/dev/null; then
+        echo "Waiting for namespace ${ns} to be deleted before removing storage..."
+        oc wait --for=delete "namespace/${ns}" --timeout=300s 2>/dev/null || echo "WARNING: namespace ${ns} still terminating"
+    fi
+done
+
+# Optionally delete LVMS storage service
+if [[ "${STORAGE_SERVICE}" == "true" ]]; then
+    echo "Deleting LVMS configuration..."
+    oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class- 2>/dev/null || true
+    # Delete LVMCluster and wait for the operator to process finalizers before removing the operator
+    oc delete -f prerequisites/lvms/lvms-config.yaml --ignore-not-found --timeout=120s 2>/dev/null || true
+    # Wait for all LVMCluster CRs to be fully removed (finalizers processed by operator)
+    retry_until 120 5 '[[ -z "$(oc get lvmcluster -n openshift-storage --no-headers 2>/dev/null)" ]]' || {
+        echo "WARNING: LVMCluster resources still exist, removing finalizers manually..."
+        for resource in lvmcluster lvmvolumegroup lvmvolumegroupnodestatus; do
+            for name in $(oc get "${resource}" -n openshift-storage -o name 2>/dev/null); do
+                oc patch "${name}" -n openshift-storage --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+            done
+        done
+    }
+    echo "Deleting LVMS operator..."
+    oc delete -f prerequisites/lvms/lvms-operator.yaml --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete namespace openshift-storage --ignore-not-found --wait=false 2>/dev/null || true
+fi
+
+# Optionally delete MetalLB ingress service
+if [[ "${INGRESS_SERVICE}" == "true" ]]; then
+    echo "Deleting MetalLB configuration..."
+    oc delete -f prerequisites/metallb/metallb-config.yaml --ignore-not-found --wait=false 2>/dev/null || true
+    echo "Deleting MetalLB operator..."
+    oc delete -f prerequisites/metallb/metallb-operator.yaml --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete namespace metallb-system --ignore-not-found --wait=false 2>/dev/null || true
+fi
+
+# Optionally delete OpenShift Virtualization
+if [[ "${VIRT_SERVICE}" == "true" ]]; then
+    echo "Deleting OpenShift Virtualization configuration..."
+    oc delete -f prerequisites/cnv/cnv-config.yaml --ignore-not-found --timeout=120s 2>/dev/null || true
+    # Wait for HyperConverged CR to be fully removed
+    retry_until 120 5 '[[ -z "$(oc get hyperconverged -n openshift-cnv --no-headers 2>/dev/null)" ]]' || {
+        echo "WARNING: CNV resources still exist, removing finalizers manually..."
+        for resource in hyperconverged kubevirt ssp cdi; do
+            for name in $(oc get "${resource}" -n openshift-cnv -o name 2>/dev/null); do
+                oc patch "${name}" -n openshift-cnv --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+            done
+        done
+    }
+    # Clean up stale webhooks left behind by the operator
+    for wh in $(oc get validatingwebhookconfiguration --no-headers 2>/dev/null | awk '/virt/ {print $1}'); do
+        oc delete validatingwebhookconfiguration "${wh}" 2>/dev/null || true
+    done
+    for wh in $(oc get mutatingwebhookconfiguration --no-headers 2>/dev/null | awk '/virt/ {print $1}'); do
+        oc delete mutatingwebhookconfiguration "${wh}" 2>/dev/null || true
+    done
+    echo "Deleting OpenShift Virtualization operator..."
+    oc delete -f prerequisites/cnv/cnv-operator.yaml --ignore-not-found --wait=false 2>/dev/null || true
+    oc delete namespace openshift-cnv --ignore-not-found --wait=false 2>/dev/null || true
+fi
+
+# Delete Authorino operator
+echo "Deleting Authorino operator..."
+oc delete -f prerequisites/authorino-operator.yaml --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete CA issuer
+echo "Deleting CA issuer..."
+oc delete -f prerequisites/ca-issuer.yaml --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete trust-manager
+echo "Deleting trust-manager..."
+oc delete -f prerequisites/trust-manager.yaml --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete cert-manager
+echo "Deleting cert-manager..."
+oc delete -k prerequisites/cert-manager --ignore-not-found --wait=false 2>/dev/null || true
+oc delete namespace cert-manager --ignore-not-found --wait=false 2>/dev/null || true
+oc delete namespace cert-manager-operator --ignore-not-found --wait=false 2>/dev/null || true
+
+# Delete the NetworkAttachmentDefinition
+echo "Deleting NetworkAttachmentDefinition..."
+oc delete networkattachmentdefinition default -n openshift-ovn-kubernetes --ignore-not-found 2>/dev/null || true
+
+# Clean up local files created by setup
+rm -f kubeconfig.hub-access
+
+# Clean up stale API services left behind by removed operators (prevents namespace deletion from hanging)
+echo "Cleaning up stale API services..."
+for api in $(oc get apiservice --no-headers 2>/dev/null | awk '/False/ {print $1}'); do
+    echo "  Deleting stale apiservice ${api}..."
+    oc delete apiservice "${api}" 2>/dev/null || true
+done
+
+# Wait for namespaces to be fully deleted
+echo ""
+echo "Waiting for namespaces to be deleted..."
+for ns in "${INSTALLER_NAMESPACE}" keycloak ansible-aap multicluster-engine openshift-storage openshift-cnv metallb-system cert-manager cert-manager-operator; do
+    if oc get namespace "${ns}" &>/dev/null; then
+        echo "  Waiting for namespace ${ns}..."
+        oc wait --for=delete "namespace/${ns}" --timeout=300s 2>/dev/null || echo "  WARNING: namespace ${ns} still terminating"
+    fi
+done
+
+echo ""
+echo "=== Teardown complete ==="


### PR DESCRIPTION
  ### Summary

  Fixes and improves the deployment flow for CaaS (Container-as-a-Service) environments.

  - **New optional operator prerequisites** — Adds Kustomize manifests (operator subscription + config) for:
    - **Multicluster Engine (MCE)** — `MultiClusterEngine` and `AgentServiceConfig` resources
    - **OpenShift Virtualization (CNV)** — KubeVirt / HyperConverged operator
    - **LVM Storage (LVMS)** — LVMCluster with `lvms-vg1` as default StorageClass
    - **MetalLB** — Operator subscription and load balancer configuration for CaaS L4LB support
  - **Selective service enablement** — `setup.sh` and `teardown.sh` support `EXTRA_SERVICES=true` (all) or granular flags: `INGRESS_SERVICE`, `STORAGE_SERVICE`, `VIRT_SERVICE`, `MCE_SERVICE`
  - **Script refactoring** — Extracts `setup.sh` into modular scripts (`prepare-aap.sh`, `prepare-fulfillment-service.sh`, `prepare-tenant.sh`, `fulfillment-cli-setup.sh`) with shared
  utilities in `lib.sh` (retry/wait helpers)
  - **Teardown automation** — New `scripts/teardown.sh` for clean resource removal
  - **Cert-manager fix** — Ensures initial application before CRD-dependent operations
  - **AAP provider configuration** — Adds `OSAC_PROVISIONING_PROVIDER`, `OSAC_AAP_TEMPLATE_PREFIX`, and `OSAC_AAP_PROVISION_TEMPLATE` env vars to the operator deployment patch
  - **CaaS RBAC** — Adds `capi-provider-role.yaml` granting access to `agents` in the `hardware-inventory` namespace
  - **Image tag cleanup** — Removes pinned digests/tags from development overlay, switches fulfillment-service base tag from `latest` to `main`, and AAP EE image/branch to `latest`/`main`
  - **Overlay rename** — Renames `overlays/ci` → `overlays/vmaas-ci`; adds new `overlays/osac-devel` with `.buildfiles`
  - **Submodule updates** — Bumps `osac-aap`, `fulfillment-service`, and `osac-operator` submodules
  - **README updates** — Documents new configuration values, optional operator setup, custom component versions, setup script variables, teardown procedures, and AAP token creation

  ### Changed Files

  | Area | Files |
  |------|-------|
  | Prerequisites | `prerequisites/kustomization.yaml`, `prerequisites/metallb/` (new), `prerequisites/mce/` (new), `prerequisites/cnv/` (new), `prerequisites/lvms/` (new) |
  | Base | `base/kustomization.yaml`, submodule pointer updates |
  | Development overlay | `overlays/development/kustomization.yaml`, `capi-provider-role.yaml` (new), `ca-trust-bundle.yaml` |
  | Renamed overlay | `overlays/ci` → `overlays/vmaas-ci` |
  | Scripts | `setup.sh`, `teardown.sh` (new), `prepare-aap.sh` (new), `prepare-fulfillment-service.sh` (new), `prepare-tenant.sh` (new), `fulfillment-cli-setup.sh` (new), `lib.sh`,
  `create-aap-token.sh` |
  | Docs | `README.md`, `.gitignore` |

  ### Test Plan

  - End-to-end `setup.sh` execution on a fresh cluster
  - Full teardown (`teardown.sh`) and re-deployment verification
  - Independent `fulfillment-cli-setup.sh` testing with DNS availability
  - Selective service deployment with `INGRESS_SERVICE`, `STORAGE_SERVICE`, `VIRT_SERVICE`, `MCE_SERVICE` flags
