### PR TITLE
OSAC-483: Add .ai-bot/ configuration for AI bug fix bot

### DIFF
--- a/.ai-bot/config.yaml
+++ b/.ai-bot/config.yaml
@@ -1,0 +1,23 @@
+# .ai-bot/config.yaml for osac-installer
+#
+# Infrastructure/deployment repo -- Kustomize overlays, shell scripts,
+# YAML manifests. No Go code, no container builds, no unit tests.
+
+imports:
+  - repo: https://github.com/flightctl/ai-workflows
+    path: .ai-workflows
+    ref: main
+    install: .ai-workflows/install.sh
+
+validation_commands:
+  - yamllint --strict .
+  - pre-commit run --all-files
+  - bash scripts/kustomize-build-all.sh
+  - bash scripts/sync-image-tags.sh
+  - python3 scripts/sync-authconfig-rego.py
+
+pr:
+  draft: true
+  title_prefix: "[AI]"
+  labels:
+    - ai-pr

--- a/.ai-bot/container.json
+++ b/.ai-bot/container.json
@@ -1,0 +1,3 @@
+{
+  "image": "quay.io/rh-ee-andalton/osac-ai:latest"
+}

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -1,0 +1,48 @@
+Read and execute .ai-workflows/bugfix/skills/feedback.md with
+the following repo-specific context.
+
+## Context Recovery
+
+Read `.ai-bot/session-context.md` and `.ai-bot/implementation-notes.md`
+to understand the prior session's decisions and changes.
+
+## Feedback Handling Rules
+
+1. **Submodule boundaries**: If feedback asks you to change a file inside
+   `base/osac-operator/`, `base/osac-fulfillment-service/`, or
+   `base/osac-aap/`, explain that these are submodules and the change
+   belongs in the component repo. Suggest what the reviewer should do
+   instead.
+
+2. **Overlay consistency**: If feedback applies to one overlay, check
+   whether parallel overlays (development, vmaas-ci, caas-ci,
+   osac-integration) need the same change. Call this out in your
+   response.
+
+3. **Namespace pitfalls**: If feedback involves namespace references,
+   verify that the change works with the kustomize namespace transformer.
+   Embedded namespace references (APIService, annotations, dnsNames)
+   need kustomize replacements, not direct edits.
+
+## Post-Change Validation
+
+After addressing all review comments, run the full validation suite:
+
+```
+yamllint --strict .
+pre-commit run --all-files
+bash scripts/kustomize-build-all.sh
+bash scripts/sync-image-tags.sh
+python3 scripts/sync-authconfig-rego.py
+```
+
+Diff the kustomize build output for affected overlays against the
+baseline to confirm only intended changes appear.
+
+## Session Artifacts
+
+Update `.ai-bot/session-context.md` with a summary of this feedback
+round (what changed, what was kept, why).
+
+Write `.ai-bot/comment-responses.json` with per-comment response
+summaries matching the comment IDs from the task file.

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -1,0 +1,139 @@
+This is a **Kustomize-based infrastructure/deployment repository**. It
+assembles three component submodules (osac-operator, fulfillment-service,
+osac-aap) into OpenShift overlays. There is no Go code, no container
+builds, and no unit tests in this repo. All validation is structural.
+
+## Validation Commands
+
+After making changes, run the following commands in order. Every command
+must pass -- CI enforces all of them on every PR.
+
+1. **YAML lint** (strict mode, repo-level `.yamllint.yaml` config):
+   ```
+   yamllint --strict .
+   ```
+
+2. **Pre-commit hooks** (trailing whitespace, merge conflicts, large
+   files, private key detection, YAML lint):
+   ```
+   pre-commit run --all-files
+   ```
+
+3. **Kustomize build** (builds all committed overlays, stubs `.buildfiles`,
+   skips submodule dirs and `.skip-build` dirs):
+   ```
+   bash scripts/kustomize-build-all.sh
+   ```
+
+4. **Image tag sync** (verifies `base/kustomization.yaml` image tags
+   match submodule commit SHAs):
+   ```
+   bash scripts/sync-image-tags.sh
+   ```
+
+5. **AuthConfig Rego sync** (verifies overlay Rego patches match the
+   base AuthConfig in the fulfillment-service submodule):
+   ```
+   python3 scripts/sync-authconfig-rego.py
+   ```
+
+If image tags or Rego policies are out of sync, the scripts support
+`--fix` mode. Run them with `--fix` and verify the output before
+committing.
+
+## Submodule Rules (Critical)
+
+- Submodules live under `base/` (osac-operator, osac-fulfillment-service,
+  osac-aap). They are pinned snapshots of upstream repos.
+- **Never `cd` into a submodule directory and run git commands there.**
+  You will operate on the submodule repo, not the installer.
+- Always run git commands from the installer repo root.
+- After updating a submodule pointer, run `bash scripts/sync-image-tags.sh --fix`
+  to update the corresponding image tag in `base/kustomization.yaml`.
+- Image tags use the format `sha-XXXXXXX` (first 7 chars of the
+  submodule commit).
+- **After bumping any submodule under `base/`, always run
+  `scripts/sync-image-tags.sh --fix` to update image tags in overlays.
+  CI will fail if tags don't match submodule SHAs.** (OSAC-912)
+
+## Repository Structure
+
+```
+base/kustomization.yaml          # Composes all submodule components
+  base/osac-operator/            # Git submodule
+  base/osac-fulfillment-service/ # Git submodule
+  base/osac-aap/                 # Git submodule
+  base/hub-access/               # Local RBAC manifests
+
+overlays/<name>/                 # Env-specific overlay
+  kustomization.yaml             # Namespace, image pins, patches, secrets
+  prefixTransformer.yaml         # Cluster-scoped resource name prefix
+  files/                         # Secrets (gitignored)
+
+prerequisites/                   # Cluster-wide operator manifests
+scripts/                         # Automation scripts (setup, teardown, sync)
+```
+
+## Coding Conventions
+
+- All YAML files must pass `yamllint --strict` with the repo's
+  `.yamllint.yaml` config (line-length disabled, document-start disabled,
+  indent-sequences: whatever).
+- Overlay `files/` directories contain secrets (pull-secrets, license
+  files, SSH keys). These are **gitignored** -- never commit them.
+- The `.buildfiles` file in an overlay lists files that CI creates as
+  empty stubs to satisfy `kustomize build` (e.g., `files/license.zip`).
+- Mark directories with `.skip-build` to exclude from
+  `kustomize-build-all.sh`. Mark with `.expect-build-failure` if the
+  build is expected to fail.
+- Cluster-scoped resources (ClusterRole, ClusterRoleBinding) must use
+  `prefixTransformer.yaml` to avoid collisions between overlays on the
+  same cluster.
+- Shell scripts must use `set -o nounset`, `set -o errexit`,
+  `set -o pipefail`. Source `scripts/lib.sh` for shared functions
+  (`retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`).
+- Always use explicit `-n <namespace>` flags in `oc` commands -- never
+  rely on the current context namespace.
+
+## Kustomize Pitfalls
+
+- The namespace transformer overwrites all `metadata.namespace`. Resources
+  targeting a different namespace (e.g., kube-system) need separate
+  kustomization directories or kustomize replacements.
+- Replacements inside Components run before the namespace transformer --
+  namespace-fixing replacements must live at the overlay level.
+- Kustomize blocks `../` in file paths.
+- Embedded namespace references (APIService, cert-manager annotations,
+  Certificate dnsNames) require kustomize replacements with
+  `delimiter`/`index` fields.
+- The `ca-trust-bundle.yaml` Bundle is cluster-scoped. On shared clusters,
+  last apply wins. Never re-apply the Bundle -- patch it to append your
+  namespace instead.
+
+## Baseline Diff Workflow
+
+When modifying Kustomize resources, always capture baseline output before
+changes and diff after to catch unintended side effects:
+
+```bash
+# Before changes
+for d in overlays/*/; do
+  kustomize build "$d" > "/tmp/baseline-$(basename $d).yaml" 2>/dev/null
+done
+
+# After changes
+for d in overlays/*/; do
+  kustomize build "$d" > "/tmp/after-$(basename $d).yaml" 2>/dev/null
+  diff "/tmp/baseline-$(basename $d).yaml" "/tmp/after-$(basename $d).yaml"
+done
+```
+
+## What Not to Modify
+
+- Do not modify files inside `base/osac-operator/`, `base/osac-fulfillment-service/`,
+  or `base/osac-aap/` -- these are submodules. Changes to component
+  manifests belong in the component repos.
+- Do not commit overlay `files/` contents (pull secrets, license.zip,
+  SSH keys, `.env` files with credentials).
+- Do not add personal overlays (e.g., `overlays/osac-<username>`) to
+  the repo.

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -1,0 +1,51 @@
+Execute the following workflow phases in order. This is an
+infrastructure/deployment repo -- there are no unit tests. Validation
+is structural (YAML lint, kustomize build, sync checks).
+
+1. **Read and execute .ai-workflows/bugfix/skills/assess.md**
+   The bug report is in `.ai-bot/issue.md`. Identify which files are
+   affected (overlays, base kustomization, scripts, prerequisites).
+   Do not ask clarifying questions -- make reasonable assumptions.
+
+2. **Read and execute .ai-workflows/bugfix/skills/diagnose.md**
+   Write your root cause analysis to `.ai-bot/diagnosis.md`.
+   For Kustomize issues, capture the full `kustomize build` output of
+   affected overlays before and after to isolate the problem.
+
+3. **Read and execute .ai-workflows/bugfix/skills/fix.md**
+   Implement the minimal fix. Key constraints:
+   - Never modify files inside submodule directories (`base/osac-operator/`,
+     `base/osac-fulfillment-service/`, `base/osac-aap/`).
+   - If the fix involves submodule pointer updates, also run
+     `bash scripts/sync-image-tags.sh --fix`.
+   - If the fix touches overlay AuthConfig Rego patches, also run
+     `python3 scripts/sync-authconfig-rego.py --fix`.
+
+4. **Validate changes**
+   Run all validation commands in sequence. If any fail, revise your
+   fix and revalidate (up to 5 iterations):
+   ```
+   yamllint --strict .
+   pre-commit run --all-files
+   bash scripts/kustomize-build-all.sh
+   bash scripts/sync-image-tags.sh
+   python3 scripts/sync-authconfig-rego.py
+   ```
+   Additionally, diff kustomize build output for affected overlays
+   against the baseline to confirm only intended changes appear.
+
+5. **Read and execute .ai-workflows/bugfix/skills/review.md**
+   Self-review your changes. Pay special attention to:
+   - Namespace references embedded in YAML strings (APIService,
+     cert-manager annotations, Certificate dnsNames)
+   - Cluster-scoped resources that need prefixTransformer coverage
+   - Overlay consistency (if you changed one overlay, check whether
+     parallel overlays need the same change)
+   If issues are found, correct them, revalidate, and re-review
+   (up to 4 iterations).
+
+6. **Write PR description to `.ai-bot/pr.md`**
+   Use the `## Title` heading format. Include:
+   - A Root Cause section from `.ai-bot/diagnosis.md`
+   - Which overlays are affected
+   - The kustomize build diff (before/after) for affected overlays


