### PR TITLE
OSAC-896: Add OC impersonation mechanism for shared cluster deployments

### DIFF
--- a/scripts/oc.sh
+++ b/scripts/oc.sh
@@ -1,0 +1,3 @@
+if [[ -n "${OC_IMPERSONATE:-}" ]]; then
+    oc() { command oc --as "${OC_IMPERSONATE}" "$@"; }
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,6 +6,7 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
+source "${SCRIPT_DIR}/oc.sh"
 
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" | awk '{print $2}')}


### PR DESCRIPTION
## Summary
- Adds `scripts/oc.sh` with an `oc()` wrapper function that injects `--as <identity>` when `OC_IMPERSONATE` is set
- Sources it from `lib.sh` so all scripts inherit the wrapper automatically
- Enables running `OC_IMPERSONATE=system:admin ./scripts/setup.sh` on clusters where impersonation is required (e.g. shared MOC cluster)