### PR TITLE
Fail if we're unable to find authorino

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -194,6 +194,10 @@ else
     }
 fi
 AUTHORINO_CSV=$(oc get csv --no-headers -n openshift-operators | awk '/authorino/ { print $1 }' | tail -1)
+if [[ -z "$AUTHORINO_CSV" ]]; then
+  echo "Unable to find authorino csv" >&2
+  exit 1
+fi
 wait_for_resource clusterserviceversion/${AUTHORINO_CSV} jsonpath='{.status.phase}'=Succeeded 300 openshift-operators
 wait_for_resource deployment/authorino-operator condition=Available 300 openshift-operators
 


### PR DESCRIPTION
If the authorino csv is not available, the setup script would ignore the
failure and start trying to wait for resource `clusterserviceversion/`,
which just caused a series of error messages until eventually timing out.
