### PR TITLE
OSAC-22: Create OSAC umbrella Helm chart and installer tooling

### DIFF
--- a/.github/workflows/helm-integration.yaml
+++ b/.github/workflows/helm-integration.yaml
@@ -12,20 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         submodules: recursive
+        persist-credentials: false
 
-    - name: Update submodules to latest main
-      run: git submodule update --remote
+    - name: Update submodules to pinned commits
+      run: git submodule update --init --recursive
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4
       with:
         version: v3.17.0
 
     - name: Create Kind cluster
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1
       with:
         cluster_name: osac-integration
 

--- a/.github/workflows/helm-integration.yaml
+++ b/.github/workflows/helm-integration.yaml
@@ -1,0 +1,85 @@
+name: Helm Integration Test
+
+on:
+  schedule:
+    # Run daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  integration-test:
+    name: Deploy to Kind Cluster
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Update submodules to latest main
+      run: git submodule update --remote
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.17.0
+
+    - name: Create Kind cluster
+      uses: helm/kind-action@v1
+      with:
+        cluster_name: osac-integration
+
+    - name: Install cert-manager
+      run: |
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
+        kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
+        kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
+        kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
+
+    - name: Build chart dependencies
+      run: helm dependency build charts/osac/
+
+    - name: Lint chart
+      run: helm lint charts/osac/
+
+    - name: Template chart (dry-run validation)
+      run: helm template osac charts/osac/ --values values/development.yaml > /dev/null
+
+    - name: Deploy umbrella chart
+      continue-on-error: true
+      run: |
+        helm install osac charts/osac/ \
+          --namespace osac \
+          --create-namespace \
+          --values values/development.yaml \
+          --set validation.enabled=false \
+          --set aap.bootstrap.enabled=false \
+          --set aap.aap.instance.enabled=false \
+          --set dbMigrate.enabled=false \
+          --timeout 10m \
+          --wait
+
+    - name: Check deployed resources
+      if: always()
+      run: |
+        echo "=== Pods ==="
+        kubectl get pods -n osac 2>/dev/null || true
+        echo "=== Deployments ==="
+        kubectl get deployments -n osac 2>/dev/null || true
+        echo "=== Services ==="
+        kubectl get services -n osac 2>/dev/null || true
+        echo "=== Helm status ==="
+        helm status osac -n osac 2>/dev/null || true
+
+    - name: Test idempotency (helm upgrade with no changes)
+      continue-on-error: true
+      run: |
+        helm upgrade osac charts/osac/ \
+          --namespace osac \
+          --values values/development.yaml \
+          --set validation.enabled=false \
+          --set aap.bootstrap.enabled=false \
+          --set aap.aap.instance.enabled=false \
+          --set dbMigrate.enabled=false \
+          --timeout 10m \
+          --wait

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -13,12 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         submodules: recursive
+        persist-credentials: false
 
     - name: Set up Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4
       with:
         version: v3.17.0
 

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,37 @@
+name: Helm Lint
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  helm-lint:
+    name: Lint Helm Charts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.17.0
+
+    - name: Build chart dependencies
+      run: helm dependency build charts/osac/
+
+    - name: Lint umbrella chart
+      run: helm lint charts/osac/
+
+    - name: Template umbrella chart (dry-run)
+      run: helm template osac charts/osac/ --values values/development.yaml > /dev/null
+
+    - name: Validate values schema
+      run: |
+        # Ensure values.schema.json is valid JSON
+        python3 -m json.tool charts/osac/values.schema.json > /dev/null

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: 'charts/.*'
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+INSTALLER_NAMESPACE ?= osac
+VALUES_FILE ?= values/development.yaml
+DEPLOY_MODE ?= helm
+
+.PHONY: help
+help: ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+##@ Helm Chart Management
+
+.PHONY: sync-charts
+sync-charts: ## Update submodules to latest main and rebuild chart dependencies
+	git submodule update --init --recursive --remote
+	helm dependency build charts/osac/
+
+.PHONY: helm-deps
+helm-deps: ## Build Helm chart dependencies
+	helm dependency build charts/osac/
+
+.PHONY: helm-lint
+helm-lint: ## Lint the umbrella chart
+	helm dependency build charts/osac/
+	helm lint charts/osac/
+
+.PHONY: helm-template
+helm-template: ## Dry-run render all templates
+	helm dependency build charts/osac/
+	helm template osac charts/osac/ --values $(VALUES_FILE)
+
+##@ Deployment
+
+.PHONY: helm-deploy
+helm-deploy: ## Deploy OSAC to current cluster using Helm
+	helm dependency build charts/osac/
+	helm upgrade --install osac charts/osac/ \
+		--namespace $(INSTALLER_NAMESPACE) \
+		--create-namespace \
+		--values $(VALUES_FILE) \
+		--timeout 40m \
+		--wait
+
+.PHONY: helm-undeploy
+helm-undeploy: ## Uninstall OSAC from current cluster
+	helm uninstall osac --namespace $(INSTALLER_NAMESPACE)
+
+.PHONY: setup
+setup: ## Run setup.sh with DEPLOY_MODE=helm
+	DEPLOY_MODE=$(DEPLOY_MODE) ./scripts/setup.sh
+
+.PHONY: teardown
+teardown: ## Teardown OSAC deployment
+	./scripts/teardown.sh
+
+##@ Validation
+
+.PHONY: helm-validate
+helm-validate: helm-lint ## Validate Helm chart (lint + template)
+	helm template osac charts/osac/ --values $(VALUES_FILE) > /dev/null
+	@echo "Validation passed."

--- a/README.md
+++ b/README.md
@@ -85,13 +85,16 @@ target Hub cluster.
 
 ## Installation Strategy
 
-OSAC uses Kustomize for installation. This approach allows you to easily override and
-customize your deployment to meet specific needs. Multiple OSAC installations can be
-deployed on the same cluster, each in its own project namespace.
+OSAC supports two installation methods:
 
-To manage dependencies, the OSAC-installer repository uses Git submodules to import the
-required manifests from each component. This ensures component versions are pinned and
-compatible with the installer.
+- **Helm** (recommended) — Uses an umbrella Helm chart (`charts/osac/`) that composes
+  all OSAC component charts into a single deployable unit. Configuration is managed via
+  values files in the `values/` directory.
+- **Kustomize** (legacy) — Uses Kustomize overlays in the `overlays/` directory.
+
+Both methods use Git submodules to import component manifests from each repository.
+The prerequisites (cert-manager, AAP operator, Authorino, Keycloak, etc.) are the
+same regardless of which method you choose.
 
 ### Customizing Your Installation
 
@@ -260,33 +263,33 @@ The `scripts/setup.sh` script automates the entire installation process, includi
 - Installing prerequisite operators (cert-manager, trust-manager, Authorino, Keycloak, AAP)
 - Optionally installing LVMS (storage service), MetalLB (ingress service), Multicluster Engine (MCE + infrastructure operator), and OpenShift Virtualization (CNV)
 - Setting up the CA issuer and network attachment definitions
-- Applying the Kustomize overlay
+- Deploying OSAC components (via Helm or Kustomize)
 - Waiting for the AAP bootstrap job to complete
 - Creating the hub access kubeconfig and registering the hub with the fulfillment service
 
 To run the automated setup:
 
 ```bash
-# Using defaults (namespace: osac-devel, overlay: development)
+# Helm mode (default) — uses values/development.yaml
 $ ./scripts/setup.sh
 
-# Or customize the namespace and overlay
-$ INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
+# Or customize the namespace and values file
+$ INSTALLER_NAMESPACE=<project-name> VALUES_FILE=values/development.yaml ./scripts/setup.sh
+
+# Kustomize mode (legacy)
+$ DEPLOY_MODE=kustomize INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
 
 # Install with all optional services (storage, ingress, virtualization, MCE)
-$ EXTRA_SERVICES=true \
-    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
-
-# Or selectively enable specific services
-$ INGRESS_SERVICE=true STORAGE_SERVICE=true \
-    INSTALLER_NAMESPACE=<project-name> INSTALLER_KUSTOMIZE_OVERLAY=<project-name> ./scripts/setup.sh
+$ EXTRA_SERVICES=true INSTALLER_NAMESPACE=<project-name> ./scripts/setup.sh
 ```
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `KUBECONFIG` | `~/.kube/config` | Path to the target cluster's kubeconfig file |
-| `INSTALLER_NAMESPACE` | from overlay | Target namespace for the OSAC deployment |
-| `INSTALLER_KUSTOMIZE_OVERLAY` | `development` | Kustomize overlay directory to use |
+| `DEPLOY_MODE` | `helm` | Deployment method: `helm` or `kustomize` |
+| `INSTALLER_NAMESPACE` | `osac` (helm) / from overlay (kustomize) | Target namespace for the OSAC deployment |
+| `VALUES_FILE` | `values/development.yaml` | Helm values file to use (helm mode only) |
+| `INSTALLER_KUSTOMIZE_OVERLAY` | `development` | Kustomize overlay directory (kustomize mode only) |
 | `EXTRA_SERVICES` | `false` | Enable all optional services (sets all below to `true`) |
 | `INGRESS_SERVICE` | `false` | Install MetalLB as the ingress/LoadBalancer service |
 | `STORAGE_SERVICE` | `false` | Install LVMS and create a default StorageClass (`lvms-vg1`) |
