### PR TITLE
Remove Host and HostPool API endpoints from OPA policies

### DIFF
--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -239,16 +239,6 @@ patches:
                     "/osac.public.v1.Events/Watch",
                     "/osac.public.v1.HostClasses/Get",
                     "/osac.public.v1.HostClasses/List",
-                    "/osac.public.v1.HostPools/Create",
-                    "/osac.public.v1.HostPools/Delete",
-                    "/osac.public.v1.HostPools/Get",
-                    "/osac.public.v1.HostPools/List",
-                    "/osac.public.v1.HostPools/Update",
-                    "/osac.public.v1.Hosts/Create",
-                    "/osac.public.v1.Hosts/Delete",
-                    "/osac.public.v1.Hosts/Get",
-                    "/osac.public.v1.Hosts/List",
-                    "/osac.public.v1.Hosts/Update",
                   }
                 }
 

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -228,16 +228,6 @@ patches:
                     "/osac.public.v1.Events/Watch",
                     "/osac.public.v1.HostClasses/Get",
                     "/osac.public.v1.HostClasses/List",
-                    "/osac.public.v1.HostPools/Create",
-                    "/osac.public.v1.HostPools/Delete",
-                    "/osac.public.v1.HostPools/Get",
-                    "/osac.public.v1.HostPools/List",
-                    "/osac.public.v1.HostPools/Update",
-                    "/osac.public.v1.Hosts/Create",
-                    "/osac.public.v1.Hosts/Delete",
-                    "/osac.public.v1.Hosts/Get",
-                    "/osac.public.v1.Hosts/List",
-                    "/osac.public.v1.Hosts/Update",
                   }
                 }
 


### PR DESCRIPTION
Remove Host and HostPool API endpoint references from OPA authorization policies in osac-installer deployment overlays:

- Remove 10 endpoint references from overlays/development/kustomization.yaml
- Remove 10 endpoint references from overlays/vmaas-ci/kustomization.yaml

Endpoints removed:
- /osac.public.v1.HostPools/{Create,Delete,Get,List,Update}
- /osac.public.v1.Hosts/{Create,Delete,Get,List,Update}

HostClass endpoints remain as HostClass is still a supported resource.

This aligns with the removal of Host and HostPool resources from fulfillment-service and osac-operator (which will be replaced by resources matching those in the updated Bare Metal Fulfillment proposal).

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted non-admin user access to HostPools and Hosts resource operations (Create, Delete, Get, List, Update) across development and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->