### PR TITLE
OSAC-898: Revert per-overlay Bundle naming; use additive selector patching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,12 @@ for d in overlays/*/; do kustomize build "$d" > "/tmp/after-$(basename $d).yaml"
 - **Replacements in Components run before the namespace transformer** -- a replacement that sets `metadata.namespace: kube-system` inside a Component will be overwritten by the overlay's namespace transformer. Replacements that fix namespace fields must live at the overlay level.
 - **Kustomize blocks `../` in file paths** -- replacements files cannot reference parent directories. Each overlay that needs replacements must have its own copy.
 - **Embedded namespace references** -- `APIService.spec.service.namespace`, `cert-manager.io/inject-ca-from` annotations, and Certificate `dnsNames` embed namespaces that the transformer cannot update. These require kustomize replacements with `delimiter`/`index` fields.
-- **`ca-trust-bundle.yaml` is cluster-scoped** -- each overlay's Bundle must use a unique name (`ca-bundle-<namespace>`) to avoid collisions on shared clusters. The `namespaceSelector` targets only that overlay's namespace. When creating a new overlay, copy `ca-trust-bundle.yaml` from an existing overlay, update `metadata.name` to `ca-bundle-<your-namespace>`, and update the `values` list to your namespace.
+- **`ca-trust-bundle.yaml` is cluster-scoped** -- the Bundle named `ca-bundle` is shared across overlays. Trust-manager names the generated ConfigMap after the Bundle, so renaming the Bundle would break all pods that mount the `ca-bundle` ConfigMap. On shared clusters, **never re-apply the Bundle** -- this overwrites the `namespaceSelector` and breaks other developers' deployments. `setup.sh` automatically patches the selector to add your namespace. If your namespace is missing from the Bundle's selector, patch it to append your namespace:
+  ```bash
+  oc patch bundle ca-bundle --type=json -p '[
+    {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<your-namespace>"}
+  ]'
+  ```
 
 ## Shared Cluster Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ for d in overlays/*/; do kustomize build "$d" > "/tmp/after-$(basename $d).yaml"
     {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<your-namespace>"}
   ]'
   ```
-  If the Bundle doesn't exist yet, create it from `overlays/<overlay>/ca-trust-bundle.yaml` and then patch as above.
+  Or run `scripts/ensure-ca-bundle.sh <your-namespace>` which handles both creation and patching.
 
 ## Shared Cluster Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,12 +113,13 @@ for d in overlays/*/; do kustomize build "$d" > "/tmp/after-$(basename $d).yaml"
 - **Replacements in Components run before the namespace transformer** -- a replacement that sets `metadata.namespace: kube-system` inside a Component will be overwritten by the overlay's namespace transformer. Replacements that fix namespace fields must live at the overlay level.
 - **Kustomize blocks `../` in file paths** -- replacements files cannot reference parent directories. Each overlay that needs replacements must have its own copy.
 - **Embedded namespace references** -- `APIService.spec.service.namespace`, `cert-manager.io/inject-ca-from` annotations, and Certificate `dnsNames` embed namespaces that the transformer cannot update. These require kustomize replacements with `delimiter`/`index` fields.
-- **`ca-trust-bundle.yaml` is cluster-scoped** -- the Bundle named `ca-bundle` is shared across overlays. Trust-manager names the generated ConfigMap after the Bundle, so renaming the Bundle would break all pods that mount the `ca-bundle` ConfigMap. On shared clusters, **never re-apply the Bundle** -- this overwrites the `namespaceSelector` and breaks other developers' deployments. `setup.sh` automatically patches the selector to add your namespace. If your namespace is missing from the Bundle's selector, patch it to append your namespace:
+- **`ca-bundle` Bundle is cluster-scoped and managed by `setup.sh`** -- trust-manager names the generated ConfigMap after the Bundle, so it must stay named `ca-bundle` (pods mount this ConfigMap by name). The Bundle is **not** applied via kustomize -- `setup.sh` creates it on first deploy and additively patches the namespace selector on subsequent deploys, so it never overwrites other developers' namespaces. For manual deployments, patch the selector to add your namespace:
   ```bash
   oc patch bundle ca-bundle --type=json -p '[
     {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<your-namespace>"}
   ]'
   ```
+  If the Bundle doesn't exist yet, create it from `overlays/<overlay>/ca-trust-bundle.yaml` and then patch as above.
 
 ## Shared Cluster Constraints
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ Use Kustomize to manage your environment-specific configurations.
 
    - In `kustomization.yaml`: Update the `namespace` field to `<project-name>`
    - In `prefixTransformer.yaml`: Update the `prefix` field to `<project-name>-`
-   - In `ca-trust-bundle.yaml`: Update `metadata.name` to `ca-bundle-<project-name>`
-     and update the `values` field element to `<project-name>`.
-     The Bundle is cluster-scoped, so each overlay must use a unique name to avoid
-     overwriting other developers' Bundles on shared clusters.
+   - In `ca-trust-bundle.yaml`: Update the `values` field element
+     to `<project-name>`. The Bundle name must stay `ca-bundle` because
+     trust-manager names the generated ConfigMap after the Bundle, and pods
+     mount the ConfigMap by that name.
    - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
      value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
      You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Use Kustomize to manage your environment-specific configurations.
        {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<project-name>"}
      ]'
      ```
