### PR TITLE
NO_ISSUE: refresh after snapshot - update Keycloak realm and credentials on snapshot boot

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -13,50 +13,96 @@ INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INST
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 
 CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+KEYCLOAK_NS="keycloak"
+REALM_JSON="prerequisites/keycloak/service/files/realm.json"
+
 echo "=== Refreshing OSAC after snapshot boot ==="
 echo "Namespace: ${INSTALLER_NAMESPACE}"
 echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
 echo "Cluster domain: ${CLUSTER_DOMAIN}"
 echo ""
 
-echo "[1/10] Patching stale routes with new domain..."
-OLD_DOMAIN=$(oc get route osac-aap -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}' 2>/dev/null | sed "s/^osac-aap-${INSTALLER_NAMESPACE}\.//")
-echo "  Old domain: ${OLD_DOMAIN}"
+echo "[1/9] Patching stale routes with new domain..."
 echo "  New domain: ${CLUSTER_DOMAIN}"
-for ns in "${INSTALLER_NAMESPACE}" keycloak; do
+for ns in "${INSTALLER_NAMESPACE}" "${KEYCLOAK_NS}"; do
     for route in $(oc get routes -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
         OLD_HOST=$(oc get route "${route}" -n "${ns}" -o jsonpath='{.spec.host}')
-        NEW_HOST=$(echo "${OLD_HOST}" | sed "s/${OLD_DOMAIN}/${CLUSTER_DOMAIN}/")
-        oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+        ROUTE_DOMAIN=$(echo "${OLD_HOST}" | sed "s/^[^.]*\.//")
+        if [[ "${ROUTE_DOMAIN}" != "${CLUSTER_DOMAIN}" ]]; then
+            ROUTE_NAME=$(echo "${OLD_HOST}" | sed "s/\.${ROUTE_DOMAIN}$//")
+            NEW_HOST="${ROUTE_NAME}.${CLUSTER_DOMAIN}"
+            echo "  ${ns}/${route}: ${OLD_HOST} -> ${NEW_HOST}"
+            oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+        fi
     done
 done
 
-echo "[2/10] Updating Keycloak realm..."
-KEYCLOAK_NS="keycloak"
-oc create configmap keycloak-realm \
-    --from-file=realm.json=prerequisites/keycloak/service/files/realm.json \
-    -n "${KEYCLOAK_NS}" --dry-run=client -o yaml | oc apply -f -
-oc rollout restart deploy/keycloak-service -n "${KEYCLOAK_NS}"
-oc rollout status deploy/keycloak-service -n "${KEYCLOAK_NS}" --timeout=300s
+echo "[2/9] Syncing Keycloak realm..."
+NEW_HASH=$(md5sum "${REALM_JSON}" | awk '{print $1}')
+OLD_HASH=$(oc get configmap keycloak-realm -n "${KEYCLOAK_NS}" -o jsonpath='{.data.realm\.json}' 2>/dev/null | md5sum | awk '{print $1}')
+if [[ "${NEW_HASH}" != "${OLD_HASH}" ]]; then
+    echo "  ConfigMap changed (${OLD_HASH:0:8} -> ${NEW_HASH:0:8}), restarting Keycloak..."
+    oc create configmap keycloak-realm \
+        --from-file=realm.json="${REALM_JSON}" \
+        -n "${KEYCLOAK_NS}" --dry-run=client -o yaml | oc apply -f -
+    oc rollout restart deploy/keycloak-service -n "${KEYCLOAK_NS}"
+    oc rollout status deploy/keycloak-service -n "${KEYCLOAK_NS}" --timeout=300s
+    oc rollout restart deploy/authorino -n "${INSTALLER_NAMESPACE}"
+    oc rollout status deploy/authorino -n "${INSTALLER_NAMESPACE}" --timeout=120s
+else
+    echo "  ConfigMap unchanged, skipping Keycloak restart"
+fi
+
+KC_URL="https://$(oc get route keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
+retry_until 60 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} '"${KC_URL}"'/realms/osac)" == "200" ]]' || {
+    echo "Timed out waiting for Keycloak"
+    exit 1
+}
+KC_ADMIN_TOKEN=$(curl -sk "${KC_URL}/realms/master/protocol/openid-connect/token" \
+    -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" | jq -r '.access_token')
+[[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token" >&2; exit 1; }
+
+echo "  Syncing clients and users via admin API..."
+jq -c '.clients[] | select(.protocol == "openid-connect" and .publicClient != true and .bearerOnly != true)' "${REALM_JSON}" | while IFS= read -r CLIENT_JSON; do
+    CID=$(echo "${CLIENT_JSON}" | jq -r '.clientId')
+    CLIENT_UUID=$(echo "${CLIENT_JSON}" | jq -r '.id')
+    HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" "${KC_URL}/admin/realms/osac/clients/${CLIENT_UUID}")
+    if [[ "${HTTP_CODE}" == "200" ]]; then
+        curl -sk -X PUT -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" -H "Content-Type: application/json" \
+            "${KC_URL}/admin/realms/osac/clients/${CLIENT_UUID}" -d "${CLIENT_JSON}" >/dev/null
+        echo "  Updated client: ${CID}"
+    else
+        curl -sk -X POST -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" -H "Content-Type: application/json" \
+            "${KC_URL}/admin/realms/osac/clients" -d "${CLIENT_JSON}" >/dev/null
+        echo "  Created client: ${CID}"
+    fi
+done
+
+jq -c '.users[]?' "${REALM_JSON}" | while IFS= read -r USER_JSON; do
+    USERNAME=$(echo "${USER_JSON}" | jq -r '.username')
+    USER_UUID=$(echo "${USER_JSON}" | jq -r '.id')
+    HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" "${KC_URL}/admin/realms/osac/users/${USER_UUID}")
+    if [[ "${HTTP_CODE}" == "200" ]]; then
+        curl -sk -X PUT -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" -H "Content-Type: application/json" \
+            "${KC_URL}/admin/realms/osac/users/${USER_UUID}" -d "${USER_JSON}" >/dev/null
+        echo "  Updated user: ${USERNAME}"
+    else
+        curl -sk -X POST -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" -H "Content-Type: application/json" \
+            "${KC_URL}/admin/realms/osac/users" -d "${USER_JSON}" >/dev/null
+        echo "  Created user: ${USERNAME}"
+    fi
+done
+
 if [[ -f prerequisites/keycloak/service/password-setup-job.yaml ]]; then
     oc delete job keycloak-set-passwords -n "${KEYCLOAK_NS}" --ignore-not-found
     oc apply -f prerequisites/keycloak/service/password-setup-job.yaml -n "${KEYCLOAK_NS}"
     oc wait --for=condition=Complete job/keycloak-set-passwords -n "${KEYCLOAK_NS}" --timeout=120s
 fi
 
-echo "[3/10] Recreating fulfillment controller credentials..."
-KC_URL="https://$(oc get route keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
-KC_ADMIN_TOKEN=$(curl -sk "${KC_URL}/realms/master/protocol/openid-connect/token" \
-    -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" | jq -r '.access_token')
-[[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token from ${KC_URL}" >&2; exit 1; }
-FC_CLIENT_ID=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-    "${KC_URL}/admin/realms/osac/clients?first=0&max=100" | \
-    jq -er '[.[] | select(.serviceAccountsEnabled == true)][0].clientId')
-[[ -n "${FC_CLIENT_ID}" && "${FC_CLIENT_ID}" != "null" ]] || { echo "ERROR: Could not find service account client in Keycloak" >&2; exit 1; }
-FC_CLIENT_SECRET=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-    "${KC_URL}/admin/realms/osac/clients?clientId=${FC_CLIENT_ID}" | \
-    jq -er '.[0].secret')
-[[ -n "${FC_CLIENT_SECRET}" && "${FC_CLIENT_SECRET}" != "null" ]] || { echo "ERROR: Could not get secret for client ${FC_CLIENT_ID}" >&2; exit 1; }
+echo "[3/9] Recreating fulfillment controller credentials..."
+FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' "${REALM_JSON}")
+FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${REALM_JSON}")
+[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
 oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
 oc create secret generic fulfillment-controller-credentials \
     --from-literal=client-id="${FC_CLIENT_ID}" \
@@ -64,18 +110,24 @@ oc create secret generic fulfillment-controller-credentials \
     -n "${INSTALLER_NAMESPACE}"
 echo "  Credentials created for client: ${FC_CLIENT_ID}"
 
-echo "[4/10] Applying kustomize overlay..."
+echo "[4/9] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
-echo "[5/10] Applying AAP configuration..."
+echo "[5/9] Waiting for fulfillment rollouts..."
+for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+    oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+done
+wait
+
+echo "[6/9] Applying AAP configuration..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
 INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
     ./scripts/aap-configuration.sh
 
 oc config set-context --current --namespace="${INSTALLER_NAMESPACE}"
 
-echo "[6/10] Waiting for AAP controller..."
+echo "[7/9] Waiting for AAP controller..."
 retry_until 300 10 '[[ "$(oc get automationcontroller osac-aap-controller -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.status.conditions[?(@.type=="Running")].status}'"'"' 2>/dev/null)" == "True" ]]' || {
     echo "Timed out waiting for AAP controller to be Running"
     exit 1
@@ -86,23 +138,18 @@ retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_R
     exit 1
 }
 
-echo "[7/10] Configuring AAP access..."
+echo "[8/9] Configuring AAP access and fulfillment service..."
 ./scripts/prepare-aap.sh
-
-echo "[8/10] Configuring fulfillment service..."
 ./scripts/prepare-fulfillment-service.sh
 
-echo "[9/10] Restarting fulfillment pods..."
-oc rollout restart deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}"
-oc rollout restart deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}"
-oc rollout restart deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}"
-oc rollout restart deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}"
-oc rollout status deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --timeout=120s
-oc rollout status deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}" --timeout=120s
-oc rollout status deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}" --timeout=120s
-oc rollout status deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}" --timeout=120s
-
-echo "[10/10] Configuring tenant..."
+echo "[9/9] Restarting fulfillment pods and configuring tenant..."
+for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+    oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
+done
+for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+    oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+done
+wait
 ./scripts/prepare-tenant.sh
 
 echo ""

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -23,10 +23,12 @@ echo "[1/10] Patching stale routes with new domain..."
 OLD_DOMAIN=$(oc get route osac-aap -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}' 2>/dev/null | sed "s/^osac-aap-${INSTALLER_NAMESPACE}\.//")
 echo "  Old domain: ${OLD_DOMAIN}"
 echo "  New domain: ${CLUSTER_DOMAIN}"
