### PR TITLE
NO_ISSUE: fix ca-bundle ConfigMap name mismatch and Docker Hub rate limit

### DIFF
--- a/overlays/caas-ci/ca-trust-bundle.yaml
+++ b/overlays/caas-ci/ca-trust-bundle.yaml
@@ -21,7 +21,7 @@
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: ca-bundle-osac-e2e-ci
+  name: ca-bundle
 spec:
   sources:
   # Source the CA certificate from cert-manager namespace where ClusterIssuer stores it

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -185,11 +185,47 @@ patches:
           items:
           - name: ca-bundle
             configMaps:
-            - ca-bundle
+            - ca-bundle-osac-devel
             items:
             - key: bundle.pem
               path: ca-bundle.crt
             mountPath: /etc/pki/tls/certs
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-controller
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-devel
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-grpc-server
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-devel
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-rest-gateway
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-devel
   # Override issuerUrl (base has :8001, we use port 443 via service mapping)
   # and admin_subjects for osac-devel namespace
   - patch: |

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -222,11 +222,47 @@ patches:
           items:
           - name: ca-bundle
             configMaps:
-            - ca-bundle
+            - ca-bundle-osac-integration
             items:
             - key: bundle.pem
               path: ca-bundle.crt
             mountPath: /etc/pki/tls/certs
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-controller
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-integration
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-grpc-server
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-integration
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-rest-gateway
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-integration
   # Override issuerUrl (base has :8001, we use port 443 via service mapping)
   # and admin_subjects for osac-integration namespace
   - patch: |

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -150,11 +150,47 @@ patches:
           items:
           - name: ca-bundle
             configMaps:
-            - ca-bundle
+            - ca-bundle-osac-e2e-ci
             items:
             - key: bundle.pem
               path: ca-bundle.crt
             mountPath: /etc/pki/tls/certs
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-controller
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-e2e-ci
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-grpc-server
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-e2e-ci
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: fulfillment-rest-gateway
+      spec:
+        template:
+          spec:
+            volumes:
+            - name: cas
+              configMap:
+                name: ca-bundle-osac-e2e-ci
   # Override issuerUrl (base has :8001, we use port 443 via service mapping)
   # and admin_subjects for osac-e2e-ci namespace
   - patch: |

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           secretName: keycloak-tls-cert
       initContainers:
       - name: wait-for-database
-        image: postgres
+        image: quay.io/sclorg/postgresql-15-c9s:latest
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash


### PR DESCRIPTION
## Summary

Fixes two deployment failures encountered during `setup.sh`:

**1. ca-bundle ConfigMap not found (Authorino, fulfillment-controller, grpc-server, rest-gateway stuck in ContainerCreating)**

[OSAC-898](https://redhat.atlassian.net/browse/OSAC-898) renamed the trust-manager Bundle CR from `ca-bundle` to `ca-bundle-<namespace>` to avoid collisions on shared clusters. However, trust-manager creates the target ConfigMap with the same name as the Bundle — so the ConfigMap became `ca-bundle-<namespace>` while all component manifests still referenced `ca-bundle`. This caused pods to fail with `configmap "ca-bundle" not found`.

Fixed by adding overlay patches for `fulfillment-controller`, `fulfillment-grpc-server`, and `fulfillment-rest-gateway` deployments, and updating the existing Authorino CR patch, to reference the correct per-overlay ConfigMap name.

Affected overlays: `vmaas-ci`, `development`, `osac-integration`. The `caas-ci` overlay was also fixed (Bundle name corrected to match its kustomization references).

**2. Keycloak init container ImagePullBackOff**

The `wait-for-database` init container in `prerequisites/keycloak/service/deployment.yaml` used `image: postgres` which resolves to `docker.io/library/postgres:latest`. With no Docker Hub credentials in the cluster's global pull secret, this hits unauthenticated rate limits. Replaced with `quay.io/sclorg/postgresql-15-c9s:latest` — the same image used by the database StatefulSet, already cached on the node, and pulled from a registry where we have credentials.

## Test plan

- [x] `kustomize-build-all.sh` passes for all overlays
- [ ] Deploy vmaas-ci overlay with `setup.sh` — verify keycloak init container starts, authorino and fulfillment pods come up