### PR TITLE
OSAC-479: Add network-fulfillment-ig ConfigMap and Secret to installer overlays

### DIFF
--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -55,6 +55,11 @@ secretGenerator:
     - HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=SingleReplica
     - HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=SingleReplica
 
+- name: network-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 # Base defaults for the cluster-fulfillment-ig ConfigMap.
 # scripts/aap-configuration.sh may override these with values
 # from files/osac-aap-configuration.env after oc apply -k.
@@ -76,6 +81,16 @@ configMapGenerator:
     - HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
     - HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
     - HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+- name: network-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+  literals:
+    - NETRIS_CONTROLLER_URL=https://redhat-ctl.netris.io
+    - NETRIS_USERNAME=netris
+    - NETRIS_SITE_ID=5
+    - NETRIS_TENANT_ID=1
+    - NETRIS_TENANT_NAME=Admin
 
 images:
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/overlays/development/files/osac-aap-configuration.env
+++ b/overlays/development/files/osac-aap-configuration.env
@@ -20,7 +20,9 @@ HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
 HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
 HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
 
-# --- Netris settings --- (Used when NETWORK_CLASS=netris, NETWORK_STEPS_COLLECTION=netris.steps)
+# --- Netris settings ---
+# Used when NETWORK_CLASS=netris, NETWORK_STEPS_COLLECTION=netris.steps.
+# These values are applied to both cluster-fulfillment-ig and network-fulfillment-ig.
 
 # Netris controller connection
 NETRIS_CONTROLLER_URL=https://redhat-ctl.netris.io

--- a/overlays/development/files/osac-aap-secrets.env.example
+++ b/overlays/development/files/osac-aap-secrets.env.example
@@ -5,7 +5,7 @@
 # Values must be plaintext — the script base64-encodes them automatically.
 # DO NOT commit osac-aap-secrets.env to git.
 
-# Netris API password
+# Netris API password (applied to both cluster-fulfillment-ig and network-fulfillment-ig)
 NETRIS_PASSWORD=
 
 # SSH private keys — place as regular key files in this directory:

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -52,6 +52,11 @@ secretGenerator:
     labels:
       osac.openshift.io/project: osac-aap
 
+- name: network-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 # Base defaults for the cluster-fulfillment-ig ConfigMap.
 # scripts/aap-configuration.sh may override these with values
 # from files/osac-aap-configuration.env after oc apply -k.
@@ -73,6 +78,16 @@ configMapGenerator:
     - HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud
     - HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable
     - HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable
+- name: network-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+  literals:
+    - NETRIS_CONTROLLER_URL=https://redhat-ctl.netris.io
+    - NETRIS_USERNAME=netris
+    - NETRIS_SITE_ID=5
+    - NETRIS_TENANT_ID=1
+    - NETRIS_TENANT_NAME=Admin
 
 images:
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -51,6 +51,11 @@ secretGenerator:
     labels:
       osac.openshift.io/project: osac-aap
 
+- name: network-fulfillment-ig
+  options:
+    labels:
+      osac.openshift.io/project: osac-aap
+
 configMapGenerator:
 - name: publish-templates-ig
   literals:

--- a/scripts/aap-configuration.sh
+++ b/scripts/aap-configuration.sh
@@ -123,3 +123,59 @@ if [[ "${has_cm_overrides}" == "true" ]] || [[ "${has_secret_overrides}" == "tru
 else
     echo "No cluster-fulfillment-ig overrides detected, using kustomize defaults"
 fi
+
+# --- network-fulfillment-ig ---
+# The networking-operations-ig instance group uses a separate ConfigMap/Secret
+# for Netris credentials. The values are sourced from the same env files.
+
+NET_CM_VARS=(
+    NETRIS_CONTROLLER_URL NETRIS_USERNAME
+    NETRIS_SITE_ID NETRIS_TENANT_ID NETRIS_TENANT_NAME
+)
+
+NET_SECRET_VARS=(
+    NETRIS_PASSWORD
+)
+
+net_patch_file=$(mktemp)
+has_net_cm_overrides=false
+
+echo "data:" > "${net_patch_file}"
+for var in "${NET_CM_VARS[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+        escaped="${!var//\'/\'\'}"
+        printf "  %s: '%s'\n" "${var}" "${escaped}" >> "${net_patch_file}"
+        has_net_cm_overrides=true
+    fi
+done
+
+if [[ "${has_net_cm_overrides}" == "true" ]]; then
+    echo "Applying network-fulfillment-ig configmap overrides..."
+    oc patch configmap/network-fulfillment-ig -n "${INSTALLER_NAMESPACE}" \
+        --patch-file="${net_patch_file}" --type=merge
+fi
+rm -f "${net_patch_file}"
+
+net_secret_patch=""
+has_net_secret_overrides=false
+
+for var in "${NET_SECRET_VARS[@]}"; do
+    if [[ -n "${!var:-}" ]]; then
+        encoded=$(printf '%s' "${!var}" | base64 | tr -d '\n')
+        [[ "${has_net_secret_overrides}" == "true" ]] && net_secret_patch+=","
+        net_secret_patch+="\"${var}\":\"${encoded}\""
+        has_net_secret_overrides=true
+    fi
+done
+
+if [[ "${has_net_secret_overrides}" == "true" ]]; then
+    echo "Applying network-fulfillment-ig secret overrides..."
+    oc patch secret/network-fulfillment-ig -n "${INSTALLER_NAMESPACE}" \
+        -p "{\"data\":{${net_secret_patch}}}" --type=merge
+fi
+
+if [[ "${has_net_cm_overrides}" == "true" ]] || [[ "${has_net_secret_overrides}" == "true" ]]; then
+    echo "network-fulfillment-ig configuration applied"
+else
+    echo "No network-fulfillment-ig overrides detected, using kustomize defaults"
+fi


### PR DESCRIPTION
## Summary
- Add `network-fulfillment-ig` ConfigMap and Secret entries to all installer overlays (development, caas-ci, vmaas-ci)
- Extend `scripts/aap-configuration.sh` to patch `network-fulfillment-ig` ConfigMap/Secret with Netris credentials from the same env files used for `cluster-fulfillment-ig`
- The `networking-operations-ig` instance group needs Netris controller credentials (URL, username, site/tenant IDs, password) injected as environment variables to run networking provisioning jobs (VirtualNetwork, Subnet, SecurityGroup, PublicIP, PublicIPPool)