-for route in $(oc get routes -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.items[*].metadata.name}'); do
-    OLD_HOST=$(oc get route "${route}" -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}')
-    NEW_HOST=$(echo "${OLD_HOST}" | sed "s/${OLD_DOMAIN}/${CLUSTER_DOMAIN}/")
-    oc patch route "${route}" -n "${INSTALLER_NAMESPACE}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+for ns in "${INSTALLER_NAMESPACE}" keycloak; do
+    for route in $(oc get routes -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+        OLD_HOST=$(oc get route "${route}" -n "${ns}" -o jsonpath='{.spec.host}')
+        NEW_HOST=$(echo "${OLD_HOST}" | sed "s/${OLD_DOMAIN}/${CLUSTER_DOMAIN}/")
+        oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+    done
 done
 
 echo "[2/10] Updating Keycloak realm..."
@@ -43,15 +45,16 @@ if [[ -f prerequisites/keycloak/service/password-setup-job.yaml ]]; then
 fi
 
 echo "[3/10] Recreating fulfillment controller credentials..."
-KC_ADMIN_TOKEN=$(curl -sk "https://keycloak.${KEYCLOAK_NS}.svc:443/realms/master/protocol/openid-connect/token" \
+KC_URL="https://$(oc get route keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
+KC_ADMIN_TOKEN=$(curl -sk "${KC_URL}/realms/master/protocol/openid-connect/token" \
     -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" | jq -r '.access_token')
-[[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token" >&2; exit 1; }
+[[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token from ${KC_URL}" >&2; exit 1; }
 FC_CLIENT_ID=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-    "https://keycloak.${KEYCLOAK_NS}.svc:443/admin/realms/osac/clients?first=0&max=100" | \
+    "${KC_URL}/admin/realms/osac/clients?first=0&max=100" | \
     jq -er '[.[] | select(.serviceAccountsEnabled == true)][0].clientId')
 [[ -n "${FC_CLIENT_ID}" && "${FC_CLIENT_ID}" != "null" ]] || { echo "ERROR: Could not find service account client in Keycloak" >&2; exit 1; }
 FC_CLIENT_SECRET=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
-    "https://keycloak.${KEYCLOAK_NS}.svc:443/admin/realms/osac/clients?clientId=${FC_CLIENT_ID}" | \
+    "${KC_URL}/admin/realms/osac/clients?clientId=${FC_CLIENT_ID}" | \
     jq -er '.[0].secret')
 [[ -n "${FC_CLIENT_SECRET}" && "${FC_CLIENT_SECRET}" != "null" ]] || { echo "ERROR: Could not get secret for client ${FC_CLIENT_ID}" >&2; exit 1; }
 oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -43,9 +43,17 @@ if [[ -f prerequisites/keycloak/service/password-setup-job.yaml ]]; then
 fi
 
 echo "[3/10] Recreating fulfillment controller credentials..."
-FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' prerequisites/keycloak/service/files/realm.json)
-FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" prerequisites/keycloak/service/files/realm.json)
-[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
+KC_ADMIN_TOKEN=$(curl -sk "https://keycloak.${KEYCLOAK_NS}.svc:443/realms/master/protocol/openid-connect/token" \
+    -d "client_id=admin-cli" -d "username=admin" -d "password=admin" -d "grant_type=password" | jq -r '.access_token')
+[[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token" >&2; exit 1; }
+FC_CLIENT_ID=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
+    "https://keycloak.${KEYCLOAK_NS}.svc:443/admin/realms/osac/clients?first=0&max=100" | \
+    jq -er '[.[] | select(.serviceAccountsEnabled == true)][0].clientId')
+[[ -n "${FC_CLIENT_ID}" && "${FC_CLIENT_ID}" != "null" ]] || { echo "ERROR: Could not find service account client in Keycloak" >&2; exit 1; }
+FC_CLIENT_SECRET=$(curl -sk -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
+    "https://keycloak.${KEYCLOAK_NS}.svc:443/admin/realms/osac/clients?clientId=${FC_CLIENT_ID}" | \
+    jq -er '.[0].secret')
+[[ -n "${FC_CLIENT_SECRET}" && "${FC_CLIENT_SECRET}" != "null" ]] || { echo "ERROR: Could not get secret for client ${FC_CLIENT_ID}" >&2; exit 1; }
 oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
 oc create secret generic fulfillment-controller-credentials \
     --from-literal=client-id="${FC_CLIENT_ID}" \

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -19,7 +19,7 @@ echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
 echo "Cluster domain: ${CLUSTER_DOMAIN}"
 echo ""
 
-echo "[1/8] Patching stale routes with new domain..."
+echo "[1/10] Patching stale routes with new domain..."
 OLD_DOMAIN=$(oc get route osac-aap -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.host}' 2>/dev/null | sed "s/^osac-aap-${INSTALLER_NAMESPACE}\.//")
 echo "  Old domain: ${OLD_DOMAIN}"
 echo "  New domain: ${CLUSTER_DOMAIN}"
@@ -29,18 +29,37 @@ for route in $(oc get routes -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.items[*]
     oc patch route "${route}" -n "${INSTALLER_NAMESPACE}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
 done
 
-echo "[2/8] Applying kustomize overlay..."
+echo "[2/10] Updating Keycloak realm..."
+KEYCLOAK_NS="keycloak"
+oc create configmap keycloak-realm \
+    --from-file=realm.json=prerequisites/keycloak/service/files/realm.json \
+    -n "${KEYCLOAK_NS}" --dry-run=client -o yaml | oc apply -f -
+oc rollout restart deploy/keycloak-service -n "${KEYCLOAK_NS}"
+oc rollout status deploy/keycloak-service -n "${KEYCLOAK_NS}" --timeout=300s
+
+echo "[3/10] Recreating fulfillment controller credentials..."
+FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' prerequisites/keycloak/service/files/realm.json)
+FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" prerequisites/keycloak/service/files/realm.json)
+[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
+oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
+oc create secret generic fulfillment-controller-credentials \
+    --from-literal=client-id="${FC_CLIENT_ID}" \
+    --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+    -n "${INSTALLER_NAMESPACE}"
+echo "  Credentials created for client: ${FC_CLIENT_ID}"
+
+echo "[4/10] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
-echo "[3/8] Applying AAP configuration..."
+echo "[5/10] Applying AAP configuration..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
 INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
     ./scripts/aap-configuration.sh
 
 oc config set-context --current --namespace="${INSTALLER_NAMESPACE}"
 
-echo "[4/8] Waiting for AAP controller..."
+echo "[6/10] Waiting for AAP controller..."
 retry_until 300 10 '[[ "$(oc get automationcontroller osac-aap-controller -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.status.conditions[?(@.type=="Running")].status}'"'"' 2>/dev/null)" == "True" ]]' || {
     echo "Timed out waiting for AAP controller to be Running"
     exit 1
@@ -51,13 +70,13 @@ retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_R
     exit 1
 }
 
-echo "[5/8] Configuring AAP access..."
+echo "[7/10] Configuring AAP access..."
 ./scripts/prepare-aap.sh
 
-echo "[6/8] Configuring fulfillment service..."
+echo "[8/10] Configuring fulfillment service..."
 ./scripts/prepare-fulfillment-service.sh
 
-echo "[7/8] Restarting fulfillment pods..."
+echo "[9/10] Restarting fulfillment pods..."
 oc rollout restart deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}"
 oc rollout restart deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}"
 oc rollout restart deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}"
@@ -67,7 +86,7 @@ oc rollout status deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}" --t
 oc rollout status deploy/fulfillment-rest-gateway -n "${INSTALLER_NAMESPACE}" --timeout=120s
 oc rollout status deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}" --timeout=120s
 
-echo "[8/8] Configuring tenant..."
+echo "[10/10] Configuring tenant..."
 ./scripts/prepare-tenant.sh
 
 echo ""

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -36,6 +36,11 @@ oc create configmap keycloak-realm \
     -n "${KEYCLOAK_NS}" --dry-run=client -o yaml | oc apply -f -
 oc rollout restart deploy/keycloak-service -n "${KEYCLOAK_NS}"
 oc rollout status deploy/keycloak-service -n "${KEYCLOAK_NS}" --timeout=300s
+if [[ -f prerequisites/keycloak/service/password-setup-job.yaml ]]; then
+    oc delete job keycloak-set-passwords -n "${KEYCLOAK_NS}" --ignore-not-found
+    oc apply -f prerequisites/keycloak/service/password-setup-job.yaml -n "${KEYCLOAK_NS}"
+    oc wait --for=condition=Complete job/keycloak-set-passwords -n "${KEYCLOAK_NS}" --timeout=120s
+fi
 
 echo "[3/10] Recreating fulfillment controller credentials..."
 FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' prerequisites/keycloak/service/files/realm.json)


### PR DESCRIPTION
## Summary

The refresh script runs after booting from a snapshot to bring the cluster in sync with the current osac-installer code. It was missing two steps that `setup.sh` performs, causing snapshot-based clusters to drift from fresh installs.

### Changes

1. **[2/10] Update Keycloak realm** — Updates the `keycloak-realm` ConfigMap with the current `realm.json` and restarts Keycloak to re-import. This ensures new users, client renames, and realm config changes take effect on snapshot clusters.

2. **[3/10] Recreate fulfillment controller credentials** — Reads the service account client ID and secret from `realm.json` and recreates the `fulfillment-controller-credentials` secret. This handles client renames (e.g. `fulfillment-controller` → `osac-controller` in PR #99).

### Context

Without these steps:
- PR #99 (AuthConfig Rego sync) fails on snapshot clusters because the Rego expects `service-account-osac-controller` but the snapshot's Keycloak only has `fulfillment-controller`
- PR #39 in osac-test-infra (JWT auth smoke tests) fails because test users (`tenant1_user`, etc.) don't exist in the snapshot's Keycloak

### Test plan

- [x] Boot from `osac-vmaas-pruned` snapshot, run refresh, wait 60s, run `make test-vmaas` from osac-test-infra — 8/8 passed (2 runs)
- [ ] Run with osac-test-infra PR #39 tests after Keycloak realm update