### PR TITLE
OSAC-704: bump fulfillment-service + sync authconfig rego

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -27,7 +27,7 @@ images:
   newName: quay.io/sclorg/postgresql-15-c9s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-4fe43c1
+  newTag: sha-c70c64d
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-744bc2c

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -406,7 +406,7 @@ patches:
                 # Note: Tenant admins can manage users. IdP managers cannot (they only manage IdP config).
                 # OPA performs method-level authorization (can this user call this method?).
                 # The application layer enforces resource-level authorization via the generic server's
-                # determineAssignedTenants validation, which ensures users can only assign tenants they have visibility to.
+                # determineAssignedTenant validation, which ensures users can only assign a tenant they have visibility to.
                 allow if {
                   is_tenant_admin
                   grpc_method in {
@@ -427,6 +427,5 @@ patches:
                 allow if {
                   is_admin
                 }
-
 replacements:
 - path: console-proxy-replacements.yaml

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -411,7 +411,7 @@ patches:
                 # Note: Tenant admins can manage users. IdP managers cannot (they only manage IdP config).
                 # OPA performs method-level authorization (can this user call this method?).
                 # The application layer enforces resource-level authorization via the generic server's
-                # determineAssignedTenants validation, which ensures users can only assign tenants they have visibility to.
+                # determineAssignedTenant validation, which ensures users can only assign a tenant they have visibility to.
                 allow if {
                   is_tenant_admin
                   grpc_method in {
@@ -432,6 +432,5 @@ patches:
                 allow if {
                   is_admin
                 }
-
 replacements:
 - path: console-proxy-replacements.yaml

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -465,7 +465,7 @@ patches:
                 # Note: Tenant admins can manage users. IdP managers cannot (they only manage IdP config).
                 # OPA performs method-level authorization (can this user call this method?).
                 # The application layer enforces resource-level authorization via the generic server's
-                # determineAssignedTenants validation, which ensures users can only assign tenants they have visibility to.
+                # determineAssignedTenant validation, which ensures users can only assign a tenant they have visibility to.
                 allow if {
                   is_tenant_admin
                   grpc_method in {
@@ -486,7 +486,6 @@ patches:
                 allow if {
                   is_admin
                 }
-
             priority: 0
         hosts:
         - '*'

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -376,7 +376,7 @@ patches:
                 # Note: Tenant admins can manage users. IdP managers cannot (they only manage IdP config).
                 # OPA performs method-level authorization (can this user call this method?).
                 # The application layer enforces resource-level authorization via the generic server's
-                # determineAssignedTenants validation, which ensures users can only assign tenants they have visibility to.
+                # determineAssignedTenant validation, which ensures users can only assign a tenant they have visibility to.
                 allow if {
                   is_tenant_admin
                   grpc_method in {


### PR DESCRIPTION
## Summary

- Bump `osac-fulfillment-service` submodule to include catalog item support ([fulfillment-service#549](https://github.com/osac-project/fulfillment-service/pull/549))
- Update fulfillment-service image tag to `sha-c70c64d`
- Sync authconfig rego comments across overlays (`determineAssignedTenants` → `determineAssignedTenant` from [fulfillment-service#543](https://github.com/osac-project/fulfillment-service/pull/543))

Replaces [osac-installer#123](https://github.com/osac-project/osac-installer/pull/123) (auto-bump that failed CI due to missing authconfig sync and image tag update).

## Test plan

- [ ] CI: check-authconfig-rego passes
- [ ] CI: check-image-tags passes

Generated with [Claude Code](https://claude.com/claude-code)