### PR TITLE
fix: Add cluster-fulfillment-ig secret back to overlays

### DIFF
--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -46,6 +46,11 @@ secretGenerator:
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
     - AAP_PROJECT_GIT_BRANCH=main
 
+- name: cluster-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 - name: publish-templates-ig
   literals:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -47,6 +47,11 @@ secretGenerator:
     - AAP_PROJECT_GIT_URI="https://github.com/osac-project/osac-aap"
     - AAP_PROJECT_GIT_BRANCH=main
 
+- name: cluster-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 - name: publish-templates-ig
   literals:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -46,6 +46,11 @@ secretGenerator:
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
     - AAP_PROJECT_GIT_BRANCH=main
 
+- name: cluster-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 - name: publish-templates-ig
   literals:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud


### PR DESCRIPTION
## Summary

We are seeing failures in aap automation jobs
```
  Normal   Pulling         11s (x9 over 93s)  kubelet            Pulling image "ghcr.io/osac-project/osac-aap:latest"                                                                                                                         
  Warning  Failed          10s (x9 over 92s)  kubelet            Error: secret "cluster-fulfillment-ig" not found  
```

Restores the `cluster-fulfillment-ig` secret to the Kustomize overlays where it was previously removed. This empty secret is required by the cluster fulfillment workflow and is labeled with `osac.openshift.io/project: osac-aap` for proper resource tracking.

## Changes

- Added `cluster-fulfillment-ig` secretGenerator entry to:
  - `overlays/caas-ci/kustomization.yaml`
  - `overlays/development/kustomization.yaml`
  - `overlays/vmaas-ci/kustomization.yaml`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new secret generator entries with standardized resource labeling across multiple deployment environments. These infrastructure configuration updates establish consistent organizational practices for resource identification and tracking, improving system maintainability and operational consistency. The changes apply uniform conventions across development and production-adjacent environments to enhance infrastructure clarity and resource management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->