### PR TITLE
MGMT-23855: Add publicippool rbac to hub-access role

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -99,6 +99,24 @@ rules:
       - secrets
     verbs:
       - create
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicippools
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicippools/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control permissions to enable management of public IP pool resources. Added comprehensive permissions for creating, deleting, retrieving, listing, patching, and updating IP pools, along with monitoring capabilities. Read-only access to pool status information has also been granted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->