### PR TITLE
Enforce avoidBuggyIPs: true in MetalLB IPAddressPool

### DIFF
--- a/prerequisites/metallb/metallb-config.yaml
+++ b/prerequisites/metallb/metallb-config.yaml
@@ -30,6 +30,7 @@ spec:
     # Replace with your environment's IP range for LoadBalancer services
     - 192.168.100.240-192.168.100.250
   autoAssign: false
+  avoidBuggyIPs: true  # safeguard: exclude .0 and .255 if the address range is ever extended
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement


### PR DESCRIPTION
Add `avoidBuggyIPs: true` to the static `caas-address-pool` IPAddressPool defined in `prerequisites/metallb/metallb-config.yaml`,

## Why
The current narrow range (192.168.100.240–192.168.100.250) does not include .0 or .255 addresses, so the flag has no immediate practical effect. It is added as a safeguard so that the protection is already in place if the address range is ever extended to a broader CIDR. 
This also keeps the static pool consistent with the dynamically created PublicIPPoolpools (https://github.com/osac-project/osac-aap/pull/299).

## Changes
- `prerequisites/metallb/metallb-config.yaml`
  - Added `avoidBuggyIPs: true` to the `caas-address-pool` spec