-     If no `ca-bundle` Bundle exists yet, apply `ca-trust-bundle.yaml` once:
-     `oc apply -f overlays/<project-name>/ca-trust-bundle.yaml`
+     Alternatively, run `scripts/ensure-ca-bundle.sh <project-name>` which
+     handles both creation and patching.
    - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
      value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
      You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`

--- a/README.md
+++ b/README.md
@@ -129,10 +129,17 @@ Use Kustomize to manage your environment-specific configurations.
 
    - In `kustomization.yaml`: Update the `namespace` field to `<project-name>`
    - In `prefixTransformer.yaml`: Update the `prefix` field to `<project-name>-`
-   - In `ca-trust-bundle.yaml`: Update the `values` field element
-     to `<project-name>`. The Bundle name must stay `ca-bundle` because
-     trust-manager names the generated ConfigMap after the Bundle, and pods
-     mount the ConfigMap by that name.
+   - The `ca-bundle` Bundle is cluster-scoped and shared across overlays.
+     **If using `setup.sh`**, it handles the Bundle automatically (creates it on
+     first deploy, patches the namespace selector on subsequent deploys).
+     **If deploying manually**, patch the Bundle to include your namespace:
+     ```bash
+     oc patch bundle ca-bundle --type=json -p '[
+       {"op":"add","path":"/spec/target/namespaceSelector/matchExpressions/0/values/-","value":"<project-name>"}
+     ]'
+     ```
+     If no `ca-bundle` Bundle exists yet, apply `ca-trust-bundle.yaml` once:
+     `oc apply -f overlays/<project-name>/ca-trust-bundle.yaml`
    - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
      value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
      You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`

--- a/overlays/caas-ci/ca-trust-bundle.yaml
+++ b/overlays/caas-ci/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle-osac-e2e-ci
+  name: ca-bundle
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -16,7 +16,6 @@ labels:
 
 resources:
 - ../../base
-- ./ca-trust-bundle.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/overlays/development/ca-trust-bundle.yaml
+++ b/overlays/development/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle-osac-devel
+  name: ca-bundle
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -16,7 +16,6 @@ labels:
 
 resources:
 - ../../base
-- ./ca-trust-bundle.yaml
 - ./capi-provider-role.yaml
 
 components:

--- a/overlays/osac-integration/ca-trust-bundle.yaml
+++ b/overlays/osac-integration/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle-osac-integration
+  name: ca-bundle
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -16,7 +16,6 @@ labels:
 
 resources:
 - ../../base
