### PR TITLE
NO-ISSUE: Remove default network attachment definition application

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,19 +23,6 @@ echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
 echo "Namespace: ${INSTALLER_NAMESPACE}"
 echo ""
 
-# Apply default network attachment definition for VMs
-if [[ "${VIRT_SERVICE}" == "true" ]]; then
-    cat <<EOF | oc apply -f -
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: default
-  namespace: openshift-ovn-kubernetes
-spec:
-  config: '{"cniVersion": "0.4.0", "name": "ovn-kubernetes", "type": "ovn-k8s-cni-overlay"}'
-EOF
-fi
-
 # Optionally install LVMS as storage service (must be before keycloak which needs a default storage class)
 if [[ "${STORAGE_SERVICE}" == "true" ]]; then
     wait_for_namespace_cleanup openshift-storage


### PR DESCRIPTION
Removed the default network attachment definition application for VMs from the setup script.

It was backported from old scripts, and it is not relevant at all as it's OSAC who is responsible to isolate VM networking by creating NetworkAttachmentDefinition through UDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed automatic application of default network attachment definitions during OpenShift virtualization setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->