### PR TITLE
Stop trying to install a second instance of aap

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -216,7 +216,9 @@ wait_for_resource deployment/keycloak-service condition=Available 600 ${KEYCLOAK
 
 # Apply AAP prerequisites and wait for it to be ready
 AAP_NS=""
-if oc get deployment automation-controller-operator-controller-manager -n ansible-aap &>/dev/null; then
+if oc get deployment automation-controller-operator-controller-manager -n aap &>/dev/null; then
+    AAP_NS="aap"
+elif oc get deployment automation-controller-operator-controller-manager -n ansible-aap &>/dev/null; then
     AAP_NS="ansible-aap"
 elif oc get deployment automation-controller-operator-controller-manager -n openshift-operators &>/dev/null; then
     AAP_NS="openshift-operators"


### PR DESCRIPTION
The setup.sh script was looking in the wrong place for the existing aap
installer. Because it wasn't finding it, it would proceed to install a
second instance of aap on the cluster.