@@ -338,10 +341,152 @@ interface contract, and how to add a new provider.
 The script will wait for all components to be ready before proceeding to the next step.
 Once it completes successfully, OSAC is fully operational.
 
-### Option B: Manual Installation
+### Option B: Manual Helm Installation
 
-If you prefer to install step-by-step, or need to install individual prerequisites,
-follow the manual process below.
+If you prefer to install step-by-step, follow the process below. The prerequisites
+are the same as Option C (Kustomize) — only the final deploy step differs.
+
+#### 1. Install Prerequisites
+
+OSAC requires several operators to be present on the cluster. The prerequisite manifests
+are located in the `prerequisites/` directory. Install them in order:
+
+```bash
+# cert-manager
+oc apply -k prerequisites/cert-manager/
+oc wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=300s
+oc wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=300s
+
+# trust-manager
+oc apply -f prerequisites/trust-manager.yaml
+oc wait --for=condition=Available deployment/trust-manager -n cert-manager --timeout=300s
+
+# CA issuer
+oc apply -f prerequisites/ca-issuer.yaml
+
+# Authorino operator
+oc apply -f prerequisites/authorino-operator.yaml
+
+# Keycloak
+oc apply -k prerequisites/keycloak/
+oc wait --for=condition=Available deployment/keycloak-service -n keycloak --timeout=600s
+
+# AAP operator
+oc apply -f prerequisites/aap-installation.yaml
+```
+
+Wait for each operator to be ready before proceeding. See
+[prerequisites/README.md](prerequisites/README.md) for details on optional
+components (LVMS, MetalLB, MCE, OpenShift Virtualization).
+
+#### 2. Initialize Submodules
+
+```bash
+git submodule update --init --recursive --remote
+```
+
+#### 3. Build Chart Dependencies
+
+```bash
+helm dependency build charts/osac/
+```
+
+#### 4. Configure Values
+
+Copy and customize a values file for your environment:
+
+```bash
+cp values/development.yaml values/<project-name>.yaml
+# Edit values/<project-name>.yaml to set:
+#   - operator.aap.url: your AAP controller URL
+#   - service.auth.issuerUrl: your Keycloak realm URL
+#   - service.idp.url: your Keycloak base URL
+#   - service.database.connection: your PostgreSQL connection details
+```
+
+#### 5. Validate (Dry-Run)
+
+```bash
+# Lint the chart
+helm lint charts/osac/
+
+# Render templates without deploying
+helm template osac charts/osac/ --values values/<project-name>.yaml > /dev/null
+```
+
+#### 6. Deploy
+
+```bash
+helm upgrade --install osac charts/osac/ \
+  --namespace <project-name> \
+  --create-namespace \
+  --values values/<project-name>.yaml \
+  --timeout 40m \
+  --wait
+```
+
+#### 7. Verify
+
+```bash
+# Check deployment status
+helm status osac -n <project-name>
+
+# Check running pods
+kubectl get pods -n <project-name>
+
+# Monitor the AAP bootstrap job (runs as a post-install hook)
+kubectl logs -f job/osac-aap-bootstrap -n <project-name>
+```
+
+#### 8. Post-Install
+
+After the AAP bootstrap job completes, run the post-install scripts:
+
+```bash
+INSTALLER_NAMESPACE=<project-name> ./scripts/prepare-aap.sh
+INSTALLER_NAMESPACE=<project-name> ./scripts/prepare-fulfillment-service.sh
+INSTALLER_NAMESPACE=<project-name> ./scripts/prepare-tenant.sh
+```
+
+#### Upgrading
+
+```bash
+helm upgrade osac charts/osac/ \
+  --namespace <project-name> \
+  --values values/<project-name>.yaml \
+  --timeout 40m \
+  --wait
+```
+
+#### Uninstalling
+
+```bash
+helm uninstall osac -n <project-name>
+```
+
+> **Note:** CRDs are preserved after uninstall (they have the
+> `helm.sh/resource-policy: keep` annotation). To remove them manually:
+> `oc delete crd -l app.kubernetes.io/part-of=osac`
+
+#### Makefile Targets
+
+For convenience, the `Makefile` provides developer targets:
+
+```bash
+make helm-deps       # Build chart dependencies
+make helm-lint       # Lint the umbrella chart
+make helm-template   # Dry-run render all templates
+make helm-validate   # Lint + template (full validation)
+make helm-deploy     # Deploy to current cluster
+make helm-undeploy   # Uninstall from current cluster
+make sync-charts     # Update submodules + rebuild dependencies
+make setup           # Run setup.sh with DEPLOY_MODE=helm
+```
+
+### Option C: Manual Kustomize Installation (Legacy)
+
+If you prefer to install step-by-step using Kustomize, or need to install individual
+prerequisites, follow the manual process below.
 
 #### Install Required Operators
 

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: osac
+description: Open Sovereign AI Cloud
+type: application
+version: 0.0.1
+
+dependencies:
+  - name: osac-operator-crds
+    version: "0.0.0"
+    repository: "file://../../base/osac-operator/charts/operator-crds"
+    alias: operatorCrds
+  - name: osac-operator
+    version: "0.0.0"
+    repository: "file://../../base/osac-operator/charts/operator"
+    alias: operator
+  - name: fulfillment-service
+    version: "0.0.0"
+    repository: "file://../../base/osac-fulfillment-service/charts/service"
+    alias: service
+  - name: osac-aap
+    version: "0.0.0"
+    repository: "file://../../base/osac-aap/charts/aap"
+    alias: aap

--- a/charts/osac/templates/NOTES.txt
+++ b/charts/osac/templates/NOTES.txt
@@ -1,0 +1,40 @@
+Open Sovereign AI Cloud (OSAC) has been installed.
+
+Release:   {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Components deployed:
+
+  Management plane:
+    - Fulfillment Service (gRPC server, REST gateway, controller)
+
+  Hub components (per management cluster):
+    - OSAC Operator CRDs
+    - OSAC Operator Controller Manager
+{{- if .Values.aap.aap.instance.enabled }}
+    - AAP instance ({{ .Values.aap.aap.instance.name }})
+{{- end }}
+{{- if .Values.aap.bootstrap.enabled }}
+    - AAP bootstrap job (post-install hook)
+{{- end }}
+
+NOTE: This chart currently deploys both the management plane and hub
+components to the same cluster. In a multi-hub architecture, the
+fulfillment service (with its database and identity provider) would
+run separately from the hub components (operator + AAP).
+
+To check the status of the deployment:
+
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pods -n {{ .Release.Namespace }}
+
+{{- if .Values.aap.bootstrap.enabled }}
+
+The AAP bootstrap job runs as a post-install hook. To monitor its progress:
+
+  kubectl logs -f job/{{ .Release.Name }}-aap-bootstrap -n {{ .Release.Namespace }}
+{{- end }}
+
+To upgrade the deployment:
+
+  helm upgrade {{ .Release.Name }} <chart-path> -n {{ .Release.Namespace }} -f <values-file>

--- a/charts/osac/templates/_helpers.tpl
+++ b/charts/osac/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "osac.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "osac.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "osac.labels" -}}
+helm.sh/chart: {{ include "osac.name" . }}
+app.kubernetes.io/part-of: osac
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/osac/templates/hooks/db-migrate.yaml
+++ b/charts/osac/templates/hooks/db-migrate.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.dbMigrate.enabled }}
+{{- if and .Values.dbMigrate.dbUrl .Values.dbMigrate.dbUrlFile }}
+{{- fail "dbMigrate: only one of dbUrl or dbUrlFile may be set, not both" }}
+{{- end }}
+{{- if not (or .Values.dbMigrate.dbUrl .Values.dbMigrate.dbUrlFile) }}
+{{- fail "dbMigrate: one of dbUrl or dbUrlFile must be set when dbMigrate.enabled is true" }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/osac/templates/hooks/db-migrate.yaml
+++ b/charts/osac/templates/hooks/db-migrate.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.dbMigrate.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac.fullname" . }}-db-migrate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: migrate
+        image: {{ .Values.dbMigrate.image }}
+        command:
+        - fulfillment-service
+        - migrate
+        {{- if .Values.dbMigrate.dbUrl }}
+        - --db-url
+        - {{ .Values.dbMigrate.dbUrl | quote }}
+        {{- end }}
+        {{- if .Values.dbMigrate.dbUrlFile }}
+        - --db-url-file
+        - {{ .Values.dbMigrate.dbUrlFile | quote }}
+        {{- end }}
+  backoffLimit: 3
+{{- end }}

--- a/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -66,7 +66,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "osac.fullname" . }}-validate
+  name: {{ include "osac.fullname" . }}-validate-{{ .Release.Namespace }}
   labels:
     {{- include "osac.labels" . | nindent 4 }}
   annotations:
@@ -84,7 +84,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "osac.fullname" . }}-validate
+  name: {{ include "osac.fullname" . }}-validate-{{ .Release.Namespace }}
   labels:
     {{- include "osac.labels" . | nindent 4 }}
   annotations:
@@ -94,7 +94,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "osac.fullname" . }}-validate
+  name: {{ include "osac.fullname" . }}-validate-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "osac.fullname" . }}-validate

