### PR TITLE
MGMT-23998: Add KubeVirt console RBAC for hub-access

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -130,3 +130,28 @@ subjects:
   - kind: ServiceAccount
     name: hub-access
     namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hub-access-console
+rules:
+  - apiGroups:
+      - subresources.kubevirt.io
+    resources:
+      - virtualmachineinstances/console
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hub-access-console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hub-access-console
+subjects:
+  - kind: ServiceAccount
+    name: hub-access
+    namespace: default


### PR DESCRIPTION
## Summary

- Add ClusterRole + ClusterRoleBinding granting the `hub-access` service account `get` access to `virtualmachineinstances/console` in the `subresources.kubevirt.io` API group
- Fixes VM serial console failing with a reconnect loop because the hub-access SA lacked KubeVirt RBAC

A ClusterRole (not a namespace-scoped Role) is needed because VMs can be in different namespaces depending on tenant and subnet configuration. Tenant isolation for console access is enforced at the fulfillment-service application layer (DAO tenant filtering), not at the Kubernetes RBAC layer — the hub-access SA is a backend identity used after the user's access has been validated.

**Jira:** [MGMT-23998](https://issues.redhat.com/browse/MGMT-23998)
**Related:** fulfillment-service logging fix in https://github.com/osac-project/fulfillment-service/pull/424

## Test plan

- [x] `kustomize build base/hub-access` renders valid ClusterRole + ClusterRoleBinding
- [x] Overlay simulation confirms name prefix, roleRef tracking, and subject namespace override all work correctly
- [ ] Apply manually to a live stack and verify `fulfillment-cli console computeinstance` works

Generated-By: Claude Code (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster-wide permissions granting the hub-access service account read access to virtual machine instance consoles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->