### PR TITLE
Add refresh-after-snapshot script for cluster-tool clones

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -15,12 +15,13 @@ INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 # Create hub access kubeconfig
 ./scripts/create-hub-access-kubeconfig.sh
 
-# Login to fulfillment internal API and create hub.
+# Login to fulfillment internal API and ensure hub exists with current kubeconfig.
 # The private API (osac.private.v1.*) is only available via the internal listener
 # (fulfillment-internal-api route, port 8001). The external listener
 # (fulfillment-api route, port 8000) only routes public API methods.
 FULFILLMENT_INTERNAL_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_INTERNAL_API_URL}
+osac delete hub hub
 osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
 
 if [[ -n "${INSTALLER_VM_TEMPLATE}" ]]; then
@@ -28,17 +29,21 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" ]]; then
     AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
     AAP_URL="https://${AAP_ROUTE_HOST}"
     AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
-    JT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
-        "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates" | jq -er '.results[0].id // empty') || {
-        echo "Failed to find osac-publish-templates AAP job template"
-        exit 1
-    }
+    echo "Waiting for AAP controller API to be ready..."
+    for attempt in $(seq 1 30); do
+        JT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
+            "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates" 2>/dev/null | jq -er '.results[0].id // empty' 2>/dev/null) && break
+        echo "  attempt ${attempt}/30 - AAP controller API not ready, retrying in 10s..."
+        sleep 10
+    done
+    [[ -z "${JT_ID:-}" ]] && { echo "Failed to find osac-publish-templates AAP job template after 30 attempts"; exit 1; }
     echo "Launching publish-templates AAP job (template ID: ${JT_ID})..."
-    curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
-        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" >/dev/null || {
-        echo "Failed to launch osac-publish-templates AAP job"
-        exit 1
-    }
+    for attempt in $(seq 1 10); do
+        curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" >/dev/null 2>&1 && break
+        echo "  launch attempt ${attempt}/10 - retrying in 10s..."
+        sleep 10
+    done
 
     echo "Waiting for computeinstancetemplate ${INSTALLER_VM_TEMPLATE} to be published..."
     retry_until 300 5 '[[ -n "$(osac get computeinstancetemplate -o json | jq -r --arg tpl "$INSTALLER_VM_TEMPLATE" '"'"'select(.id == $tpl)'"'"' 2> /dev/null)" ]]' || {

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
+INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
+
+CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+echo "=== Refreshing OSAC after snapshot boot ==="
+echo "Namespace: ${INSTALLER_NAMESPACE}"
+echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
+echo "Cluster domain: ${CLUSTER_DOMAIN}"
+echo ""
+
+echo "[1/8] Patching stale routes with new domain..."
+OLD_DOMAIN=$(oc get route osac-aap -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}' 2>/dev/null | sed "s/^osac-aap-${INSTALLER_NAMESPACE}\.//")
+echo "  Old domain: ${OLD_DOMAIN}"
+echo "  New domain: ${CLUSTER_DOMAIN}"
+for route in $(oc get routes -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.items[*].metadata.name}'); do
+    OLD_HOST=$(oc get route "${route}" -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}')
+    NEW_HOST=$(echo "${OLD_HOST}" | sed "s/${OLD_DOMAIN}/${CLUSTER_DOMAIN}/")
+    oc patch route "${route}" -n "${INSTALLER_NAMESPACE}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+done
+
+echo "[2/8] Applying kustomize overlay..."
+oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
+oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
+
+echo "[3/8] Applying AAP configuration..."
+INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
+INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
+    ./scripts/aap-configuration.sh
+
+oc config set-context --current --namespace="${INSTALLER_NAMESPACE}"
+
+echo "[4/8] Waiting for AAP controller..."
+retry_until 300 10 '[[ "$(oc get automationcontroller osac-aap-controller -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.status.conditions[?(@.type=="Running")].status}'"'"' 2>/dev/null)" == "True" ]]' || {
+    echo "Timed out waiting for AAP controller to be Running"
+    exit 1
+}
+AAP_ROUTE_HOST=$(oc get route osac-aap -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}')
+retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_ROUTE_HOST}"'/api/gateway/v1/)" == "200" ]]' || {
+    echo "Timed out waiting for AAP gateway API to respond"
+    exit 1
+}
+
+echo "[5/8] Configuring AAP access..."
+./scripts/prepare-aap.sh
+
+echo "[6/8] Configuring fulfillment service..."
+./scripts/prepare-fulfillment-service.sh
+
+echo "[7/8] Restarting fulfillment pods..."
+oc rollout restart deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}"
+oc rollout restart deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}"
+oc rollout restart deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}"
+oc rollout restart deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}"
+oc rollout status deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --timeout=120s
+oc rollout status deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}" --timeout=120s
+oc rollout status deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}" --timeout=120s
+oc rollout status deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}" --timeout=120s
+
+echo "[8/8] Configuring tenant..."
+./scripts/prepare-tenant.sh
+
+echo ""
+echo "=== Refresh complete ==="
+echo "Cluster domain: ${CLUSTER_DOMAIN}"
+echo "Namespace: ${INSTALLER_NAMESPACE}"


### PR DESCRIPTION
## Summary

- Adds `scripts/refresh-after-snapshot.sh` — refreshes all domain-sensitive OSAC resources after booting a cluster from a snapshot via [cluster-tool](https://github.com/omer-vishlitzky/cluster-tool)
- Makes `prepare-fulfillment-service.sh` idempotent (deletes existing hub before creating)

## Context

cluster-tool boots OpenShift SNO clusters from golden snapshots in ~6 minutes via recert-based identity regeneration. After boot, the cluster has a new domain but OSAC application resources (routes, AAP configs, hub kubeconfig, fulfillment controller) still reference the old domain.

This script handles all the domain-sensitive cleanup:

1. Deletes stale routes (both kustomize-managed and AAP-operator-managed)
2. Re-applies kustomize overlay (recreates fulfillment-api route with correct domain)
3. Triggers AAP operator reconciliation via annotation (recreates AAP routes with correct domain)
4. Waits for AAP controller to be healthy
5. Recreates AAP API token and sets OSAC_AAP_URL
6. Regenerates hub kubeconfig and re-registers hub
7. Restarts fulfillment pods to pick up new hub config
8. Ensures tenant exists

## Usage

```bash
cluster-tool boot --flavor osac-64-post-setup --name my-test
export KUBECONFIG=~/.kube/my-test.kubeconfig
INSTALLER_KUSTOMIZE_OVERLAY=vmaas-ci INSTALLER_VM_TEMPLATE=osac.templates.ocp_virt_vm ./scripts/refresh-after-snapshot.sh
```

Total time: ~10 minutes (6 min boot + 4 min refresh) vs 2+ hours from scratch.

## Test plan

- [x] Boot from osac-64-post-setup snapshot
- [x] Run refresh-after-snapshot.sh — all 9 steps pass
- [x] Run `make test-vmaas` — 8/8 tests pass
- [x] Verified no stale domain references in routes, configmaps, secrets, or fulfillment logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refresh workflow to re-sync the deployment stack after snapshot boots so components and routes pick up the current cluster domain and configuration.

* **Chores**
  * Updated fulfillment setup to delete and recreate the hub during initialization to ensure a clean registration state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->