### PR TITLE
MGMT-24226: Pin AAP runtime refs to submodule commit in CI overlays

### DIFF
--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -42,9 +42,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:latest
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-ffe8959
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
-    - AAP_PROJECT_GIT_BRANCH=main
+    - AAP_PROJECT_GIT_BRANCH=ffe89599749830427c5c3b765071b7355a0f14f3
 
 - name: cluster-fulfillment-ig
   options:

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -42,9 +42,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:latest
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-ffe8959
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
-    - AAP_PROJECT_GIT_BRANCH=main
+    - AAP_PROJECT_GIT_BRANCH=ffe89599749830427c5c3b765071b7355a0f14f3
 
 - name: cluster-fulfillment-ig
   options:

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -37,6 +37,36 @@ for submodule in osac-operator osac-fulfillment-service osac-aap; do
   fi
 done
 
+aap_commit=$(git -C "${REPO_ROOT}" submodule status "base/osac-aap" | awk '{print $1}' | tr -d '+')
+aap_short="${aap_commit:0:7}"
+aap_tag="sha-${aap_short}"
+
+CI_OVERLAYS=("vmaas-ci" "caas-ci")
+
+for overlay in "${CI_OVERLAYS[@]}"; do
+  overlay_file="${REPO_ROOT}/overlays/${overlay}/kustomization.yaml"
+  [[ ! -f "${overlay_file}" ]] && continue
+
+  current_ee=$(grep "AAP_EE_IMAGE=" "${overlay_file}" | sed 's/.*AAP_EE_IMAGE=//' | tr -d ' ')
+  expected_ee="ghcr.io/osac-project/osac-aap:${aap_tag}"
+
+  current_branch=$(grep "AAP_PROJECT_GIT_BRANCH=" "${overlay_file}" | sed 's/.*AAP_PROJECT_GIT_BRANCH=//' | tr -d ' ')
+  expected_branch="${aap_commit}"
+
+  for pair in "AAP_EE_IMAGE ${current_ee} ${expected_ee}" "AAP_PROJECT_GIT_BRANCH ${current_branch} ${expected_branch}"; do
+    read -r key current expected <<< "${pair}"
+    if [[ "${current}" == "${expected}" ]]; then
+      echo "${overlay} ${key}: OK"
+    elif [[ "${1:-}" == "--fix" ]]; then
+      sed -i "s|${key}=${current}|${key}=${expected}|" "${overlay_file}"
+      echo "${overlay} ${key}: FIXED ${current} -> ${expected}"
+    else
+      echo "${overlay} ${key}: MISMATCH current=${current} expected=${expected}"
+      errors=$((errors + 1))
+    fi
+  done
+done
+
 if [[ ${errors} -gt 0 ]]; then
   echo ""
   echo "Run '$0 --fix' to update the tags automatically."


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24194

CI overlays (`vmaas-ci`, `caas-ci`) used `AAP_EE_IMAGE=:latest` and
`AAP_PROJECT_GIT_BRANCH=main`, causing AAP to pull whatever is on
osac-aap `main` at runtime — regardless of the submodule pin in
`base/kustomization.yaml`.

This means a breaking change merged to osac-aap would silently break
all osac-installer e2e tests without any submodule bump, and the
failure would surface on an unrelated PR that happens to trigger e2e.

This is exactly what happened today: osac-aap [MGMT-23769](https://redhat.atlassian.net/browse/MGMT-23769) (compute
instance template restructure) landed on `main` on Apr 28-29, and
PR #84 (DNS docs, completely unrelated) caught the `publish-templates`
timeout failure on Apr 30.

Changes:
- Pin `AAP_EE_IMAGE` to `sha-<submodule-commit>` in CI overlays
- Pin `AAP_PROJECT_GIT_BRANCH` to the full submodule commit SHA
- Extend `sync-image-tags.sh` to validate these, so bumping the
  submodule without updating the overlay is caught by the existing
  `check-image-tags` CI workflow
- Dev overlays (`development`, `hypershift2`) are intentionally left
  on `latest`/`main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned CI infrastructure image references to specific versions instead of using latest tags.
  * Updated CI configuration to use specific commit identifiers.
  * Enhanced synchronization tooling to validate and maintain version consistency across CI overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->