### PR DESCRIPTION
## Summary

Adds `.ai-bot/` configuration directory to enable the AI bug fix bot for osac-installer. Follows the same pattern established in fulfillment-service ([PR #554](https://github.com/osac-project/fulfillment-service/pull/554), merged).

### Files

| File | Purpose |
|------|---------|
| `instructions.md` | Repo-specific context: validation commands, submodule rules, Kustomize pitfalls, coding conventions, what not to modify |
| `new-ticket-workflow.md` | Bugfix workflow: assess → diagnose → fix → validate (yamllint + pre-commit + kustomize build + sync checks) → self-review → write PR description |
| `feedback-workflow.md` | PR review feedback workflow: context recovery, submodule boundary enforcement, overlay consistency checks, re-validation |
| `config.yaml` | Bot configuration: ai-workflows import, validation commands, PR defaults (draft, `ai-pr` label) |

### [OSAC-912](https://redhat.atlassian.net/browse/OSAC-912) fix included

Added explicit instruction: after bumping any submodule under `base/`, always run `scripts/sync-image-tags.sh --fix` to update image tags in overlays.

---

## Decisions (from [fulfillment-service PR #554 review](https://github.com/osac-project/fulfillment-service/pull/554#issuecomment-4486828911))

| Decision | Answer |
|----------|--------|
| **Container image** | Andy's purpose-built image (`quay.io/rh-ee-andalton/osac-ai:latest`) — already set in `container.json` |
| **ai-workflows URL** | `https://github.com/flightctl/ai-workflows` — ✅ correct in config |
| **Jira project key** | `OSAC` |
| **Draft PRs** | Yes — drafts by default |
| **PR labels** | `ai-pr` — ✅ correct in config |
| **Scope** | Bugfix-only to start |
| **Target branch** | `main` always |
| **Sensitive files** | Covered by `.gitignore` (pull-secret, ssh keys, license.zip, etc.) — no extra config needed |
| **Submodule init** | Instructions include submodule rules; bot should run `git submodule update --init --recursive` before validation |

### Remaining repo-specific question

1. **Overlay scope** — Should the AI bot be restricted from modifying CI-specific overlays (vmaas-ci, caas-ci, osac-integration) or overlays with ExternalSecrets (hypershift2)? Current default: bot can touch any overlay, CI validates everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)