### PR TITLE
OSAC-898: Use per-overlay names for ca-trust-bundle to avoid collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,12 +113,7 @@ for d in overlays/*/; do kustomize build "$d" > "/tmp/after-$(basename $d).yaml"
 - **Replacements in Components run before the namespace transformer** -- a replacement that sets `metadata.namespace: kube-system` inside a Component will be overwritten by the overlay's namespace transformer. Replacements that fix namespace fields must live at the overlay level.
 - **Kustomize blocks `../` in file paths** -- replacements files cannot reference parent directories. Each overlay that needs replacements must have its own copy.
 - **Embedded namespace references** -- `APIService.spec.service.namespace`, `cert-manager.io/inject-ca-from` annotations, and Certificate `dnsNames` embed namespaces that the transformer cannot update. These require kustomize replacements with `delimiter`/`index` fields.
-- **`ca-trust-bundle.yaml` is cluster-scoped** -- the Bundle named `ca-bundle` is not covered by `prefixTransformer.yaml`. On shared clusters, last apply wins. Do not rename or restructure. **Never re-apply the Bundle** -- this overwrites the `namespaceSelector` and breaks other developers' deployments. If your namespace is missing from the Bundle's selector, patch it to append your namespace:
-  ```bash
-  oc --as=system:admin patch bundle ca-bundle --type=json -p '[
-    {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<your-namespace>"}
-  ]'
-  ```
+- **`ca-trust-bundle.yaml` is cluster-scoped** -- each overlay's Bundle must use a unique name (`ca-bundle-<namespace>`) to avoid collisions on shared clusters. The `namespaceSelector` targets only that overlay's namespace. When creating a new overlay, copy `ca-trust-bundle.yaml` from an existing overlay, update `metadata.name` to `ca-bundle-<your-namespace>`, and update the `values` list to your namespace.
 
 ## Shared Cluster Constraints
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ Use Kustomize to manage your environment-specific configurations.
 
    - In `kustomization.yaml`: Update the `namespace` field to `<project-name>`
    - In `prefixTransformer.yaml`: Update the `prefix` field to `<project-name>-`
-   - In `ca-trust-bundle.yaml`: Update the `values` field element
-     to `<project-name>`.
+   - In `ca-trust-bundle.yaml`: Update `metadata.name` to `ca-bundle-<project-name>`
+     and update the `values` field element to `<project-name>`.
+     The Bundle is cluster-scoped, so each overlay must use a unique name to avoid
+     overwriting other developers' Bundles on shared clusters.
    - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
      value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
      You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`

--- a/overlays/caas-ci/ca-trust-bundle.yaml
+++ b/overlays/caas-ci/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle
+  name: ca-bundle-osac-e2e-ci
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/development/ca-trust-bundle.yaml
+++ b/overlays/development/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle
+  name: ca-bundle-osac-devel
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/osac-integration/ca-trust-bundle.yaml
+++ b/overlays/osac-integration/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle
+  name: ca-bundle-osac-integration
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/vmaas-ci/ca-trust-bundle.yaml
+++ b/overlays/vmaas-ci/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle
+  name: ca-bundle-osac-e2e-ci
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -243,6 +243,13 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
+# Clean up legacy shared ca-bundle Bundle if a per-overlay one now exists
+if oc get bundle "ca-bundle-${INSTALLER_NAMESPACE}" &>/dev/null && \
+   oc get bundle ca-bundle &>/dev/null; then
+    echo "Deleting legacy shared ca-bundle Bundle (replaced by ca-bundle-${INSTALLER_NAMESPACE})..."
+    oc delete bundle ca-bundle
+fi
+
 # Create controller OAuth credentials from the Keycloak realm config
 FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
 [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- Renames each overlay's Bundle from `ca-bundle` to `ca-bundle-<namespace>` (e.g. `ca-bundle-osac-devel`, `ca-bundle-osac-e2e-ci`) so they don't overwrite each other on shared clusters
- Updates README and AGENTS.md to document that new overlays must set a unique Bundle name

## Test plan
- [ ] Verify `kustomize build` passes for all overlays
- [ ] On a shared cluster, confirm that applying one overlay doesn't overwrite another's Bundle