### PR TITLE
MGMT-23734/MGMT-23903: add PublicIP RBAC to hub-access Role

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -117,6 +117,24 @@ rules:
       - publicippools/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicips
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicips/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

[MGMT-23903](https://redhat.atlassian.net/browse/MGMT-23903): Add `publicips` and `publicips/status` RBAC entries to the hub-access
Role so the fulfillment-service reconciler can manage PublicIP CRs on hub clusters.

Required before the PublicIP reconciler ([MGMT-23901](https://redhat.atlassian.net/browse/MGMT-23901)) is deployed, otherwise the
hub-access service account gets 403 Forbidden when creating/updating/deleting
PublicIP CRs.

## Testing

```
$ kustomize build base/hub-access/ | grep -A 10 publicips
  - publicips
  verbs:
  - create
  - delete
  - get
  - list
  - patch
  - update
  - watch
- apiGroups:
  - osac.openshift.io
--
  - publicips/status
  verbs:
  - get

$ grep -c 'publicips$' base/hub-access/rbac.yaml
1

$ grep -c 'publicips/status' base/hub-access/rbac.yaml
1
```

## Ticket

[MGMT-23903](https://redhat.atlassian.net/browse/MGMT-23903)
(subtask of [MGMT-23734](https://redhat.atlassian.net/browse/MGMT-23734)

<br>

<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded role-based access control to enable management of publicips resources with full create, read, update, delete, list, patch, and watch permissions, plus status viewing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->