### PR TITLE
NO_ISSUE: Fix refresh script race conditions causing e2e-vmaas flakes

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -60,3 +60,31 @@ wait_for_resource() {
 
     oc wait --for="${condition}" "${resource}" ${ns_args[@]+"${ns_args[@]}"} --timeout="${timeout}s"
 }
+
+# Retry a command until it succeeds or times out.
+# All output (stdout/stderr) is preserved on every attempt.
+# Usage: retry_command <timeout_seconds> <interval_seconds> <command> [args...]
+retry_command() {
+    local timeout="$1"
+    local interval="$2"
+    shift 2
+    local start=${SECONDS}
+    local attempt=1
+    while true; do
+        local elapsed=$(( SECONDS - start ))
+        echo "  retry_command[attempt=${attempt} elapsed=${elapsed}s timeout=${timeout}s]: $*"
+        local rc=0
+        "$@" || rc=$?
+        if (( rc == 0 )); then
+            echo "  retry_command: succeeded on attempt ${attempt} after $(( SECONDS - start ))s"
+            return 0
+        fi
+        if (( SECONDS - start >= timeout )); then
+            echo "  retry_command: FAILED after ${attempt} attempts, $(( SECONDS - start ))s elapsed (exit code ${rc})"
+            return "${rc}"
+        fi
+        echo "  retry_command: exit code ${rc}, retrying in ${interval}s..."
+        sleep "${interval}"
+        (( attempt++ ))
+    done
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -85,6 +85,6 @@ retry_command() {
         fi
         echo "  retry_command: exit code ${rc}, retrying in ${interval}s..."
         sleep "${interval}"
-        (( attempt++ ))
+        attempt=$(( attempt + 1 ))
     done
 }

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -20,10 +20,17 @@ INSTALLER_CLUSTER_TEMPLATE=${INSTALLER_CLUSTER_TEMPLATE:-}
 # The private API (osac.private.v1.*) is only available via the internal listener
 # (fulfillment-internal-api route, port 8001). The external listener
 # (fulfillment-api route, port 8000) only routes public API methods.
-FULFILLMENT_INTERNAL_API_URL=https://$(oc get route -n ${INSTALLER_NAMESPACE} fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
-osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address ${FULFILLMENT_INTERNAL_API_URL}
-osac delete hub hub
-osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace ${INSTALLER_NAMESPACE}
+FULFILLMENT_INTERNAL_API_URL=https://$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
+echo "Fulfillment internal API URL: ${FULFILLMENT_INTERNAL_API_URL}"
+
+echo "Logging into fulfillment internal API..."
+retry_command 300 10 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address "${FULFILLMENT_INTERNAL_API_URL}"
+
+echo "Deleting existing hub..."
+retry_command 300 10 osac delete hub hub
+
+echo "Creating hub..."
+retry_command 300 10 osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace "${INSTALLER_NAMESPACE}"
 
 if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; then
     # Trigger a one-time publish-templates AAP job

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -134,10 +134,14 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
 echo "[4/8] Waiting for fulfillment rollouts..."
+pids=()
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+    pids+=($!)
 done
-wait
+failed=0
+for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
+if (( failed )); then echo "ERROR: Fulfillment rollout failed"; exit 1; fi
 
 echo "[5/8] Applying AAP configuration..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
@@ -165,10 +169,14 @@ echo "[8/8] Restarting fulfillment pods and configuring tenant..."
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done
+pids=()
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+    pids+=($!)
 done
-wait
+failed=0
+for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
+if (( failed )); then echo "ERROR: Fulfillment rollout failed after restart"; exit 1; fi
 ./scripts/prepare-tenant.sh
 
 echo ""

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -32,7 +32,7 @@ for ns in "${INSTALLER_NAMESPACE}" "${KEYCLOAK_NS}"; do
             ROUTE_NAME=$(echo "${OLD_HOST}" | sed "s/\.${ROUTE_DOMAIN}$//")
             NEW_HOST="${ROUTE_NAME}.${CLUSTER_DOMAIN}"
             echo "  ${ns}/${route}: ${OLD_HOST} -> ${NEW_HOST}"
-            oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+            retry_command 300 10 oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
         fi
     done
 done
@@ -109,6 +109,14 @@ oc create secret generic fulfillment-controller-credentials \
 echo "  Credentials created for client: ${FC_CLIENT_ID}"
 
 echo "[4/9] Applying kustomize overlay..."
+echo "  Checking trust-manager readiness..."
+echo "  trust-manager pods:"
+oc get pods -n cert-manager -l app.kubernetes.io/name=trust-manager --no-headers 2>/dev/null || echo "    (none found)"
+echo "  trust-manager endpoints:"
+oc get endpoints trust-manager -n cert-manager --no-headers 2>/dev/null || echo "    (none found)"
+echo "  Waiting for trust-manager rollout..."
+oc rollout status deploy/trust-manager -n cert-manager --timeout=300s
+echo "  trust-manager ready"
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -22,22 +22,43 @@ echo "Overlay: ${INSTALLER_KUSTOMIZE_OVERLAY}"
 echo "Cluster domain: ${CLUSTER_DOMAIN}"
 echo ""
 
-echo "[1/9] Patching stale routes with new domain..."
-echo "  New domain: ${CLUSTER_DOMAIN}"
-for ns in "${INSTALLER_NAMESPACE}" "${KEYCLOAK_NS}"; do
-    for route in $(oc get routes -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
-        OLD_HOST=$(oc get route "${route}" -n "${ns}" -o jsonpath='{.spec.host}')
-        ROUTE_DOMAIN=$(echo "${OLD_HOST}" | sed "s/^[^.]*\.//")
-        if [[ "${ROUTE_DOMAIN}" != "${CLUSTER_DOMAIN}" ]]; then
-            ROUTE_NAME=$(echo "${OLD_HOST}" | sed "s/\.${ROUTE_DOMAIN}$//")
-            NEW_HOST="${ROUTE_NAME}.${CLUSTER_DOMAIN}"
-            echo "  ${ns}/${route}: ${OLD_HOST} -> ${NEW_HOST}"
-            retry_command 300 10 oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
-        fi
-    done
-done
+echo "Waiting for cluster services to stabilize..."
 
-echo "[2/9] Syncing Keycloak realm..."
+patch_stale_routes() {
+    echo "  Patching stale routes with new domain..."
+    for ns in "${INSTALLER_NAMESPACE}" "${KEYCLOAK_NS}"; do
+        for route in $(oc get routes -n "${ns}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            OLD_HOST=$(oc get route "${route}" -n "${ns}" -o jsonpath='{.spec.host}')
+            ROUTE_DOMAIN=$(echo "${OLD_HOST}" | sed "s/^[^.]*\.//")
+            if [[ "${ROUTE_DOMAIN}" != "${CLUSTER_DOMAIN}" ]]; then
+                ROUTE_NAME=$(echo "${OLD_HOST}" | sed "s/\.${ROUTE_DOMAIN}$//")
+                NEW_HOST="${ROUTE_NAME}.${CLUSTER_DOMAIN}"
+                echo "  ${ns}/${route}: ${OLD_HOST} -> ${NEW_HOST}"
+                retry_command 300 10 oc patch route "${route}" -n "${ns}" --type=merge -p "{\"spec\":{\"host\":\"${NEW_HOST}\"}}"
+            fi
+        done
+    done
+}
+
+oc rollout status deploy/trust-manager -n cert-manager --timeout=300s &
+pid_tm=$!
+oc wait --for=condition=Ready certificate/keycloak-tls -n "${KEYCLOAK_NS}" --timeout=300s &
+pid_kc=$!
+patch_stale_routes &
+pid_rt=$!
+
+failed=0
+wait ${pid_tm} || failed=1
+wait ${pid_kc} || failed=1
+wait ${pid_rt} || failed=1
+if (( failed )); then
+    echo "ERROR: Cluster services did not stabilize within timeout"
+    exit 1
+fi
+echo "Cluster services ready"
+echo ""
+
+echo "[1/8] Syncing Keycloak realm..."
 NEW_HASH=$(md5sum "${REALM_JSON}" | awk '{print $1}')
 OLD_HASH=$(oc get configmap keycloak-realm -n "${KEYCLOAK_NS}" -o jsonpath='{.data.realm\.json}' 2>/dev/null | md5sum | awk '{print $1}')
 if [[ "${NEW_HASH}" != "${OLD_HASH}" ]]; then
@@ -97,7 +118,7 @@ if [[ -f prerequisites/keycloak/service/password-setup-job.yaml ]]; then
     oc wait --for=condition=Complete job/keycloak-set-passwords -n "${KEYCLOAK_NS}" --timeout=120s
 fi
 
-echo "[3/9] Recreating fulfillment controller credentials..."
+echo "[2/8] Recreating fulfillment controller credentials..."
 FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' "${REALM_JSON}")
 FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${REALM_JSON}")
 [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
@@ -108,32 +129,24 @@ oc create secret generic fulfillment-controller-credentials \
     -n "${INSTALLER_NAMESPACE}"
 echo "  Credentials created for client: ${FC_CLIENT_ID}"
 
-echo "[4/9] Applying kustomize overlay..."
-echo "  Checking trust-manager readiness..."
-echo "  trust-manager pods:"
-oc get pods -n cert-manager -l app.kubernetes.io/name=trust-manager --no-headers 2>/dev/null || echo "    (none found)"
-echo "  trust-manager endpoints:"
-oc get endpoints trust-manager -n cert-manager --no-headers 2>/dev/null || echo "    (none found)"
-echo "  Waiting for trust-manager rollout..."
-oc rollout status deploy/trust-manager -n cert-manager --timeout=300s
-echo "  trust-manager ready"
+echo "[3/8] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
-echo "[5/9] Waiting for fulfillment rollouts..."
+echo "[4/8] Waiting for fulfillment rollouts..."
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
 done
 wait
 
-echo "[6/9] Applying AAP configuration..."
+echo "[5/8] Applying AAP configuration..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
 INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
     ./scripts/aap-configuration.sh
 
 oc config set-context --current --namespace="${INSTALLER_NAMESPACE}"
 
-echo "[7/9] Waiting for AAP controller..."
+echo "[6/8] Waiting for AAP controller..."
 retry_until 300 10 '[[ "$(oc get automationcontroller osac-aap-controller -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.status.conditions[?(@.type=="Running")].status}'"'"' 2>/dev/null)" == "True" ]]' || {
     echo "Timed out waiting for AAP controller to be Running"
     exit 1
@@ -144,11 +157,11 @@ retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_R
     exit 1
 }
 
-echo "[8/9] Configuring AAP access and fulfillment service..."
+echo "[7/8] Configuring AAP access and fulfillment service..."
 ./scripts/prepare-aap.sh
 ./scripts/prepare-fulfillment-service.sh
 
-echo "[9/9] Restarting fulfillment pods and configuring tenant..."
+echo "[8/8] Restarting fulfillment pods and configuring tenant..."
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done


### PR DESCRIPTION
## Problem

The e2e-vmaas CI job has a high failure rate, with the vast majority of failures caused by race conditions in the refresh script — not actual test failures.

Four root causes account for ~80% of all CI failures:

| Root Cause | Description |
|------------|-------------|
| Route patching | API endpoint `10.128.0.1:443` refuses connections after snapshot boot |
| trust-manager webhook | No endpoints when kustomize applies Bundle CRs |
| Keycloak TLS cert | cert-manager reissuing `keycloak-tls` after recert causes TLS handshake failures |
| gRPC fulfillment | `osac` CLI calls fail before server is reachable |

All four are the same fundamental bug: the script doesn't wait for what it's about to use. The cluster passes the operator readiness gate (34/34), but individual services need additional time after snapshot boot + recert.

## Fix

### Parallel stability gate (before any steps)

A single parallel gate waits for all pre-kustomize dependencies concurrently:
- `oc rollout status deploy/trust-manager` — trust-manager is not a cluster operator, so 34/34 misses it
- `oc wait --for=condition=Ready certificate/keycloak-tls` — cert-manager reissues TLS certs after recert
- Route patching with `retry_command` — API admission webhook needs time after recert

All three run in parallel. Total wall time = max(all three) ≈ 2-3 min typical.

### Post-kustomize retries

`osac login`, `osac delete hub`, `osac create hub` wrapped in `retry_command` (5min timeout each) — handles gRPC server not being ready after deployment rollout.

### Other fixes

- `retry_command` helper in `lib.sh` with correct exit code handling (`local rc=0; "$@" || rc=$?` instead of the bash-broken `local rc=$?`)
- Fixed bare `wait` calls that silently swallowed rollout failures under `set -o errexit`
- Verbose logging: each retry attempt logs attempt number, elapsed time, and exit code

### Timeout budget

| Phase | Timeout | Typical |
|-------|---------|---------|
| Parallel gate | 5 min (all 3 concurrent) | 2-3 min |
| osac CLI retries | 5 min each × 3 | 0 (pass first try) |
| **Worst case total added** | **20 min** | **2-3 min** |

Well under the 50-min SSH timeout.