-- ./ca-trust-bundle.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/overlays/vmaas-ci/ca-trust-bundle.yaml
+++ b/overlays/vmaas-ci/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle-osac-e2e-ci
+  name: ca-bundle
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -16,7 +16,6 @@ labels:
 
 resources:
 - ../../base
-- ./ca-trust-bundle.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/scripts/ensure-ca-bundle.sh
+++ b/scripts/ensure-ca-bundle.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Ensure the shared ca-bundle Bundle exists and includes the given namespace.
+#
+# The Bundle is cluster-scoped and shared across overlays. It is NOT applied via
+# kustomize because that would overwrite the namespaceSelector and break other
+# developers' deployments. This script creates the Bundle on first deploy and
+# additively patches the selector on subsequent deploys.
+#
+# Usage: ensure-ca-bundle.sh <namespace>
+
+NAMESPACE="${1:?Usage: ensure-ca-bundle.sh <namespace>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/oc.sh"
+
+if oc get bundle ca-bundle &>/dev/null; then
+    EXISTING=$(oc get bundle ca-bundle -o jsonpath='{.spec.target.namespaceSelector.matchExpressions[0].values}')
+    if ! echo "${EXISTING}" | grep -q "\"${NAMESPACE}\""; then
+        echo "Adding ${NAMESPACE} to ca-bundle namespace selector..."
+        oc patch bundle ca-bundle --type=json -p \
+            "[{\"op\":\"add\",\"path\":\"/spec/target/namespaceSelector/matchExpressions/0/values/-\",\"value\":\"${NAMESPACE}\"}]"
+    fi
+else
+    echo "Creating ca-bundle Bundle targeting ${NAMESPACE}..."
+    oc apply -f - <<EOF
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ca-bundle
+spec:
+  sources:
+  - secret:
+      name: "default-ca"
+      key: "ca.crt"
+  target:
+    configMap:
+      key: bundle.pem
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - ${NAMESPACE}
+EOF
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -248,11 +248,16 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
-# Clean up legacy shared ca-bundle Bundle if a per-overlay one now exists
-if oc get bundle "ca-bundle-${INSTALLER_NAMESPACE}" &>/dev/null && \
-   oc get bundle ca-bundle &>/dev/null; then
-    echo "Deleting legacy shared ca-bundle Bundle (replaced by ca-bundle-${INSTALLER_NAMESPACE})..."
-    oc delete bundle ca-bundle
+# Ensure the shared ca-bundle Bundle includes our namespace in its selector.
+# The Bundle is cluster-scoped and shared across overlays; patching the selector
+# is additive and won't affect other developers' namespaces.
+if oc get bundle ca-bundle &>/dev/null; then
+    EXISTING=$(oc get bundle ca-bundle -o jsonpath='{.spec.target.namespaceSelector.matchExpressions[0].values}')
+    if ! echo "${EXISTING}" | grep -q "\"${INSTALLER_NAMESPACE}\""; then
+        echo "Adding ${INSTALLER_NAMESPACE} to ca-bundle namespace selector..."
+        oc patch bundle ca-bundle --type=json -p \
+            "[{\"op\":\"add\",\"path\":\"/spec/target/namespaceSelector/matchExpressions/0/values/-\",\"value\":\"${INSTALLER_NAMESPACE}\"}]"
+    fi
 fi
 
 # Create controller OAuth credentials from the Keycloak realm config

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -248,40 +248,8 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
-# Ensure the shared ca-bundle Bundle exists and includes our namespace.
-# The Bundle is cluster-scoped and shared across overlays. We never apply it
-# via kustomize because that would overwrite the namespaceSelector and break
-# other developers' deployments. Instead we create it once or patch additively.
-if oc get bundle ca-bundle &>/dev/null; then
-    EXISTING=$(oc get bundle ca-bundle -o jsonpath='{.spec.target.namespaceSelector.matchExpressions[0].values}')
-    if ! echo "${EXISTING}" | grep -q "\"${INSTALLER_NAMESPACE}\""; then
-        echo "Adding ${INSTALLER_NAMESPACE} to ca-bundle namespace selector..."
-        oc patch bundle ca-bundle --type=json -p \
-            "[{\"op\":\"add\",\"path\":\"/spec/target/namespaceSelector/matchExpressions/0/values/-\",\"value\":\"${INSTALLER_NAMESPACE}\"}]"
-    fi
-else
-    echo "Creating ca-bundle Bundle targeting ${INSTALLER_NAMESPACE}..."
-    oc apply -f - <<BUNDLE_EOF
-apiVersion: trust.cert-manager.io/v1alpha1
-kind: Bundle
-metadata:
-  name: ca-bundle
-spec:
-  sources:
-  - secret:
-      name: "default-ca"
-      key: "ca.crt"
-  target:
-    configMap:
-      key: bundle.pem
-    namespaceSelector:
-      matchExpressions:
-      - key: kubernetes.io/metadata.name
-        operator: In
-        values:
-        - ${INSTALLER_NAMESPACE}
-BUNDLE_EOF
-fi
+# Ensure the shared ca-bundle Bundle exists and includes our namespace
+"${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
 
 # Create controller OAuth credentials from the Keycloak realm config
 FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -248,9 +248,10 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 # Apply kustomize overlay
 oc apply -k overlays/${INSTALLER_KUSTOMIZE_OVERLAY}
 
