### PR TITLE
NO_ISSUE: fix cert-manager webhook race and kubeconfig write path

### DIFF
--- a/scripts/create-hub-access-kubeconfig.sh
+++ b/scripts/create-hub-access-kubeconfig.sh
@@ -21,7 +21,7 @@ token=$(oc -n "$namespace" extract secret/hub-access --keys token --to - 2>/dev/
 
 echo "generating a kubeconfig for hub-access serviceaccount in $namespace namespace on $server_url"
 
-cat <<EOF >kubeconfig.hub-access
+cat <<EOF >/tmp/kubeconfig.hub-access
 apiVersion: v1
 clusters:
 - cluster:

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -20,7 +20,7 @@ VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
 # Login to fulfillment API and create hub
 FULFILLMENT_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment-api -o jsonpath='{.status.ingress[0].host}')
 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_API_URL}
-osac create hub --kubeconfig=kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
+osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
 
 # Wait for computeinstancetemplate to exist (VMaaS only)
 if [[ "${VIRT_SERVICE}" == "true" ]]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -167,11 +167,17 @@ wait_for_resource deployment/cert-manager-webhook condition=Available 300 cert-m
 wait_for_resource deployment/cert-manager-cainjector condition=Available 300 cert-manager
 
 # Apply trust-manager prerequisites and wait for it to be ready
-oc apply -f prerequisites/trust-manager.yaml
+retry_until 60 5 'oc apply -f prerequisites/trust-manager.yaml 2>/dev/null' || {
+    echo "Failed to apply trust-manager prerequisites"
+    exit 1
+}
 wait_for_resource deployment/trust-manager condition=Available 300 cert-manager
 
 # Apply CA issuer prerequisites and wait for it to be ready
-oc apply -f prerequisites/ca-issuer.yaml
+retry_until 60 5 'oc apply -f prerequisites/ca-issuer.yaml 2>/dev/null' || {
+    echo "Failed to apply CA issuer prerequisites"
+    exit 1
+}
 wait_for_resource clusterissuer/default-ca condition=Ready 300
 
 # Apply authorino prerequisites and wait for it to be ready


### PR DESCRIPTION
Two CI fixes:

1. **cert-manager webhook TLS race**: On fresh clusters, the cert-manager webhook deployment
becomes Available before its TLS certificate is trusted by the API server. The immediate
`oc apply` of trust-manager/ca-issuer resources hits the webhook and fails with
`x509: certificate signed by unknown authority`. Fixed by wrapping in `retry_until`.

2. **kubeconfig.hub-access permission denied**: On OpenShift, pods run as a random UID that
can't write to `/installer` (owned by root from the Dockerfile `ADD`). Fixed by writing
to `/tmp` which is world-writable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kubeconfig output path handling in setup scripts for improved consistency.
  * Added automatic retry mechanism with error handling for prerequisite resource deployment to enhance setup robustness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->