### PR TITLE
MGMT-22635: fix setup for CI E2E jobs

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -10,9 +10,7 @@ source "${SCRIPT_DIR}/lib.sh"
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
 [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
-INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
-EXTRA_SERVICES=${EXTRA_SERVICES:-"false"}
-VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 
 # Create hub access kubeconfig
 ./scripts/create-hub-access-kubeconfig.sh
@@ -22,9 +20,25 @@ FULFILLMENT_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment
 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_API_URL}
 osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
 
-# Wait for computeinstancetemplate to exist (VMaaS only)
-if [[ "${VIRT_SERVICE}" == "true" ]]; then
-    retry_until 1200 5 '[[ -n "$(osac get computeinstancetemplate -o json | jq -r --arg tpl ${INSTALLER_VM_TEMPLATE} '"'"'select(.id == $tpl)'"'"' 2> /dev/null)" ]]' || {
+if [[ -n "${INSTALLER_VM_TEMPLATE}" ]]; then
+    # Trigger a one-time publish-templates AAP job
+    AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
+    AAP_URL="https://${AAP_ROUTE_HOST}"
+    AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
+    JT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates" | jq -er '.results[0].id // empty') || {
+        echo "Failed to find osac-publish-templates AAP job template"
+        exit 1
+    }
+    echo "Launching publish-templates AAP job (template ID: ${JT_ID})..."
+    curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" >/dev/null || {
+        echo "Failed to launch osac-publish-templates AAP job"
+        exit 1
+    }
+
+    echo "Waiting for computeinstancetemplate ${INSTALLER_VM_TEMPLATE} to be published..."
+    retry_until 1200 5 '[[ -n "$(osac get computeinstancetemplate -o json | jq -r --arg tpl "$INSTALLER_VM_TEMPLATE" '"'"'select(.id == $tpl)'"'"' 2> /dev/null)" ]]' || {
         echo "Timed out waiting for computeinstancetemplate to exist"
         exit 1
     }

--- a/scripts/prepare-tenant.sh
+++ b/scripts/prepare-tenant.sh
@@ -11,7 +11,7 @@ source "${SCRIPT_DIR}/lib.sh"
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
 [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
-INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 
 # Create Tenant CR
 cat <<EOF | oc apply -f -

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/lib.sh"
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
 [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
-INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-"osac.templates.ocp_virt_vm"}
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 # EXTRA_SERVICES=true enables all optional services (storage, ingress, virtualization, MCE)
 EXTRA_SERVICES=${EXTRA_SERVICES:-"false"}
 INGRESS_SERVICE=${INGRESS_SERVICE:-${EXTRA_SERVICES}}
@@ -213,8 +213,11 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
 # Wait for AAP bootstrap job to complete
-echo "Waiting for AAP bootstrap job to complete (this may take up to 20 minutes)..."
-wait_for_resource job/aap-bootstrap condition=complete 1200 ${INSTALLER_NAMESPACE}
+echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
+wait_for_resource job/aap-bootstrap condition=complete 2400 ${INSTALLER_NAMESPACE}
+
+# Wait for Authorino to be ready (gRPC auth depends on it)
+wait_for_resource deployment/authorino condition=Available 300 ${INSTALLER_NAMESPACE}
 
 # Update project context
 oc project ${INSTALLER_NAMESPACE}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-22635

## Summary
- Wait for Authorino deployment before running prepare scripts — fixes `failed to check permissions` in CaaS CI jobs
- Increase AAP bootstrap timeout from 20 to 40 minutes — fixes intermittent timeouts in VMaaS CI jobs
- Trigger publish-templates AAP job and wait for VM template when `INSTALLER_VM_TEMPLATE` is set — fixes `Template 'osac.templates.ocp_virt_vm' doesn't exist` in VMaaS CI jobs
- Remove hardcoded `INSTALLER_VM_TEMPLATE` default so CaaS CI (which doesn't pass it) skips template publishing

## Test plan
- [x] CaaS setup + teardown cycle (no template wait, hub created successfully)
- [x] VMaaS setup + teardown cycle (template published and available)
- [x] Consecutive teardown runs on clean cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined VM template configuration defaults and environment variable handling for improved flexibility.
  * Extended bootstrap job timeout to support longer system initialization scenarios.
  * Added readiness verification for additional services to ensure proper deployment sequencing.
  * Enhanced template provisioning workflow with improved service integration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->