-# Ensure the shared ca-bundle Bundle includes our namespace in its selector.
-# The Bundle is cluster-scoped and shared across overlays; patching the selector
-# is additive and won't affect other developers' namespaces.
+# Ensure the shared ca-bundle Bundle exists and includes our namespace.
+# The Bundle is cluster-scoped and shared across overlays. We never apply it
+# via kustomize because that would overwrite the namespaceSelector and break
+# other developers' deployments. Instead we create it once or patch additively.
 if oc get bundle ca-bundle &>/dev/null; then
     EXISTING=$(oc get bundle ca-bundle -o jsonpath='{.spec.target.namespaceSelector.matchExpressions[0].values}')
     if ! echo "${EXISTING}" | grep -q "\"${INSTALLER_NAMESPACE}\""; then
@@ -258,6 +259,28 @@ if oc get bundle ca-bundle &>/dev/null; then
         oc patch bundle ca-bundle --type=json -p \
             "[{\"op\":\"add\",\"path\":\"/spec/target/namespaceSelector/matchExpressions/0/values/-\",\"value\":\"${INSTALLER_NAMESPACE}\"}]"
     fi
+else
+    echo "Creating ca-bundle Bundle targeting ${INSTALLER_NAMESPACE}..."
+    oc apply -f - <<BUNDLE_EOF
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ca-bundle
+spec:
+  sources:
+  - secret:
+      name: "default-ca"
+      key: "ca.crt"
+  target:
+    configMap:
+      key: bundle.pem
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - ${INSTALLER_NAMESPACE}
+BUNDLE_EOF
 fi
 
 # Create controller OAuth credentials from the Keycloak realm config


### PR DESCRIPTION
## Summary

- Reverts the Bundle rename from `ca-bundle` to `ca-bundle-<namespace>` introduced in [OSAC-898](https://redhat.atlassian.net/browse/OSAC-898) (#107)
- Trust-manager names the generated ConfigMap after the Bundle, so renaming broke all pods that mount the `ca-bundle` ConfigMap (authorino, fulfillment-controller, fulfillment-grpc-server, fulfillment-rest-gateway, AAP automation jobs)
- Replaces the legacy cleanup logic in `setup.sh` with an additive JSON patch that appends the overlay namespace to the shared Bundle's selector without overwriting other developers' namespaces