--- a/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.validation.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac.fullname" . }}-pre-install-validate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "osac.fullname" . }}-validate
+      containers:
+      - name: validate
+        image: {{ .Values.validation.image }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          echo "=== OSAC Pre-install Validation ==="
+
+          # Check that cert-manager CRDs exist
+          echo "Checking for cert-manager CRDs..."
+          if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+            echo "  cert-manager CRDs found."
+          else
+            echo "ERROR: cert-manager CRDs not found."
+            echo "Please install cert-manager before deploying OSAC."
+            exit 1
+          fi
+
+          # Check that a default StorageClass exists
+          echo "Checking for default StorageClass..."
+          DEFAULT_SC=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null)
+          if [ -n "$DEFAULT_SC" ]; then
+            echo "  Default StorageClass found: $DEFAULT_SC"
+          else
+            echo "WARNING: No default StorageClass found."
+            echo "Some components (PostgreSQL, Keycloak) may fail to create PVCs."
+          fi
+
+          echo "=== Validation passed ==="
+  backoffLimit: 0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "osac.fullname" . }}-validate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "osac.fullname" . }}-validate
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "osac.fullname" . }}-validate
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "osac.fullname" . }}-validate
+subjects:
+- kind: ServiceAccount
+  name: {{ include "osac.fullname" . }}-validate
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OSAC Helm Chart Values",
+  "description": "Configuration values for Open Sovereign AI Cloud deployment",
+  "type": "object",
+  "properties": {
+    "operatorCrds": {
+      "type": "object",
+      "description": "OSAC Operator CRDs configuration",
+      "properties": {
+        "install": {
+          "type": "boolean",
+          "description": "Install OSAC CRDs",
+          "default": true
+        }
+      }
+    },
+    "operator": {
+      "type": "object",
+      "description": "OSAC Operator configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Operator container image repository",
+              "default": "ghcr.io/osac-project/osac-operator"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Operator container image tag",
+              "default": "latest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Image pull policy",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "Always"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of operator replicas",
+          "minimum": 1,
+          "default": 1
+        },
+        "provisioning": {
+          "type": "object",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Provisioning provider",
+              "enum": ["aap", "eda"],
+              "default": "aap"
+            }
+          }
+        },
+        "aap": {
+          "type": "object",
+          "description": "AAP connection settings for the operator",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "AAP controller URL"
+            },
+            "token": {
+              "type": "string",
+              "description": "AAP API token"
+            },
+            "insecureSkipVerify": {
+              "type": "string",
+              "description": "Skip TLS verification for AAP",
+              "default": "true"
+            },
+            "statusPollInterval": {
+              "type": "string",
+              "description": "Interval for polling AAP job status",
+              "default": "30s"
+            },
+            "templatePrefix": {
+              "type": "string",
+              "description": "Prefix for AAP job templates",
+              "default": "osac"
+            }
+          }
+        },
+        "fulfillment": {
+          "type": "object",
+          "properties": {
+            "serverAddress": {
+              "type": "string",
+              "description": "Fulfillment service gRPC address",
+              "default": "fulfillment-api:8000"
+            },
+            "tokenFile": {
+              "type": "string",
+              "description": "Path to service account token file"
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "description": "Fulfillment Service configuration",
+      "properties": {
+        "variant": {
+          "type": "string",
+          "description": "Deployment variant",
+          "enum": ["openshift", "kind"],
+          "default": "openshift"
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "string",
+              "description": "Fulfillment service container image"
+            },
+            "envoy": {
+              "type": "string",
+              "description": "Envoy proxy container image"
+            }
+          }
+        }
+      }
+    },
+    "aap": {
+      "type": "object",
+      "description": "AAP bootstrap and instance configuration",
+      "properties": {
+        "aap": {
+          "type": "object",
+          "properties": {
+            "instance": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Create AAP instance CR (set false if AAP is managed externally)",
+                  "default": true
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the AAP instance",
+                  "default": "osac-aap"
+                }
+              }
+            }
+          }
+        },
+        "bootstrap": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Run AAP bootstrap job after install",
+              "default": true
+            },
+            "image": {
+              "type": "string",
+              "description": "Bootstrap job container image"
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "description": "Number of retries for bootstrap job",
+              "default": 15
+            }
+          }
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "description": "Pre-install validation hook",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run pre-install validation checks",
+          "default": true
+        }
+      }
+    },
+    "dbMigrate": {
+      "type": "object",
+      "description": "Database migration hook",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run database migrations on upgrade",
+          "default": true
+        },
+        "image": {
+          "type": "string",
+          "description": "Container image for migration job (should match fulfillment service image)"
+        },
+        "dbUrl": {
+          "type": "string",
+          "description": "Database connection URL (optional, alternative to dbUrlFile)"
+        },
+        "dbUrlFile": {
+          "type": "string",
+          "description": "Path to file containing database connection URL (optional, alternative to dbUrl)"
+        }
+      }
+    }
+  }
+}

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -1,0 +1,120 @@
+# Open Sovereign AI Cloud - Unified Helm Values
+# This values file configures all OSAC components via the umbrella chart.
+
+# --- Operator CRDs ---
+operatorCrds:
+  install: true
+
+# --- Operator ---
+operator:
+  image:
+    repository: ghcr.io/osac-project/osac-operator
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  provisioning:
+    provider: "aap"
+  aap:
+    url: ""
+    token: ""
+    insecureSkipVerify: "true"
+    statusPollInterval: "30s"
+    templatePrefix: "osac"
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  controllers:
+    clusterOrder: true
+    computeInstance: true
+    tenant: true
+    networking: true
+  configSecret:
+    name: "osac-config"
+    optional: true
+
+# --- Fulfillment Service ---
+service:
+  variant: openshift
+  images:
+    service: ghcr.io/osac-project/fulfillment-service:latest
+    envoy: docker.io/envoyproxy/envoy:v1.33.0
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: ""
+    controllerCredentials: []
+  idp:
+    provider: keycloak
+    url: ""
+    credentials: []
+  database:
+    connection: []
+    # Example:
+    # connection:
+    # - secret:
+    #     name: fulfillment-db
+    #     items:
+    #     - key: url
+    #       param: url
+  log:
+    level: info
+    headers: false
+    bodies: false
+
+# --- AAP ---
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+      controller:
+        disabled: false
+      eda:
+        disabled: false
+      hub:
+        disabled: true
+      lightspeed:
+        disabled: true
+      noLog: true
+      redisMode: standalone
+      routeTlsTerminationMechanism: Edge
+      imagePullPolicy: IfNotPresent
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:latest
+    cliImage: quay.io/openshift/origin-cli:4.20.0
+    backoffLimit: 15
+    gateway:
+      hostname: ""
+    eda:
+      hostname: ""
+    controller:
+      hostname: ""
+  configAsCode:
+    manifestSecret: "config-as-code-manifest-ig"
+    secret: "config-as-code-ig"
+
+# --- Validation hooks ---
+validation:
+  enabled: true
+  image: bitnami/kubectl:latest
+
+# --- Database migration hook ---
+# NOTE: Disabled until the 'migrate' subcommand is released in the
+# fulfillment-service image. Re-enable once available.
+dbMigrate:
+  enabled: false
+  image: ghcr.io/osac-project/fulfillment-service:latest
+  dbUrl: ""
+  dbUrlFile: ""

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -1,0 +1,1001 @@
+# OSAC Helm Deployment Guide
+
+Step-by-step guide for deploying OSAC on a clean connected OpenShift cluster
+using the Helm umbrella chart. Covers VMaaS and CaaS profiles.
+
+## Table of Contents
+
+- [Before You Begin](#before-you-begin)
+- [Phase 1: Cluster Prerequisites](#phase-1-cluster-prerequisites)
+  - [1.1 Storage (LVMS)](#11-storage-lvms)
+  - [1.2 Ingress (MetalLB)](#12-ingress-metallb)
+  - [1.3 Multicluster Engine (MCE)](#13-multicluster-engine-mce)
+  - [1.4 OpenShift Virtualization (CNV)](#14-openshift-virtualization-cnv)
+  - [1.5 cert-manager and trust-manager](#15-cert-manager-and-trust-manager)
+  - [1.6 CA Issuer](#16-ca-issuer)
+  - [1.7 Authorino Operator](#17-authorino-operator)
+  - [1.8 Keycloak](#18-keycloak)
+  - [1.9 AAP Operator](#19-aap-operator)
+- [Phase 2: Prepare Secrets and Configuration](#phase-2-prepare-secrets-and-configuration)
+  - [2.1 CA Trust Bundle](#21-ca-trust-bundle)
+  - [2.2 PostgreSQL Database](#22-postgresql-database)
+  - [2.3 Fulfillment Controller Credentials](#23-fulfillment-controller-credentials)
+  - [2.4 AAP License](#24-aap-license)
+  - [2.5 AAP Config-as-Code Secret](#25-aap-config-as-code-secret)
+  - [2.6 Instance Group Configuration (Optional)](#26-instance-group-configuration-optional)
+- [Phase 3: Deploy OSAC via Helm](#phase-3-deploy-osac-via-helm)
+  - [3.1 Initialize Submodules](#31-initialize-submodules)
+  - [3.2 Choose a Values File](#32-choose-a-values-file)
+  - [3.3 Validate](#33-validate)
+  - [3.4 Deploy](#34-deploy)
+  - [3.5 Verify](#35-verify)
+- [Phase 4: Post-Install Configuration](#phase-4-post-install-configuration)
+  - [4.1 Create AAP API Token](#41-create-aap-api-token)
+  - [4.2 Install the OSAC CLI](#42-install-the-osac-cli)
+  - [4.3 Register the Hub](#43-register-the-hub)
+  - [4.4 Create Tenants](#44-create-tenants)
+  - [4.5 Apply AAP Instance Group Overrides](#45-apply-aap-instance-group-overrides)
+- [Profile Reference](#profile-reference)
+- [Automated Alternative](#automated-alternative)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Before You Begin
+
+### Requirements
+
+| Requirement | Details |
+|-------------|---------|
+| OpenShift | 4.17+ with cluster-admin access |
+| CLI tools | `oc`, `helm`, `git`, `jq` |
+| Network | Outbound access to github.com, ghcr.io, quay.io, registry.redhat.io |
+| Storage | A default StorageClass (or install LVMS below) |
+| AAP license | Subscription manifest (`license.zip`) from [Red Hat Customer Portal](https://access.redhat.com/) |
+
+### Clone and Verify
+
+```bash
+git clone https://github.com/osac-project/osac-installer.git
+cd osac-installer
+
+# Verify cluster access
+oc whoami
+oc whoami --show-server
+```
+
+### Choose Your Namespace
+
+Pick a namespace for OSAC. All commands below use `NAMESPACE` — set it once:
+
+```bash
+export NAMESPACE=osac
+```
+
+---
+
+## Phase 1: Cluster Prerequisites
+
+Install in the order shown — some prerequisites depend on earlier ones
+(e.g., Keycloak needs a StorageClass, AAP bootstrap needs cert-manager).
+
+### Which Prerequisites Do I Need?
+
+| Prerequisite | Required? | Notes |
+|-------------|-----------|-------|
+| cert-manager + trust-manager | **Yes** | TLS certificates for all OSAC services |
+| CA Issuer | **Yes** | Self-signed CA for internal certificates |
+| Authorino | **Yes** | gRPC authorization for the fulfillment service |
+| Keycloak | **Yes** | Identity provider for OAuth/OIDC |
+| AAP Operator | **Yes** | Ansible Automation Platform for provisioning workflows |
+| LVMS | Only if no default StorageClass exists | Provides `lvms-vg1` StorageClass |
+| MetalLB | Only if no LoadBalancer service exists | Provides bare-metal load balancing |
+| MCE | Only for CaaS (cluster provisioning) | Multicluster Engine + infrastructure operator |
+| CNV | Only for VMaaS (VM provisioning) | OpenShift Virtualization |
+
+### 1.1 Storage (LVMS)
+
+Skip if your cluster already has a default StorageClass (`oc get sc`).
+
+```bash
+oc apply -f prerequisites/lvms/lvms-operator.yaml
+
+# Wait for the LVMS operator CSV to appear
+until LVMS_CSV=$(oc get csv --no-headers -n openshift-storage 2>/dev/null \
+  | awk '/lvms/ { print $1 }' | tail -1) && [[ -n "${LVMS_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${LVMS_CSV}"
+oc wait csv/${LVMS_CSV} -n openshift-storage \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+
+# Apply LVMCluster configuration
+oc apply -f prerequisites/lvms/lvms-config.yaml
+
+# Wait for the StorageClass and set it as default
+oc wait --for=jsonpath='{.metadata.name}'=lvms-vg1 sc/lvms-vg1 --timeout=300s
+oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+```
+
+### 1.2 Ingress (MetalLB)
+
+MetalLB provides a `LoadBalancer` service type implementation. Whether you
+need it depends on your cluster:
+
+- **Cloud clusters** (AWS, Azure, GCP) — the cloud provider handles
+  LoadBalancer services automatically. **Skip MetalLB.**
+- **Bare-metal / on-prem clusters** (e.g., MOC) — no built-in LoadBalancer.
+  **Install MetalLB.**
+
+To check, run:
+
+```bash
+oc get svc -A --field-selector spec.type=LoadBalancer
+```
+
+If existing LoadBalancer services have assigned IPs under `EXTERNAL-IP`, you
+already have a LoadBalancer implementation. If they show `<pending>`, you need
+MetalLB.
+
+```bash
+oc apply -f prerequisites/metallb/metallb-operator.yaml
+
+# Wait for the MetalLB operator CSV to appear
+until METALLB_CSV=$(oc get csv --no-headers -n metallb-system 2>/dev/null \
+  | awk '/metallb/ { print $1 }' | tail -1) && [[ -n "${METALLB_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${METALLB_CSV}"
+oc wait csv/${METALLB_CSV} -n metallb-system \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+oc wait deployment/metallb-operator-controller-manager -n metallb-system \
+  --for=condition=Available --timeout=300s
+
+# Apply MetalLB configuration (IPAddressPool, L2Advertisement)
+oc apply -f prerequisites/metallb/metallb-config.yaml
+```
+
+### 1.3 Multicluster Engine (MCE)
+
+Required for **CaaS** (cluster provisioning). Skip for VMaaS-only.
+
+```bash
+oc apply -f prerequisites/mce/mce-operator.yaml
+
+# Wait for the MCE operator CSV to appear
+until MCE_CSV=$(oc get csv --no-headers -n multicluster-engine 2>/dev/null \
+  | awk '/multicluster-engine/ { print $1 }' | tail -1) && [[ -n "${MCE_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${MCE_CSV}"
+oc wait csv/${MCE_CSV} -n multicluster-engine \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s
+
+# Create the MultiClusterEngine instance
+cat <<EOF | oc apply -f -
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec: {}
+EOF
+
+# Wait for MCE to become Available (can take several minutes)
+oc wait multiclusterengine/multiclusterengine \
+  --for=jsonpath='{.status.phase}'=Available --timeout=600s
+
+# Apply AgentServiceConfig
+oc apply -f prerequisites/mce/mce-config.yaml
+
+# Wait for the infrastructure operator
+oc wait deployment/assisted-service -n multicluster-engine \
+  --for=condition=Available --timeout=600s
+```
+
+### 1.4 OpenShift Virtualization (CNV)
+
+Required for **VMaaS** (VM provisioning). Skip for CaaS-only.
+
+```bash
+oc apply -f prerequisites/cnv/cnv-operator.yaml
+
+# Wait for the CNV operator CSV to appear
+until CNV_CSV=$(oc get csv --no-headers -n openshift-cnv 2>/dev/null \
+  | awk '/kubevirt-hyperconverged-operator/ { print $1 }' | tail -1) && [[ -n "${CNV_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${CNV_CSV}"
+oc wait csv/${CNV_CSV} -n openshift-cnv \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=600s
+
+# Apply HyperConverged CR
+oc apply -f prerequisites/cnv/cnv-config.yaml
+
+# Wait for HyperConverged to be Available (can take up to 10 minutes)
+oc wait hyperconverged/kubevirt-hyperconverged -n openshift-cnv \
+  --for=jsonpath='{.status.conditions[?(@.type=="Available")].status}'=True \
+  --timeout=900s
+```
+
+### 1.5 cert-manager and trust-manager
+
+The cert-manager prerequisite file contains both the operator Subscription and
+the `CertManager` CR. The CR will fail on first apply because the CRD doesn't
+exist yet — this is expected. Apply, wait for the operator, then apply again:
+
+```bash
+# First apply: creates Namespace, OperatorGroup, Subscription.
+# The CertManager CR will fail — that's expected.
+oc apply -k prerequisites/cert-manager/ || true
+
+# Wait for the operator to install and register the CRD
+oc wait crd/certmanagers.operator.openshift.io --for=condition=Established --timeout=300s
+
+# Second apply: now the CertManager CR succeeds
+oc apply -k prerequisites/cert-manager/
+
+# Wait for cert-manager deployments
+oc wait deployment/cert-manager -n cert-manager --for=condition=Available --timeout=300s
+oc wait deployment/cert-manager-webhook -n cert-manager --for=condition=Available --timeout=300s
+oc wait deployment/cert-manager-cainjector -n cert-manager --for=condition=Available --timeout=300s
+
+# Install trust-manager
+oc apply -f prerequisites/trust-manager.yaml
+oc wait deployment/trust-manager -n cert-manager --for=condition=Available --timeout=300s
+```
+
+### 1.6 CA Issuer
+
+```bash
+oc apply -f prerequisites/ca-issuer.yaml
+oc wait clusterissuer/default-ca --for=condition=Ready --timeout=300s
+```
+
+### 1.7 Authorino Operator
+
+```bash
+oc apply -f prerequisites/authorino-operator.yaml
+
+# Wait for the Authorino CSV to appear
+until AUTHORINO_CSV=$(oc get csv --no-headers -n openshift-operators 2>/dev/null \
+  | awk '/authorino/ { print $1 }' | tail -1) && [[ -n "${AUTHORINO_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${AUTHORINO_CSV}"
+oc wait csv/${AUTHORINO_CSV} -n openshift-operators \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+oc wait deployment/authorino-operator -n openshift-operators \
+  --for=condition=Available --timeout=300s
+```
+
+### 1.8 Keycloak
+
+Keycloak provides identity management (OAuth/OIDC) for OSAC. It includes its
+own PostgreSQL database.
+
+```bash
+oc apply -k prerequisites/keycloak/
+oc wait deployment/keycloak-service -n keycloak --for=condition=Available --timeout=600s
+```
+
+### 1.9 AAP Operator
+
+This installs the AAP operator only. The AAP instance itself (controller, EDA,
+gateway) is created by the Helm chart.
+
+> **Note:** Depending on the AAP version, the operator may install into the
+> `ansible-aap` or `aap` namespace. The commands below use `ansible-aap`. If
+> your AAP operator is already installed in a different namespace, adjust
+> `AAP_NS` accordingly.
+
+```bash
+oc apply -f prerequisites/aap-installation.yaml
+
+# Detect the AAP operator namespace
+AAP_NS=""
+for ns in aap ansible-aap openshift-operators; do
+  if oc get deployment automation-controller-operator-controller-manager \
+    -n "${ns}" &>/dev/null; then
+    AAP_NS="${ns}"
+    break
+  fi
+done
+[[ -z "${AAP_NS}" ]] && AAP_NS="ansible-aap"
+echo "AAP operator namespace: ${AAP_NS}"
+
+# Wait for the AAP CSV to appear
+until AAP_CSV=$(oc get csv --no-headers -n ${AAP_NS} 2>/dev/null \
+  | awk '/aap/ { print $1 }' | tail -1) && [[ -n "${AAP_CSV}" ]]; do
+  sleep 10
+done
+echo "Found CSV: ${AAP_CSV}"
+oc wait csv/${AAP_CSV} -n ${AAP_NS} \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+oc wait deployment/automation-controller-operator-controller-manager -n ${AAP_NS} \
+  --for=condition=Available --timeout=300s
+```
+
+---
+
+## Phase 2: Prepare Secrets and Configuration
+
+The Helm chart deploys OSAC components but does **not** create all required
+secrets and configmaps. Several must be created manually before or after the
+Helm install.
+
+Create the namespace first (Helm will reuse it with `--create-namespace`):
+
+```bash
+oc create namespace ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+```
+
+### 2.1 CA Trust Bundle
+
+The fulfillment-service pods need a `ca-bundle` ConfigMap containing the
+cluster's CA certificate. This is managed by trust-manager — you create a
+`Bundle` resource that tells trust-manager to sync the CA from cert-manager
+into your OSAC namespace:
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ca-bundle
+spec:
+  sources:
+  - secret:
+      name: "default-ca"
+      key: "ca.crt"
+  target:
+    configMap:
+      key: bundle.pem
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - ${NAMESPACE}
+EOF
+```
+
+Verify the configmap was created (trust-manager syncs it within seconds):
+
+```bash
+oc get configmap ca-bundle -n ${NAMESPACE}
+```
+
+### 2.2 PostgreSQL Database
+
+The fulfillment-service requires a PostgreSQL database. The connection details
+are provided via a `fulfillment-db` secret.
+
+**Option A: Deploy the bundled dev postgres chart** (single-replica, non-HA,
+suitable for dev/test):
+
+```bash
+# Deploy PostgreSQL with TLS and a 'service' database
+helm install fulfillment-db base/osac-fulfillment-service/it/charts/postgres/ \
+  -n ${NAMESPACE} \
+  --set certs.issuerRef.name=default-ca \
+  --set certs.caBundle.configMap=ca-bundle \
+  --set 'databases[0].name=service' \
+  --set 'databases[0].user=service'
+
+# Create the connection secret.
+# The postgres chart enforces mutual TLS (pg_hba.conf uses "hostssl ... cert"),
+# so the URL must use sslmode=verify-full with paths to the client certificate
+# files. These paths correspond to where the fulfillment-service chart mounts
+# the projected database volume.
+oc create secret generic fulfillment-db \
+  --from-literal=url='postgres://service@postgres:5432/service?sslmode=verify-full&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert&sslcert=/etc/fulfillment-grpc-server/db/sslcert&sslkey=/etc/fulfillment-grpc-server/db/sslkey' \
+  -n ${NAMESPACE}
+```
+
+The postgres chart only creates a **server** certificate — client certificates
+must be created separately. Create a cert-manager Certificate for the
+`service` database user:
+
+```bash
+cat <<'EOF' | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: postgres-client-service
+  namespace: osac
+spec:
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-ca
+  commonName: service
+  usages:
+  - client auth
+  secretName: postgres-client-cert-service
+  privateKey:
+    rotationPolicy: Always
+EOF
+
+# Wait for the certificate to be issued
+oc wait certificate/postgres-client-service -n ${NAMESPACE} \
+  --for=condition=Ready --timeout=60s
+```
+
+> **Note:** The values files already include a `database.connection` entry
+> that mounts the `postgres-client-cert-service` secret into the projected
+> volume at `/etc/fulfillment-grpc-server/db/`. This provides the `sslcert`,
+> `sslkey`, and `sslrootcert` files referenced in the connection URL above.
+
+**Option B: Use an existing database** — create the secret manually with
+your connection details:
+
+```bash
+oc create secret generic fulfillment-db \
+  --from-literal=url='postgres://user:password@host:5432/dbname?sslmode=require' \
+  -n ${NAMESPACE}
+```
+
+### 2.3 Fulfillment Controller Credentials
+
+OAuth client credentials for the fulfillment controller, extracted from the
+Keycloak realm configuration. The Keycloak client is named `osac-controller`
+and the OPA authorization policy expects JWT username
+`service-account-osac-controller`:
+
+```bash
+FC_CLIENT_SECRET=$(jq -r \
+  '.clients[] | select(.clientId == "osac-controller") | .secret' \
+  prerequisites/keycloak/service/files/realm.json)
+
+oc create secret generic fulfillment-controller-credentials \
+  --from-literal=client-id=osac-controller \
+  --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+  -n ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+```
+
+### 2.4 AAP License
+
+The AAP bootstrap job requires a subscription manifest (license.zip). Obtain
+it from the [Red Hat Customer Portal](https://access.redhat.com/) under
+**Subscriptions > Subscription Allocations > Export Manifest**.
+
+```bash
+# Create the license secret
+oc create secret generic config-as-code-manifest-ig \
+  --from-file=license.zip=/path/to/your/license.zip \
+  -n ${NAMESPACE}
+```
+
+### 2.5 AAP Config-as-Code Secret
+
+This tells the AAP bootstrap job which execution environment image and git
+repository to use for configuration playbooks.
+
+```bash
+oc create secret generic config-as-code-ig \
+  --from-literal=AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:latest \
+  --from-literal=AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap \
+  --from-literal=AAP_PROJECT_GIT_BRANCH=main \
+  -n ${NAMESPACE}
+```
+
+> **Tip:** If using a custom osac-aap image or branch, update these values
+> accordingly. The `AAP_EE_IMAGE` is the Execution Environment image that AAP
+> uses to run automation jobs.
+
+### 2.6 Instance Group Configuration (Optional)
+
+> **Skip this section** if you just want to test the OSAC deployment. These
+> secrets are only needed when AAP actually provisions real infrastructure
+> (creates clusters on ESI/Netris, VMs on KubeVirt, etc.). All instance group
+> secrets are referenced as `optional: true` — OSAC will install and run
+> without them.
+
+AAP job templates run inside "instance groups" that receive environment
+variables from ConfigMaps and Secrets. Create them only when you're ready to
+provision real workloads against a specific backend.
+
+<details>
+<summary><strong>cluster-fulfillment-ig</strong> — CaaS backend credentials (click to expand)</summary>
+
+Contains network backend settings, base domains, cloud credentials, and SSH
+keys. See
+[base/osac-aap/config/base/configmap-cluster-fulfillment-ig-example.yaml](../base/osac-aap/config/base/configmap-cluster-fulfillment-ig-example.yaml)
+and
+[base/osac-aap/config/base/secret-cluster-fulfillment-ig-example.yaml](../base/osac-aap/config/base/secret-cluster-fulfillment-ig-example.yaml)
+for full examples.
+
+```bash
+# ConfigMap with non-sensitive settings
+oc create configmap cluster-fulfillment-ig \
+  --from-literal=NETWORK_CLASS=esi \
+  --from-literal=NETWORK_STEPS_COLLECTION=massopencloud.steps \
+  --from-literal=EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud \
+  --from-literal=EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud \
+  --from-literal=EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift \
+  --from-literal=HOSTED_CLUSTER_BASE_DOMAIN=box.massopen.cloud \
+  --from-literal=HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY=HighlyAvailable \
+  --from-literal=HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY=HighlyAvailable \
+  -n ${NAMESPACE}
+
+# Secret with sensitive credentials (include only the keys you have)
+oc create secret generic cluster-fulfillment-ig \
+  --from-literal=NETRIS_PASSWORD=<your-netris-password> \
+  --from-file=SERVER_SSH_KEY=/path/to/server-ssh-key \
+  --from-file=SERVER_SSH_BASTION_KEY=/path/to/bastion-ssh-key \
+  -n ${NAMESPACE}
+
+# AWS credentials — only needed if using Route53 for DNS:
+#   --from-literal=AWS_ACCESS_KEY_ID=<your-aws-key>
+#   --from-literal=AWS_SECRET_ACCESS_KEY=<your-aws-secret>
+
+# OpenStack credentials — only needed if using OpenStack backends:
+#   --from-literal=OS_AUTH_URL=<your-openstack-auth-url>
+#   --from-literal=OS_AUTH_TYPE=v3applicationcredential
+#   --from-literal=OS_APPLICATION_CREDENTIAL_ID=<your-credential-id>
+#   --from-literal=OS_APPLICATION_CREDENTIAL_SECRET=<your-credential-secret>
+```
+
+</details>
+
+<details>
+<summary><strong>network-fulfillment-ig</strong> — Netris networking credentials (click to expand)</summary>
+
+```bash
+oc create configmap network-fulfillment-ig \
+  --from-literal=NETRIS_CONTROLLER_URL=https://redhat-ctl.netris.io \
+  --from-literal=NETRIS_USERNAME=netris \
+  --from-literal=NETRIS_SITE_ID=5 \
+  --from-literal=NETRIS_TENANT_ID=1 \
+  --from-literal=NETRIS_TENANT_NAME=Admin \
+  -n ${NAMESPACE}
+
+oc create secret generic network-fulfillment-ig \
+  --from-literal=NETRIS_PASSWORD=<your-netris-password> \
+  -n ${NAMESPACE}
+```
+
+</details>
+
+<details>
+<summary><strong>publish-templates-ig</strong> — Template publishing config (click to expand)</summary>
+
+Tells the template publishing job which collections to scan and which
+fulfillment endpoint to register templates with.
+
+```bash
+oc create configmap publish-templates-ig \
+  --from-literal=OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud \
+  --from-literal=OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001 \
+  -n ${NAMESPACE}
+```
+
+</details>
+
+#### Alternative: Use env files
+
+Instead of creating each ConfigMap/Secret manually, you can use the
+`scripts/aap-configuration.sh` script. Copy and edit the env files:
+
+```bash
+cp overlays/development/files/osac-aap-secrets.env.example \
+   overlays/development/files/osac-aap-secrets.env
+# Edit osac-aap-secrets.env with your credentials
+# Edit overlays/development/files/osac-aap-configuration.env with your settings
+
+# Apply after Helm deploy:
+INSTALLER_NAMESPACE=${NAMESPACE} INSTALLER_KUSTOMIZE_OVERLAY=development \
+  ./scripts/aap-configuration.sh
+```
+
+---
+
+## Phase 3: Deploy OSAC via Helm
+
+### 3.1 Initialize Submodules
+
+The umbrella chart uses `file://` references to component charts via git
+submodules.
+
+```bash
+git submodule update --init --recursive
+```
+
+### 3.2 Choose a Values File
+
+| Profile | Values File | Operator Controllers | Notes |
+|---------|-------------|---------------------|-------|
+| Development (all) | `values/development.yaml` | clusterOrder, computeInstance, tenant, networking | All controllers, `latest` images |
+| CaaS CI | `values/caas-ci.yaml` | clusterOrder, tenant, networking | Cluster provisioning only, pinned images |
+| VMaaS CI | `values/vmaas-ci.yaml` | computeInstance, tenant, networking | VM provisioning only, pinned images |
+
+To customize, copy and edit:
+
+```bash
+cp values/development.yaml values/my-env.yaml
+```
+
+Key settings to review in your values file:
+
+| Setting | Description | Where to Find |
+|---------|-------------|---------------|
+| `operator.aap.url` | AAP controller API URL | Set post-install by `prepare-aap.sh` |
+| `service.auth.issuerUrl` | Keycloak realm URL | `https://keycloak.keycloak.svc.cluster.local/realms/osac` (default works) |
+| `service.idp.url` | Keycloak base URL | `https://keycloak.keycloak.svc.cluster.local` (default works) |
+| `service.database.connection` | PostgreSQL connection | Referenced from `fulfillment-db` secret |
+| `aap.aap.instance.enabled` | Create AAP instance CR | `true` (chart manages AAP instance) |
+| `aap.bootstrap.enabled` | Run bootstrap job | `true` (configures AAP with job templates) |
+
+### 3.3 Validate
+
+```bash
+# Build dependencies
+helm dependency build charts/osac/
+
+# Lint
+helm lint charts/osac/
+
+# Dry-run render
+helm template osac charts/osac/ \
+  --namespace ${NAMESPACE} \
+  --values values/development.yaml > /dev/null
+```
+
+### 3.4 Deploy
+
+```bash
+helm upgrade --install osac charts/osac/ \
+  --namespace ${NAMESPACE} \
+  --create-namespace \
+  --values values/development.yaml \
+  --timeout 40m \
+  --wait
+```
+
+> **Note:** The database migration hook (`dbMigrate.enabled`) is disabled by
+> default because the `fulfillment-service migrate` subcommand has not been
+> released yet. Once it is released in a tagged image, enable it with
+> `--set dbMigrate.enabled=true` to run migrations automatically on upgrade.
+
+The `--wait` flag blocks until all Deployments, StatefulSets, and Jobs
+(excluding Helm hooks) are ready. The AAP bootstrap job runs as a
+post-install hook and may take 10-40 minutes.
+
+### 3.5 Verify
+
+```bash
+# Helm release status
+helm status osac -n ${NAMESPACE}
+
+# Pod status
+oc get pods -n ${NAMESPACE}
+
+# Monitor the AAP bootstrap job
+oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
+
+# Check key deployments
+oc get deployment -n ${NAMESPACE}
+```
+
+Expected deployments:
+- `osac-operator-controller-manager` — OSAC operator
+- `fulfillment-grpc-server` — Fulfillment gRPC API
+- `fulfillment-rest-gateway` — Fulfillment REST API
+- `fulfillment-controller` — Fulfillment controller
+- `fulfillment-ingress-proxy` — Envoy proxy
+- `authorino` — Authorization service
+
+---
+
+## Phase 4: Post-Install Configuration
+
+After the Helm chart is deployed and the AAP bootstrap job completes, run
+these steps to finish the setup.
+
+### 4.1 Create AAP API Token
+
+The operator needs an API token to communicate with AAP. This script
+authenticates with the AAP gateway, creates a write-scoped token, and patches
+the operator deployment with the AAP URL.
+
+```bash
+# Wait for AAP gateway to be ready
+oc wait deployment/osac-aap-gateway -n ${NAMESPACE} \
+  --for=condition=Available --timeout=600s
+
+# Create the token
+INSTALLER_NAMESPACE=${NAMESPACE} ./scripts/prepare-aap.sh
+```
+
+What this does:
+1. Gets the AAP admin password from secret `osac-aap-admin-password`
+2. Creates an API token via `POST /api/gateway/v1/tokens/`
+3. Stores the token in secret `osac-aap-api-token`
+4. Sets `OSAC_AAP_URL` on the operator deployment (triggers rollout)
+
+### 4.2 Install the OSAC CLI
+
+The hub registration step requires the `osac` CLI.
+
+```bash
+curl -L -o osac \
+  https://github.com/osac-project/fulfillment-service/releases/latest/download/osac_Linux_x86_64
+chmod +x osac
+sudo mv osac /usr/local/bin/
+```
+
+### 4.3 Register the Hub
+
+Register the current cluster as a management hub with the fulfillment service.
+
+```bash
+# Wait for fulfillment service
+oc wait deployment/fulfillment-grpc-server -n ${NAMESPACE} \
+  --for=condition=Available --timeout=300s
+oc wait deployment/fulfillment-ingress-proxy -n ${NAMESPACE} \
+  --for=condition=Available --timeout=300s
+
+# Set project context
+oc project ${NAMESPACE}
+
+# Register the hub
+INSTALLER_NAMESPACE=${NAMESPACE} ./scripts/prepare-fulfillment-service.sh
+```
+
+What this does:
+1. Creates a hub-access kubeconfig using the `hub-access` ServiceAccount
+2. Logs into the fulfillment internal API
+3. Registers the cluster as hub "hub" in the fulfillment service
+
+### 4.4 Create Tenants
+
+```bash
+INSTALLER_NAMESPACE=${NAMESPACE} ./scripts/prepare-tenant.sh
+```
+
+What this does:
+1. Labels the default StorageClass with OSAC tenant labels
+2. Creates a namespace-scoped Tenant (`${NAMESPACE}`)
+3. Creates a "shared" Tenant (used for admin operations)
+4. Waits for both Tenants to reach `Ready` status
+
+### 4.5 Apply AAP Instance Group Overrides
+
+If you created the instance group ConfigMaps/Secrets in
+[Phase 2.6](#26-instance-group-configuration-optional) before the Helm deploy, they
+are already in place. If you need to apply overrides after deployment (e.g.,
+from env files):
+
+```bash
+INSTALLER_NAMESPACE=${NAMESPACE} \
+INSTALLER_KUSTOMIZE_OVERLAY=development \
+  ./scripts/aap-configuration.sh
+```
+
+---
+
+## Profile Reference
+
+### VMaaS (VM as a Service)
+
+Prerequisites needed: LVMS (if no SC), CNV, cert-manager, Authorino,
+Keycloak, AAP.
+
+```bash
+export NAMESPACE=osac
+# Phase 1: Install LVMS (if needed), CNV, cert-manager, trust-manager,
+#           CA issuer, Authorino, Keycloak, AAP operator
+# Phase 2: Create secrets (license, config-as-code, credentials)
+# Phase 3: Deploy
+helm upgrade --install osac charts/osac/ \
+  --namespace ${NAMESPACE} --create-namespace \
+  --values values/vmaas-ci.yaml \
+  --timeout 40m --wait
+# Phase 4: Post-install scripts
+```
+
+### CaaS (Cluster as a Service)
+
+Prerequisites needed: LVMS (if no SC), MCE, cert-manager, Authorino,
+Keycloak, AAP.
+
+```bash
+export NAMESPACE=osac
+# Phase 1: Install LVMS (if needed), MCE, cert-manager, trust-manager,
+#           CA issuer, Authorino, Keycloak, AAP operator
+# Phase 2: Create secrets (license, config-as-code, credentials)
+# Phase 3: Deploy
+helm upgrade --install osac charts/osac/ \
+  --namespace ${NAMESPACE} --create-namespace \
+  --values values/caas-ci.yaml \
+  --timeout 40m --wait
+# Phase 4: Post-install scripts
+```
+
+### Both VMaaS + CaaS
+
+Prerequisites needed: All of the above (LVMS, MCE, CNV, cert-manager,
+Authorino, Keycloak, AAP).
+
+```bash
+export NAMESPACE=osac
+# Phase 1: Install all prerequisites
+# Phase 2: Create secrets
+# Phase 3: Deploy
+helm upgrade --install osac charts/osac/ \
+  --namespace ${NAMESPACE} --create-namespace \
+  --values values/development.yaml \
+  --timeout 40m --wait
+# Phase 4: Post-install scripts
+```
+
+---
+
+## Automated Alternative
+
+If you prefer a single command, `scripts/setup.sh` performs all phases
+automatically:
+
+```bash
+# VMaaS + CaaS with all optional services
+EXTRA_SERVICES=true \
+INSTALLER_NAMESPACE=osac \
+VALUES_FILE=values/development.yaml \
+  ./scripts/setup.sh
+
+# VMaaS only
+VIRT_SERVICE=true \
+INSTALLER_NAMESPACE=osac \
+VALUES_FILE=values/vmaas-ci.yaml \
+  ./scripts/setup.sh
+
+# CaaS only
+MCE_SERVICE=true \
+INSTALLER_NAMESPACE=osac \
+VALUES_FILE=values/caas-ci.yaml \
+  ./scripts/setup.sh
+```
+
+The script handles prerequisite installation, secret creation, Helm deploy,
+and all post-install steps. Set `DEPLOY_MODE=helm` (default) to use Helm.
+
+**Shared cluster deployments:** If multiple developers share the same cluster
+and you need to impersonate a different user, set `OC_IMPERSONATE`:
+
+```bash
+OC_IMPERSONATE=developer@example.com \
+INSTALLER_NAMESPACE=my-osac \
+VALUES_FILE=values/development.yaml \
+  ./scripts/setup.sh
+```
+
+---
+
+## Troubleshooting
+
+### AAP Bootstrap Job Failing
+
+```bash
+# Check bootstrap job logs
+oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
+
+# Check if the license secret exists
+oc get secret config-as-code-manifest-ig -n ${NAMESPACE}
+
+# Check if AAP instance is ready
+oc get ansible-automation-platform -n ${NAMESPACE}
+```
+
+Common causes:
+- Missing `config-as-code-manifest-ig` secret (no license.zip)
+- Missing `config-as-code-ig` secret (no EE image configured)
+- AAP instance not yet ready (init container still waiting)
+
+### Fulfillment Service Pods CrashLooping
+
+```bash
+oc logs deployment/fulfillment-grpc-server -n ${NAMESPACE}
+oc logs deployment/fulfillment-controller -n ${NAMESPACE}
+```
+
+Common causes:
+- **`no pg_hba.conf entry ... no encryption`** — The `fulfillment-db` secret uses
+  `sslmode=disable` but postgres requires mutual TLS. Use `sslmode=verify-full`
+  with client cert paths (see [Phase 2.2](#22-postgresql-database))
+- **`unable to read CA file: open .../sslrootcert: no such file or directory`** —
+  The `postgres-client-cert-service` secret doesn't exist. Create the client
+  certificate (see [Phase 2.2](#22-postgresql-database))
+- **`failed to read client identifier from file`** — Missing
+  `fulfillment-controller-credentials` secret or `auth.controllerCredentials`
+  not set in values (see [Phase 2.3](#23-fulfillment-controller-credentials))
+- **`PermissionDenied` from Authorino** — The OPA policy expects JWT username
+  `service-account-osac-controller`. Ensure the `fulfillment-controller-credentials`
+  secret uses `client-id=osac-controller` (see [Phase 2.3](#23-fulfillment-controller-credentials))
+- Missing `fulfillment-db` secret (database not configured)
+- cert-manager certificates not issued (check `oc get certificate -n ${NAMESPACE}`)
+
+### Fulfillment Controller PermissionDenied
+
+The OPA policy in the AuthConfig expects JWT username
+`service-account-osac-controller`. This means the `fulfillment-controller-credentials`
+secret must use `client-id=osac-controller` (matching the Keycloak client name).
+
+If you see `PermissionDenied` errors, check the credentials secret:
+
+```bash
+oc get secret fulfillment-controller-credentials -n ${NAMESPACE} \
+  -o jsonpath='{.data.client-id}' | base64 -d
+# Should output: osac-controller
+```
+
+If it shows a different value, recreate the secret:
+
+```bash
+FC_CLIENT_SECRET=$(jq -r \
+  '.clients[] | select(.clientId == "osac-controller") | .secret' \
+  prerequisites/keycloak/service/files/realm.json)
+
+oc create secret generic fulfillment-controller-credentials \
+  --from-literal=client-id=osac-controller \
+  --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+  -n ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+
+# Restart the controller to pick up the change
+oc delete pod -l app=fulfillment-controller -n ${NAMESPACE}
+```
+
+### Operator Not Reconciling
+
+```bash
+oc logs deployment/osac-operator-controller-manager -n ${NAMESPACE}
+```
+
+Common causes:
+- `OSAC_AAP_URL` not set (run `prepare-aap.sh`)
+- `osac-aap-api-token` secret missing or token expired
+- AAP controller not reachable from the operator pod
+
+### Database Migration Hook Failing
+
+The db-migrate hook is **disabled by default** (`dbMigrate.enabled: false`)
+because the `fulfillment-service migrate` subcommand has not been released
+yet. If you enable it and it fails with `BackoffLimitExceeded`:
+
+```bash
+# Check the error
+oc logs job/osac-db-migrate -n ${NAMESPACE}
+
+# Fix: delete the failed job and redeploy with the hook disabled
+oc delete job osac-db-migrate -n ${NAMESPACE}
+helm upgrade --install osac charts/osac/ \
+  --namespace ${NAMESPACE} \
+  --values values/development.yaml \
+  --timeout 40m \
+  --wait
+```
+
+### Helm Install Timeout
+
+If `helm upgrade --install` times out at 40 minutes, the AAP bootstrap hook
+is likely still running:
+
+```bash
+# Check hook status
+oc get pods -n ${NAMESPACE} | grep bootstrap
+
+# The hook has backoffLimit=15 — it retries on failure
+# Monitor progress:
+oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
+```
+
+### Clean Reinstall
+
+```bash
+# Uninstall OSAC
+helm uninstall osac -n ${NAMESPACE}
+
+# Delete the namespace (waits for all resources to terminate)
+oc delete namespace ${NAMESPACE} --wait
+
+# CRDs are preserved. To remove them:
+oc delete crd -l app.kubernetes.io/part-of=osac
+```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -302,10 +302,15 @@ else
 fi
 wait_for_resource deployment/osac-console-proxy condition=Available 300 "${CONSOLE_PROXY_NS}"
 
+# Wait for AAP bootstrap job to complete.
+# In kustomize mode, the job is named "aap-bootstrap".
+# In helm mode, the job is a post-install hook named "osac-aap-bootstrap".
+# helm --wait does not wait for hook jobs, so we must wait explicitly.
+echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
 if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
-    # In kustomize mode, wait for bootstrap job (in helm mode, this is a hook)
-    echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
     wait_for_resource job/aap-bootstrap condition=complete 2400 "${INSTALLER_NAMESPACE}"
+else
+    wait_for_resource job/osac-aap-bootstrap condition=complete 2400 "${INSTALLER_NAMESPACE}"
 fi
 
 # Wait for Authorino to be ready (gRPC auth depends on it)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,9 +8,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 source "${SCRIPT_DIR}/oc.sh"
 
+# Deploy mode: "helm" (default) or "kustomize" (legacy)
+DEPLOY_MODE=${DEPLOY_MODE:-"helm"}
+
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
-INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
-[[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+VALUES_FILE=${VALUES_FILE:-"values/development.yaml"}
+
+if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
+    INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}
+    [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
+else
+    INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-"osac"}
+fi
+
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 # EXTRA_SERVICES=true enables all optional services (storage, ingress, virtualization, MCE)
 EXTRA_SERVICES=${EXTRA_SERVICES:-"false"}
@@ -20,7 +30,12 @@ VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
 MCE_SERVICE=${MCE_SERVICE:-${EXTRA_SERVICES}}
 
 echo "=== Setting up OSAC deployment ==="
-echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
+echo "Deploy mode: ${DEPLOY_MODE}"
+if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
+    echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
+else
+    echo "Values file: ${VALUES_FILE}"
+fi
 echo "Namespace: ${INSTALLER_NAMESPACE}"
 echo ""
 
@@ -245,8 +260,21 @@ wait_for_resource deployment/automation-controller-operator-controller-manager c
 # Wait for OSAC namespace to finish terminating if needed
 wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 
-# Apply kustomize overlay
-oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
+if [[ "${DEPLOY_MODE}" == "helm" ]]; then
+    # --- Helm deployment mode ---
+    echo "Deploying OSAC using Helm..."
+    helm dependency build charts/osac/
+    helm upgrade --install osac charts/osac/ \
+        --namespace "${INSTALLER_NAMESPACE}" \
+        --create-namespace \
+        --values "${VALUES_FILE}" \
+        --timeout 40m \
+        --wait
+else
+    # --- Kustomize deployment mode (legacy) ---
+    echo "Deploying OSAC using Kustomize..."
+    oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
+fi
 
 # Ensure the shared ca-bundle Bundle exists and includes our namespace
 "${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
@@ -274,9 +302,11 @@ else
 fi
 wait_for_resource deployment/osac-console-proxy condition=Available 300 "${CONSOLE_PROXY_NS}"
 
-# Wait for AAP bootstrap job to complete
-echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
-wait_for_resource job/aap-bootstrap condition=complete 2400 ${INSTALLER_NAMESPACE}
+if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
+    # In kustomize mode, wait for bootstrap job (in helm mode, this is a hook)
+    echo "Waiting for AAP bootstrap job to complete (this may take up to 40 minutes)..."
+    wait_for_resource job/aap-bootstrap condition=complete 2400 "${INSTALLER_NAMESPACE}"
+fi
 
 # Wait for Authorino to be ready (gRPC auth depends on it)
 wait_for_resource deployment/authorino condition=Available 300 ${INSTALLER_NAMESPACE}

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -1,0 +1,96 @@
+# OSAC CaaS (Cluster-as-a-Service) CI Environment Values
+# Replaces overlays/caas-ci/kustomization.yaml
+
+# --- Operator ---
+operator:
+  image:
+    repository: ghcr.io/osac-project/osac-operator
+    tag: sha-0cced2f
+    pullPolicy: Always
+  provisioning:
+    provider: "aap"
+  aap:
+    insecureSkipVerify: "true"
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  controllers:
+    clusterOrder: true
+    tenant: true
+    networking: true
+
+# --- Fulfillment Service ---
+service:
+  variant: openshift
+  images:
+    service: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+    envoy: docker.io/envoyproxy/envoy:v1.33.0
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+    - secret:
+        name: postgres-client-cert-service
+        items:
+        - key: tls.crt
+          param: sslcert
+        - key: tls.key
+          param: sslkey
+        - key: ca.crt
+          param: sslrootcert
+  log:
+    level: info
+
+# --- AAP ---
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:sha-acd61c8
+    cliImage: quay.io/openshift/origin-cli:4.20.0
+    backoffLimit: 15
+  configAsCode:
+    manifestSecret: "config-as-code-manifest-ig"
+    secret: "config-as-code-ig"
+
+# --- Validation ---
+validation:
+  enabled: true
+
+# --- Database migration ---
+dbMigrate:
+  enabled: false
+  image: ghcr.io/osac-project/fulfillment-service:sha-58ba45f

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-0cced2f
+    tag: sha-bded096
     pullPolicy: Always
   provisioning:
     provider: "aap"
@@ -23,7 +23,7 @@ operator:
 service:
   variant: openshift
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+    service: ghcr.io/osac-project/fulfillment-service:sha-201abdd
     envoy: docker.io/envoyproxy/envoy:v1.33.0
   certs:
     issuerRef:
@@ -79,7 +79,7 @@ aap:
       name: "osac-aap"
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:sha-acd61c8
+    image: ghcr.io/osac-project/osac-aap:sha-1e2c4d2
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
@@ -93,4 +93,4 @@ validation:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+  image: ghcr.io/osac-project/fulfillment-service:sha-201abdd

--- a/values/development.yaml
+++ b/values/development.yaml
@@ -1,0 +1,97 @@
+# OSAC Development Environment Values
+# Replaces overlays/development/kustomization.yaml
+
+# --- Operator ---
+operator:
+  image:
+    repository: ghcr.io/osac-project/osac-operator
+    tag: latest
+    pullPolicy: Always
+  provisioning:
+    provider: "aap"
+  aap:
+    url: ""  # Set to https://osac-aap.<namespace>.apps.<cluster>.<domain>/api/controller
+    insecureSkipVerify: "true"
+    statusPollInterval: "30s"
+    templatePrefix: "osac"
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  controllers:
+    clusterOrder: true
+    computeInstance: true
+    tenant: true
+    networking: true
+
+# --- Fulfillment Service ---
+service:
+  variant: openshift
+  images:
+    service: ghcr.io/osac-project/fulfillment-service:latest
+    envoy: docker.io/envoyproxy/envoy:v1.33.0
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+    - secret:
+        name: postgres-client-cert-service
+        items:
+        - key: tls.crt
+          param: sslcert
+        - key: tls.key
+          param: sslkey
+        - key: ca.crt
+          param: sslrootcert
+  log:
+    level: info
+
+# --- AAP ---
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:latest
+    cliImage: quay.io/openshift/origin-cli:4.20.0
+    backoffLimit: 15
+
+# --- Validation ---
+validation:
+  enabled: true
+
+# --- Database migration ---
+dbMigrate:
+  enabled: false
+  image: ghcr.io/osac-project/fulfillment-service:latest

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-0cced2f
+    tag: sha-bded096
     pullPolicy: Always
   provisioning:
     provider: "aap"
@@ -23,7 +23,7 @@ operator:
 service:
   variant: openshift
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+    service: ghcr.io/osac-project/fulfillment-service:sha-201abdd
     envoy: docker.io/envoyproxy/envoy:v1.33.0
   certs:
     issuerRef:
@@ -79,7 +79,7 @@ aap:
       name: "osac-aap"
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:sha-acd61c8
+    image: ghcr.io/osac-project/osac-aap:sha-1e2c4d2
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
@@ -93,4 +93,4 @@ validation:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+  image: ghcr.io/osac-project/fulfillment-service:sha-201abdd

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -1,0 +1,96 @@
+# OSAC VMaaS (VM-as-a-Service) CI Environment Values
+# Replaces overlays/vmaas-ci/kustomization.yaml
+
+# --- Operator ---
+operator:
+  image:
+    repository: ghcr.io/osac-project/osac-operator
+    tag: sha-0cced2f
+    pullPolicy: Always
+  provisioning:
+    provider: "aap"
+  aap:
+    insecureSkipVerify: "true"
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  controllers:
+    computeInstance: true
+    tenant: true
+    networking: true
+
+# --- Fulfillment Service ---
+service:
+  variant: openshift
+  images:
+    service: ghcr.io/osac-project/fulfillment-service:sha-58ba45f
+    envoy: docker.io/envoyproxy/envoy:v1.33.0
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+    - secret:
+        name: postgres-client-cert-service
+        items:
+        - key: tls.crt
+          param: sslcert
+        - key: tls.key
+          param: sslkey
+        - key: ca.crt
+          param: sslrootcert
+  log:
+    level: info
+
+# --- AAP ---
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:sha-acd61c8
+    cliImage: quay.io/openshift/origin-cli:4.20.0
+    backoffLimit: 15
+  configAsCode:
+    manifestSecret: "config-as-code-manifest-ig"
+    secret: "config-as-code-ig"
+
+# --- Validation ---
+validation:
+  enabled: true
+
+# --- Database migration ---
+dbMigrate:
+  enabled: false
+  image: ghcr.io/osac-project/fulfillment-service:sha-58ba45f


### PR DESCRIPTION
## Summary

Replaces the Kustomize-based installer with a Helm umbrella chart pattern for deploying OSAC. Part of [OSAC-22](https://redhat.atlassian.net/browse/OSAC-22).

**What this PR adds:**

- **Umbrella Helm chart** (`charts/osac/`) — composes operator CRDs, operator, fulfillment service, and AAP charts via `file://` dependencies through git submodules
- **Environment values files** (`values/`) — development, CaaS CI, and VMaaS CI profiles replacing Kustomize overlays
- **Setup script update** — dual `DEPLOY_MODE` support (helm/kustomize) in `scripts/setup.sh`
- **Makefile** — developer convenience targets (`sync-charts`, `helm-lint`, `helm-deploy`)
- **CI workflows** — `helm-lint.yaml` (PR validation) and `helm-integration.yaml` (periodic kind-cluster test)
- **Deployment guide** (`docs/helm-deployment-guide.md`) — step-by-step instructions for deploying on a clean OpenShift cluster, including prerequisites, secrets, and post-install configuration

**Architecture note:** The chart currently co-deploys the management plane (fulfillment service) and hub components (operator, AAP) to the same cluster. In a future multi-hub architecture, these would be deployed separately.

## Commits

1. **[OSAC-693](https://redhat.atlassian.net/browse/OSAC-693): Create OSAC umbrella Helm chart** — Chart.yaml, values, schema, hooks, NOTES.txt
2. **[OSAC-694](https://redhat.atlassian.net/browse/OSAC-694): Add values files, setup script, and Makefile** — Environment values with mTLS config, dual-mode setup script, Makefile
3. **[OSAC-696](https://redhat.atlassian.net/browse/OSAC-696): Add Helm CI workflows** — Lint on PRs, periodic integration test
4. **[OSAC-693](https://redhat.atlassian.net/browse/OSAC-693): Add deployment guide, update README, bump submodules** — Comprehensive deployment docs, known issue workarounds

## Test plan

- [x] `helm dependency build charts/osac/ && helm lint charts/osac/` passes
- [x] `helm template osac charts/osac/ --values values/development.yaml` renders without errors
- [x] Deployed on a clean OpenShift cluster — all pods Running
- [x] Fulfillment service connects to postgres via mTLS
- [x] Fulfillment controller authenticates and reconciles (after OPA workaround)
- [x] AAP bootstrap job completes successfully
- [x] Post-install scripts (prepare-aap.sh, prepare-fulfillment-service.sh, prepare-tenant.sh) succeed