### PR TITLE
WIP: OSAC-682: Align bootstrap job image with AAP_EE_IMAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,16 +174,29 @@ To test a specific revision of a component, you need to:
 
    The component image names used in the base are:
 
-   | Component | Image name |
-   |-----------|-----------|
-   | Fulfillment Service | `fulfillment-service` |
-   | OSAC Operator | `osac-operator` |
-   | OSAC AAP | `osac-aap` |
+   | Component | Image name | Description |
+   |-----------|-----------|-------------|
+   | Fulfillment Service | `fulfillment-service` | API server for cluster/VM management |
+   | OSAC Operator | `osac-operator` | Kubernetes operator for reconciliation |
+   | OSAC AAP | `osac-aap` | Execution Environment image used by the AAP bootstrap job and AAP job templates |
 
 #### OSAC AAP Customization
 
-For osac-aap, in addition to the image override, you must also update the AAP
-configuration secrets in your overlay's `kustomization.yaml`:
+The `osac-aap` image is the Execution Environment (EE) image. It is used in two
+places: as the container image for the **bootstrap job** during installation, and
+as the EE image configured in **AAP for running job templates** after installation.
+When overriding this image, you must update both the Kustomize `images` section
+and the `AAP_EE_IMAGE` secret literal to keep them in sync:
+
+```yaml
+images:
+  - name: osac-aap
+    newName: <your-registry>/osac-aap
+    newTag: <your-tag>
+```
+
+You must also update the AAP configuration secrets in your overlay's
+`kustomization.yaml`:
 
 ```yaml
 secretGenerator:

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -93,6 +93,9 @@ configMapGenerator:
     - NETRIS_TENANT_NAME=Admin
 
 images:
+  - name: osac-aap
+    newName: ghcr.io/osac-project/osac-aap
+    newTag: sha-6f5dbdd
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli
     newTag: "4.20.0"

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -90,6 +90,9 @@ configMapGenerator:
     - NETRIS_TENANT_NAME=Admin
 
 images:
+  - name: osac-aap
+    newName: ghcr.io/osac-project/osac-aap
+    newTag: latest
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli
     newTag: "4.20.0"

--- a/overlays/hypershift2/kustomization.yaml
+++ b/overlays/hypershift2/kustomization.yaml
@@ -49,6 +49,9 @@ configMapGenerator:
       - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 
 images:
+  - name: osac-aap
+    newName: ghcr.io/osac-project/osac-aap
+    newTag: latest
   - name: ghcr.io/osac-project/osac-operator
     digest: sha256:9b271b405219e6be4c61259b8ebfcb3b41a7fa58ecccd6ada93c10d046f510a8
   - name: ghcr.io/osac-project/fulfillment-service

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -63,6 +63,9 @@ configMapGenerator:
     - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 
 images:
+  - name: osac-aap
+    newName: ghcr.io/osac-project/osac-aap
+    newTag: sha-6f5dbdd
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     newName: quay.io/openshift/origin-cli
     newTag: "4.20.0"

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -53,6 +53,8 @@ for overlay in "${CI_OVERLAYS[@]}"; do
   current_branch=$(grep "AAP_PROJECT_GIT_BRANCH=" "${overlay_file}" | sed 's/.*AAP_PROJECT_GIT_BRANCH=//' | tr -d ' ')
   expected_branch="${aap_commit}"
 
+  current_image_tag=$(grep -A2 "name: osac-aap$" "${overlay_file}" | grep "newTag:" | awk '{print $2}')
+
   for pair in "AAP_EE_IMAGE ${current_ee} ${expected_ee}" "AAP_PROJECT_GIT_BRANCH ${current_branch} ${expected_branch}"; do
     read -r key current expected <<< "${pair}"
     if [[ "${current}" == "${expected}" ]]; then
@@ -65,6 +67,16 @@ for overlay in "${CI_OVERLAYS[@]}"; do
       errors=$((errors + 1))
     fi
   done
+
+  if [[ "${current_image_tag}" == "${aap_tag}" ]]; then
+    echo "${overlay} osac-aap image: OK"
+  elif [[ "${1:-}" == "--fix" ]]; then
+    sed -i "/name: osac-aap$/,/newTag:/{s|newTag:.*|newTag: ${aap_tag}|}" "${overlay_file}"
+    echo "${overlay} osac-aap image: FIXED ${current_image_tag} -> ${aap_tag}"
+  else
+    echo "${overlay} osac-aap image: MISMATCH current=${current_image_tag} expected=${aap_tag}"
+    errors=$((errors + 1))
+  fi
 done
 
 if [[ ${errors} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Add `osac-aap` Kustomize image overrides to development and hypershift2 overlays so the bootstrap job container uses the same image as `AAP_EE_IMAGE`
- CI overlays already match via `scripts/sync-image-tags.sh`
- Previously, the bootstrap job ran with `sha-6f5dbdd` (from base) while AAP was configured to use `latest` (from `AAP_EE_IMAGE` in the overlay secret)

## Test plan

- [ ] Verify `oc apply -k overlays/development` renders the bootstrap job with the correct image
- [ ] Verify `oc apply -k overlays/hypershift2` renders the bootstrap job with the correct image
- [ ] Run `kustomize build overlays/development | grep -A5 'name: bootstrap'` to confirm image match

🤖 Generated with [Claude Code](https://claude.com/claude-code)