### PR TITLE
MGMT-23832: Add networking CRD RBAC to hub-access Role

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -40,6 +40,60 @@ rules:
     verbs:
       - get
   - apiGroups:
+      - osac.openshift.io
+    resources:
+      - virtualnetworks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - virtualnetworks/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - subnets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - subnets/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - securitygroups
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - securitygroups/status
+    verbs:
+      - get
+  - apiGroups:
       - ""
     resources:
       - secrets


### PR DESCRIPTION
## Summary
- Add `virtualnetworks`, `subnets`, and `securitygroups` (plus `/status` subresources) to the `hub-access` Role
- Same permissions as existing `clusterorders` and `computeinstances` entries (full CRUD + watch)
- Required because the fulfillment controller creates networking CRs on the hub cluster via the `hub-access` service account

## Test plan
- [ ] Deploy with updated RBAC in a two-cluster setup and verify networking resources can be created on the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The hub-access role now has expanded permissions to create, update, delete, and manage virtual networks, subnets, and security groups, along with access to their status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->