### PR TITLE
MGMT-24125: pin OSAC component images by SHA tag

### DIFF
--- a/.github/workflows/check-image-tags.yaml
+++ b/.github/workflows/check-image-tags.yaml
@@ -1,0 +1,18 @@
+name: Check image tags match submodules
+
+on:
+  pull_request:
+
+concurrency:
+  group: "check-image-tags-${{ github.head_ref || github.run_id }}"
+  cancel-in-progress: true
+
+jobs:
+  check-image-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Verify image tags match submodule commits
+        run: bash scripts/sync-image-tags.sh

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -24,15 +24,13 @@ images:
 - name: postgres
   newName: quay.io/sclorg/postgresql-15-c9s
   newTag: latest
-- name: fulfillment-service
-  newName: ghcr.io/osac-project/fulfillment-service
-  newTag: latest
+- name: ghcr.io/osac-project/fulfillment-service
+  newTag: sha-f2cd619
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
-  newTag: latest
-- name: osac-operator
-  newName: ghcr.io/osac-project/osac-operator
-  newTag: latest
+  newTag: sha-ffe8959
+- name: ghcr.io/osac-project/osac-operator
+  newTag: sha-fe83a9f
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Sync image tags in base/kustomization.yaml to match submodule commits.
+# Each component repo publishes SHA-tagged images on every main merge.
+# This script reads the submodule commits and updates the kustomization.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KUSTOMIZATION="${REPO_ROOT}/base/kustomization.yaml"
+
+declare -A IMAGE_NAME=(
+  [osac-operator]="ghcr.io/osac-project/osac-operator"
+  [osac-fulfillment-service]="ghcr.io/osac-project/fulfillment-service"
+  [osac-aap]="osac-aap"
+)
+
+errors=0
+
+for submodule in osac-operator osac-fulfillment-service osac-aap; do
+  commit=$(git -C "${REPO_ROOT}" submodule status "base/${submodule}" | awk '{print $1}' | tr -d '+')
+  short="${commit:0:7}"
+  tag="sha-${short}"
+  image="${IMAGE_NAME[$submodule]}"
+
+  current_tag=$(grep -A2 "name: ${image}$" "${KUSTOMIZATION}" | grep "newTag:" | awk '{print $2}')
+
+  if [[ "${current_tag}" == "${tag}" ]]; then
+    echo "${image}: OK (${tag})"
+  elif [[ "${1:-}" == "--fix" ]]; then
+    escaped_image=$(echo "${image}" | sed 's|/|\\/|g')
+    sed -i "/name: ${escaped_image}$/,/newTag:/{s|newTag:.*|newTag: ${tag}|}" "${KUSTOMIZATION}"
+    echo "${image}: FIXED ${current_tag} -> ${tag}"
+  else
+    echo "${image}: MISMATCH current=${current_tag} expected=${tag}"
+    errors=$((errors + 1))
+  fi
+done
+
+if [[ ${errors} -gt 0 ]]; then
+  echo ""
+  echo "Run '$0 --fix' to update the tags automatically."
+  exit 1
+fi


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24125

Pin osac-operator, fulfillment-service, and osac-aap image tags to the SHA matching their submodule commit instead of floating :latest.

Adds `scripts/sync-image-tags.sh` which validates tags match submodules (run with `--fix` to auto-update). Adds a CI check that fails PRs on mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned container images to specific commit-based tags, replacing floating tags for more stable, reproducible deployments.
  * Added an automated CI check that validates image tags match repository references and can auto-fix mismatches to keep deployment manifests in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->