### PR TITLE
MGMT-24006: Add netris integration to the installation flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ local/
 **/dockerconfig.json
 **/*pull-secret.json
 [lL]icense.zip
+**/osac-aap-secrets.env
 
 # Claude.md file
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The OSAC platform relies on three core components to deliver governed self-servi
 > * Red Hat OpenShift Advanced Cluster Management (RHACM)
 > * Red Hat OpenShift Virtualization (OCP-Virt) - **Optional**: Only required for VM as a Service (VMaaS) support
 > * Red Hat Ansible Automation Platform (AAP)
-> * ESI (Elastic System Infrastructure) - Required for bare metal provisioning
+> * A network backend for bare metal provisioning: either **ESI** (Elastic System Infrastructure) or **Netris** (see [Network Backend Configuration](#network-backend-configuration-caas))
 
 **Configuration Manifests**
 
@@ -279,6 +279,32 @@ $ INGRESS_SERVICE=true STORAGE_SERVICE=true \
 | `STORAGE_SERVICE` | `false` | Install LVMS and create a default StorageClass (`lvms-vg1`) |
 | `VIRT_SERVICE` | `false` | Install OpenShift Virtualization |
 | `MCE_SERVICE` | `false` | Install Multicluster Engine and infrastructure operator |
+
+#### AAP Configuration
+
+The automation backend (AAP) is configured via two env files in your overlay's
+`files/` directory:
+
+- **`osac-aap-configuration.env`** — non-sensitive settings (network class, domains,
+  connection details). Tracked in git with ESI defaults; customize for your
+  environment.
+- **`osac-aap-secrets.env`** — sensitive credentials (passwords, SSH keys, AWS keys).
+  Gitignored, you create this file.
+
+Edit these files to match your environment, then run `setup.sh` — the script
+applies them automatically via `scripts/aap-configuration.sh`.
+
+See [docs/aap-configuration.md](docs/aap-configuration.md) for the full variable
+reference.
+
+#### Network Backend Configuration (CaaS)
+
+By default the network backend is **ESI**. To switch to **Netris**, set
+`NETWORK_CLASS=netris` in your overlay's `osac-aap-configuration.env` and fill in
+the Netris-specific connection details and credentials.
+
+See [docs/network-backend.md](docs/network-backend.md) for Netris-specific
+variables and the `NETRIS_RESOURCE_CLASS_MAP` format.
 
 > **Note:** The script requires `osac` to be installed and available in your
 > `PATH` (see [OSAC CLI: Setup & Usage](#osac-cli-setup--usage) below for

--- a/docs/aap-configuration.md
+++ b/docs/aap-configuration.md
@@ -1,0 +1,71 @@
+# AAP Configuration
+
+The OSAC automation backend (AAP) receives its runtime configuration via
+Kubernetes ConfigMaps and Secrets that are mounted into AAP instance group
+execution pods via `envFrom`. This makes every key available as an environment
+variable during playbook execution.
+
+Currently only the **cluster-fulfillment-ig** instance group mounts these
+variables, as it is the only instance group that consumes them (for cluster provisioning workflows).
+This will be expanded to additional instance groups in the future as more automation workflows are added.
+
+## Configuration Files
+
+Each overlay contains a tracked configuration file under `files/`; add a local
+secrets file only when credential overrides are needed:
+
+| File | Tracked in git | Purpose |
+|------|---------------|---------|
+| `osac-aap-configuration.env` | Yes | Non-sensitive settings (network class, domains, hosted cluster defaults) |
+| `osac-aap-secrets.env` | No (gitignored, optional) | Sensitive credentials (passwords, SSH keys, AWS keys) |
+
+The `scripts/aap-configuration.sh` script reads `osac-aap-configuration.env`
+and, when present, `osac-aap-secrets.env`, then patches the
+`cluster-fulfillment-ig` ConfigMap and Secret on the cluster. The setup script
+(`setup.sh`) calls this automatically after applying the Kustomize overlay.
+
+For manual deployments, run the script standalone after `oc apply -k`:
+
+```bash
+INSTALLER_NAMESPACE=<project-name> ./scripts/aap-configuration.sh
+```
+
+Shell environment variables override values from the env files, which is useful
+for CI pipelines.
+
+## ConfigMap Variables (`osac-aap-configuration.env`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NETWORK_CLASS` | `esi` | Network backend (`netris` or `esi`) |
+| `NETWORK_STEPS_COLLECTION` | `massopencloud.steps` | Ansible collection for network steps |
+| `EXTERNAL_ACCESS_BASE_DOMAIN` | `box.massopen.cloud` | Base domain for cluster DNS records |
+| `EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS` | `box.massopen.cloud` | Comma-separated list of allowed domains |
+| `EXTERNAL_ACCESS_API_INTERNAL_NETWORK` | `hypershift` | Internal network for API access |
+| `HOSTED_CLUSTER_BASE_DOMAIN` | `box.massopen.cloud` | Base domain for hosted clusters |
+| `HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY` | `HighlyAvailable` | Control plane HA policy |
+| `HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY` | `HighlyAvailable` | Infrastructure HA policy |
+
+## Secret Variables (`osac-aap-secrets.env`)
+
+Values must be **plaintext** — the script base64-encodes them when patching the
+Kubernetes Secret. Do not pre-encode them.
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS credentials for Route53 DNS |
+| `AWS_SECRET_ACCESS_KEY` | AWS credentials for Route53 DNS |
+
+Additional variables are added by specific network backends — see
+[Network Backend Configuration](network-backend.md).
+
+> **Note on SSH keys:** The env file parser reads one line at a time. For
+> multi-line values like SSH private keys, replace newlines with literal `\n`
+> on a single line — the script unescapes them back to real newlines before
+> storing. Alternatively, pass them via shell environment variables.
+
+## Reference
+
+See `base/osac-aap/config/base/configmap-cluster-fulfillment-ig-example.yaml` and
+`base/osac-aap/config/base/secret-cluster-fulfillment-ig-example.yaml` for full
+examples.

--- a/docs/network-backend.md
+++ b/docs/network-backend.md
@@ -1,0 +1,63 @@
+# Network Backend Configuration
+
+The network backend controls how hosted clusters get their networking
+infrastructure (server clusters, NAT, DNS, MetalLB). The backend is selected by
+the `NETWORK_CLASS` variable in `osac-aap-configuration.env`.
+
+For general AAP configuration (env files, how the script works, base variables),
+see [AAP Configuration](aap-configuration.md).
+
+## Supported Backends
+
+| `NETWORK_CLASS` | `NETWORK_STEPS_COLLECTION` | Description |
+|-----------------|---------------------------|-------------|
+| `esi` (default) | `massopencloud.steps` | ESI (Elastic System Infrastructure) |
+| `netris` | `netris.steps` | Netris controller API |
+
+## Netris Configuration
+
+When using `NETWORK_CLASS=netris`, the following additional variables must be set.
+
+### ConfigMap Variables (add to `osac-aap-configuration.env`)
+
+| Variable | Description |
+|----------|-------------|
+| `NETRIS_CONTROLLER_URL` | Netris controller API URL |
+| `NETRIS_USERNAME` | Netris API username |
+| `NETRIS_SITE_ID` | Netris site ID (integer) |
+| `NETRIS_TENANT_ID` | Netris tenant ID (integer) |
+| `NETRIS_TENANT_NAME` | Netris tenant name |
+| `NETRIS_MGMT_VPC_ID` | Management VPC ID |
+| `NETRIS_MGMT_VPC_NAME` | Management VPC name |
+| `NETRIS_RESOURCE_CLASS_MAP` | JSON dict mapping resource classes to config (see below) |
+| `SERVER_SSH_BASTION_HOST` | Bastion hostname/IP for SSH to bare-metal servers |
+| `SERVER_SSH_BASTION_USER` | Bastion SSH username |
+| `SERVER_SSH_USER` | Server SSH username |
+| `SERVER_MGMT_ROUTE_DESTINATION` | Management route destination CIDR |
+| `SERVER_MGMT_ROUTE_GATEWAY` | Management route gateway IP |
+
+### Secret Variables (add to `osac-aap-secrets.env`)
+
+Values must be plaintext — the script base64-encodes them automatically.
+
+| Variable | Description |
+|----------|-------------|
+| `NETRIS_PASSWORD` | Netris API password |
+| `SERVER_SSH_KEY` | Private key for SSH to bare-metal servers |
+| `SERVER_SSH_BASTION_KEY` | Private key for SSH to the bastion host |
+
+### `NETRIS_RESOURCE_CLASS_MAP` Format
+
+```json
+{
+  "fc430": {
+    "server_cluster_template_id": 89,
+    "mgmt_interface": "ens4",
+    "vpc_interfaces": ["ens13"]
+  }
+}
+```
+
+Each key is a resource class name. `server_cluster_template_id` is the Netris server
+cluster template ID, `mgmt_interface` is the management NIC name, and `vpc_interfaces`
+lists the data-plane NIC names.

--- a/overlays/caas-ci/files/osac-aap-configuration.env
+++ b/overlays/caas-ci/files/osac-aap-configuration.env
@@ -1,0 +1,44 @@
+# AAP runtime configuration for the cluster-fulfillment-ig ConfigMap.
+# These values are applied to the cluster by scripts/aap-configuration.sh.
+# Edit the values below to match your environment.
+
+# Network class: "esi" (default) or "netris"
+NETWORK_CLASS=esi
+NETWORK_STEPS_COLLECTION=massopencloud.steps
+
+# External access / DNS
+EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
+EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
+EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift
+
+# Hosted cluster defaults
+HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
+HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
+HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+
+# --- Netris settings (uncomment and fill in when using NETWORK_CLASS=netris) ---
+
+# Netris controller connection
+# NETRIS_CONTROLLER_URL=
+# NETRIS_USERNAME=
+
+# Site and tenant
+# NETRIS_SITE_ID=
+# NETRIS_TENANT_ID=
+# NETRIS_TENANT_NAME=
+
+# Management VPC
+# NETRIS_MGMT_VPC_ID=
+# NETRIS_MGMT_VPC_NAME=
+
+# Per-resource-class configuration (JSON)
+# NETRIS_RESOURCE_CLASS_MAP={"fc430": {"server_cluster_template_id": 89, "mgmt_interface": "ens4", "vpc_interfaces": ["ens13"]}}
+
+# Management network routing
+# SERVER_MGMT_ROUTE_DESTINATION=
+# SERVER_MGMT_ROUTE_GATEWAY=
+
+# SSH bastion access
+# SERVER_SSH_BASTION_HOST=
+# SERVER_SSH_BASTION_USER=
+# SERVER_SSH_USER=

--- a/overlays/caas-ci/files/osac-aap-secrets.env.example
+++ b/overlays/caas-ci/files/osac-aap-secrets.env.example
@@ -1,0 +1,17 @@
+# Sensitive credentials for the cluster-fulfillment-ig Secret.
+# Copy this file to osac-aap-secrets.env and fill in your values.
+# These values are applied to the cluster by scripts/aap-configuration.sh.
+#
+# Values must be plaintext — the script base64-encodes them automatically.
+# DO NOT commit osac-aap-secrets.env to git.
+
+# Netris API password
+NETRIS_PASSWORD=
+
+# SSH private keys (single line — replace newlines with literal \n)
+SERVER_SSH_KEY=
+SERVER_SSH_BASTION_KEY=
+
+# AWS credentials for Route53 DNS
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -55,6 +55,24 @@ secretGenerator:
   literals:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
 
+# Base defaults for the cluster-fulfillment-ig ConfigMap.
+# scripts/aap-configuration.sh may override these with values
+# from files/osac-aap-configuration.env after oc apply -k.
+configMapGenerator:
+- name: cluster-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+  literals:
+    - NETWORK_CLASS=esi
+    - NETWORK_STEPS_COLLECTION=massopencloud.steps
+    - EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
+    - EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
+    - EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift
+    - HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
+    - HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
+    - HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+
 images:
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli

--- a/overlays/development/files/osac-aap-configuration.env
+++ b/overlays/development/files/osac-aap-configuration.env
@@ -1,0 +1,44 @@
+# AAP runtime configuration for the cluster-fulfillment-ig ConfigMap.
+# These values are applied to the cluster by scripts/aap-configuration.sh.
+# Edit the values below to match your environment.
+
+# Network class: "esi" (default) or "netris"
+NETWORK_CLASS=esi
+NETWORK_STEPS_COLLECTION=massopencloud.steps
+
+# External access / DNS
+EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
+EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
+EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift
+
+# Hosted cluster defaults
+HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
+HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
+HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+
+# --- Netris settings --- (Used when NETWORK_CLASS=netris, NETWORK_STEPS_COLLECTION=netris.steps)
+
+# Netris controller connection
+NETRIS_CONTROLLER_URL=https://redhat-ctl.netris.io
+NETRIS_USERNAME=netris
+
+# Site and tenant
+NETRIS_SITE_ID=5
+NETRIS_TENANT_ID=1
+NETRIS_TENANT_NAME=Admin
+
+# Management VPC
+NETRIS_MGMT_VPC_ID=4
+NETRIS_MGMT_VPC_NAME=RH-Infra
+
+# Per-resource-class configuration (JSON)
+NETRIS_RESOURCE_CLASS_MAP={"fc430": {"server_cluster_template_id": 89, "mgmt_interface": "ens4", "vpc_interfaces": ["ens13"]}}
+
+# Management network routing
+SERVER_MGMT_ROUTE_DESTINATION=10.8.0.0/30
+SERVER_MGMT_ROUTE_GATEWAY=192.168.16.1
+
+# SSH bastion access
+SERVER_SSH_BASTION_HOST=redhat-ctl.netris.io
+SERVER_SSH_BASTION_USER=ubuntu
+SERVER_SSH_USER=core

--- a/overlays/development/files/osac-aap-secrets.env.example
+++ b/overlays/development/files/osac-aap-secrets.env.example
@@ -1,0 +1,17 @@
+# Sensitive credentials for the cluster-fulfillment-ig Secret.
+# Copy this file to osac-aap-secrets.env and fill in your values.
+# These values are applied to the cluster by scripts/aap-configuration.sh.
+#
+# Values must be plaintext — the script base64-encodes them automatically.
+# DO NOT commit osac-aap-secrets.env to git.
+
+# Netris API password
+NETRIS_PASSWORD=
+
+# SSH private keys (single line — replace newlines with literal \n)
+SERVER_SSH_KEY=
+SERVER_SSH_BASTION_KEY=
+
+# AWS credentials for Route53 DNS
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -56,6 +56,24 @@ secretGenerator:
   literals:
     - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
 
+# Base defaults for the cluster-fulfillment-ig ConfigMap.
+# scripts/aap-configuration.sh may override these with values
+# from files/osac-aap-configuration.env after oc apply -k.
+configMapGenerator:
+- name: cluster-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+  literals:
+    - NETWORK_CLASS=esi
+    - NETWORK_STEPS_COLLECTION=massopencloud.steps
+    - EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
+    - EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
+    - EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift
+    - HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
+    - HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
+    - HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+
 images:
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli

--- a/scripts/aap-configuration.sh
+++ b/scripts/aap-configuration.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+
+OVERLAY_FILES="overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files"
+CONFIG_FILE="${OVERLAY_FILES}/osac-aap-configuration.env"
+SECRETS_FILE="${OVERLAY_FILES}/osac-aap-secrets.env"
+
+# Source env files. Shell environment variables take precedence (set -a exports
+# only new variables; existing ones are not overwritten by source).
+load_env_file() {
+    local file="$1"
+    if [[ ! -f "${file}" ]]; then
+        return
+    fi
+    echo "Loading ${file}..."
+    while IFS='=' read -r key value; do
+        key="${key%%#*}"
+        key="${key// /}"
+        [[ -z "${key}" ]] && continue
+        if [[ "${value}" =~ ^\"(.*)\"$ ]] || [[ "${value}" =~ ^\'(.*)\'$ ]]; then
+            value="${BASH_REMATCH[1]}"
+        fi
+        value="${value//\\n/$'\n'}"
+        if [[ -z "${!key:-}" ]]; then
+            export "${key}=${value}"
+        fi
+    done < <(grep -v '^\s*#' "${file}" | grep -v '^\s*$')
+}
+
+load_env_file "${CONFIG_FILE}"
+load_env_file "${SECRETS_FILE}"
+
+CM_VARS=(
+    NETWORK_CLASS NETWORK_STEPS_COLLECTION
+    EXTERNAL_ACCESS_BASE_DOMAIN EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK
+    HOSTED_CLUSTER_BASE_DOMAIN
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY
+    NETRIS_CONTROLLER_URL NETRIS_USERNAME
+    NETRIS_SITE_ID NETRIS_TENANT_ID NETRIS_TENANT_NAME
+    NETRIS_MGMT_VPC_ID NETRIS_MGMT_VPC_NAME
+    NETRIS_RESOURCE_CLASS_MAP
+    SERVER_MGMT_ROUTE_DESTINATION SERVER_MGMT_ROUTE_GATEWAY
+    SERVER_SSH_BASTION_HOST SERVER_SSH_BASTION_USER SERVER_SSH_USER
+)
+
+SECRET_VARS=(
+    NETRIS_PASSWORD
+    SERVER_SSH_KEY SERVER_SSH_BASTION_KEY
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+)
+
+# --- ConfigMap overrides ---
+patch_file=$(mktemp)
+has_cm_overrides=false
+
+echo "data:" > "${patch_file}"
+for var in "${CM_VARS[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+        escaped="${!var//\'/\'\'}"
+        printf "  %s: '%s'\n" "${var}" "${escaped}" >> "${patch_file}"
+        has_cm_overrides=true
+    fi
+done
+
+if [[ "${has_cm_overrides}" == "true" ]]; then
+    echo "Applying cluster-fulfillment-ig configmap overrides..."
+    oc patch configmap/cluster-fulfillment-ig -n "${INSTALLER_NAMESPACE}" \
+        --patch-file="${patch_file}" --type=merge
+fi
+rm -f "${patch_file}"
+
+# --- Secret overrides ---
+secret_patch=""
+has_secret_overrides=false
+
+for var in "${SECRET_VARS[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+        encoded=$(printf '%s' "${!var}" | base64 | tr -d '\n')
+        [[ "${has_secret_overrides}" == "true" ]] && secret_patch+=","
+        secret_patch+="\"${var}\":\"${encoded}\""
+        has_secret_overrides=true
+    fi
+done
+
+if [[ "${has_secret_overrides}" == "true" ]]; then
+    echo "Applying cluster-fulfillment-ig secret overrides..."
+    oc patch secret/cluster-fulfillment-ig -n "${INSTALLER_NAMESPACE}" \
+        -p "{\"data\":{${secret_patch}}}" --type=merge
+fi
+
+if [[ "${has_cm_overrides}" == "true" ]] || [[ "${has_secret_overrides}" == "true" ]]; then
+    echo "cluster-fulfillment-ig configuration applied"
+else
+    echo "No cluster-fulfillment-ig overrides detected, using kustomize defaults"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -256,6 +256,11 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
+# Apply cluster-fulfillment-ig configmap/secret overrides from environment variables
+INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
+INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
+    ./scripts/aap-configuration.sh
+
 # Wait for AAP bootstrap job to complete
 echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
 wait_for_resource job/aap-bootstrap condition=complete 2400 ${INSTALLER_NAMESPACE}


### PR DESCRIPTION
## Summary                                                            
                                         
  Add Netris network backend support to the OSAC installer. Users       
  configure the
  AAP automation backend via env files in their overlay —               
  `osac-aap-configuration.env`                                          
  for non-sensitive settings and `osac-aap-secrets.env` for credentials
  — making it                                                           
  easy to switch between ESI and Netris without passing dozens of
  environment                                                           
  variables on the command line.                            
                                                                        
  ## What changed                                           

  - **`scripts/aap-configuration.sh`** (new): Reads                     
  `osac-aap-configuration.env`
    and, when present, `osac-aap-secrets.env` from the overlay's        
  `files/` directory,                                                   
    then patches the `cluster-fulfillment-ig` ConfigMap and Secret via
    `oc patch --type=merge`. Shell env vars override file values for CI 
  use.                                                                  
                                                                        
  - **`scripts/setup.sh`**: Calls `aap-configuration.sh` after `oc apply
   -k`,                                                     
    passing `INSTALLER_NAMESPACE` and `INSTALLER_KUSTOMIZE_OVERLAY` to  
  the child                                                 
    script.

  -                                                                     
  **`overlays/{development,caas-ci}/files/osac-aap-configuration.env`**
  (new,                                                                 
    tracked): Non-sensitive settings pre-filled with Netris defaults for
   the                                                                  
    development environment. Users edit to match their environment.
                                                                        
  - **`overlays/{development,caas-ci}/files/osac-aap-secrets.env.example
  `** (new,                                                             
    tracked): Template for sensitive credentials. Users copy to
    `osac-aap-secrets.env` (gitignored) and fill in their values.       
                                                                        
  - **`overlays/{development,caas-ci,vmaas-ci}/kustomization.yaml`**:   
  Added                                                                 
    `configMapGenerator` for `cluster-fulfillment-ig` with ESI defaults.
   Comments                                                             
    note that the script may override these values.
                                                                        
  - **`docs/aap-configuration.md`** (new): Documents the env file       
  mechanism,
    ConfigMap/Secret variable reference, plaintext secret requirement,  
  and SSH key                                                           
    handling.
                                                                        
  - **`docs/network-backend.md`** (new): Documents Netris-specific      
  variables and the                                                     
    `NETRIS_RESOURCE_CLASS_MAP` JSON format. Links back to the AAP      
  configuration doc                                                     
    for the general setup.
                                                                        
  - **`README.md`**: Added separate AAP Configuration and Network       
  Backend                                                               
    Configuration sections with links to the detailed docs. Updated     
  prerequisites                                                         
    to list Netris as an alternative to ESI.
                                                                        
  - **`.gitignore`**: Added `**/osac-aap-secrets.env`.                  
   
  ## How to use

  1. Edit `overlays/<project>/files/osac-aap-configuration.env` — set                                                                             
     `NETWORK_CLASS=netris` and fill in connection details
  2. Copy `osac-aap-secrets.env.example` to `osac-aap-secrets.env` and add                                                                        
     credentials (passwords, SSH keys, AWS keys)                                                                                                  
  3. Run `./scripts/setup.sh`                                                                                                                     
                                                                                                                                                  
  Existing ESI deployments are unaffected — without env files the script is a                                                                     
  no-op and the kustomize ESI defaults apply.   


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a Netris network backend alongside ESI and a runtime AAP configuration workflow that applies overlayed env-file settings.
  * Automated post-deploy application of AAP ConfigMap/Secret overrides.

* **Documentation**
  * New and updated docs covering network backend selection, Netris configuration details, and AAP configuration workflow with examples.

* **Chores**
  * Gitignore updated to exclude local secrets env files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->