### PR TITLE
NO-ISSUE: fix sync-image-tags.sh dash prefix bug

### DIFF
--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -18,7 +18,7 @@ declare -A IMAGE_NAME=(
 errors=0
 
 for submodule in osac-operator osac-fulfillment-service osac-aap; do
-  commit=$(git -C "${REPO_ROOT}" submodule status "base/${submodule}" | awk '{print $1}' | tr -d '+')
+  commit=$(git -C "${REPO_ROOT}" submodule status "base/${submodule}" | awk '{print $1}' | tr -d ' +-')
   short="${commit:0:7}"
   tag="sha-${short}"
   image="${IMAGE_NAME[$submodule]}"
@@ -37,7 +37,7 @@ for submodule in osac-operator osac-fulfillment-service osac-aap; do
   fi
 done
 
-aap_commit=$(git -C "${REPO_ROOT}" submodule status "base/osac-aap" | awk '{print $1}' | tr -d '+')
+aap_commit=$(git -C "${REPO_ROOT}" submodule status "base/osac-aap" | awk '{print $1}' | tr -d ' +-')
 aap_short="${aap_commit:0:7}"
 aap_tag="sha-${aap_short}"
 


### PR DESCRIPTION
## Summary

- Fix `sync-image-tags.sh` only stripping `+` prefix from `git submodule status` output
- `git submodule status` can prefix SHAs with ` ` (up to date), `+` (modified), or `-` (not initialized)
- Uninitialized submodules kept the `-` prefix, producing broken tags like `sha--7ba53e5`
- Fix: `tr -d '+'` → `tr -d ' +-'`

## Test plan

- [x] Verified the fix produces correct tags for all three prefix types

Generated with [Claude Code](https://claude.com/claude-code)