### PR TITLE
DRAFT: NO-ISSUE: skip aap-bootstrap job during snapshot refresh

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -132,6 +132,7 @@ echo "  Credentials created for client: ${FC_CLIENT_ID}"
 echo "[3/8] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
+oc delete job aap-bootstrap -n "${INSTALLER_NAMESPACE}" --ignore-not-found
 
 echo "[4/8] Waiting for fulfillment rollouts..."
 pids=()

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -132,7 +132,10 @@ echo "  Credentials created for client: ${FC_CLIENT_ID}"
 echo "[3/8] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
+echo "  Deleting aap-bootstrap job (AAP config survives from snapshot, bootstrap not needed)"
 oc delete job aap-bootstrap -n "${INSTALLER_NAMESPACE}" --ignore-not-found
+echo "  AAP jobs in namespace:"
+oc get jobs -n "${INSTALLER_NAMESPACE}" --no-headers 2>/dev/null || echo "  (none)"
 
 echo "[4/8] Waiting for fulfillment rollouts..."
 pids=()
@@ -161,6 +164,12 @@ retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_R
     echo "Timed out waiting for AAP gateway API to respond"
     exit 1
 }
+
+echo "  AAP snapshot state diagnostics:"
+echo "  - AutomationController status: $(oc get automationcontroller osac-aap-controller -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Running")].status}' 2>/dev/null || echo 'NOT FOUND')"
+echo "  - AAP project revisions: $(curl -sk "https://${AAP_ROUTE_HOST}/api/controller/v2/projects/" -H "Authorization: Bearer $(oc create token -n "${INSTALLER_NAMESPACE}" admin 2>/dev/null)" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{d.get(\"count\",0)} projects, current_job statuses: {[p.get(\"status\",\"?\") for p in d.get(\"results\",[])]}' )" 2>/dev/null || echo 'could not query')"
+echo "  - Job templates: $(curl -sk "https://${AAP_ROUTE_HOST}/api/controller/v2/job_templates/" -H "Authorization: Bearer $(oc create token -n "${INSTALLER_NAMESPACE}" admin 2>/dev/null)" 2>/dev/null | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{d.get(\"count\",0)} templates: {[t[\"name\"] for t in d.get(\"results\",[])]}' )" 2>/dev/null || echo 'could not query')"
+echo "  - Existing computeinstancetemplates: $(oc get computeinstancetemplate -n "${INSTALLER_NAMESPACE}" --no-headers 2>/dev/null | wc -l || echo 0)"
 
 echo "[7/8] Configuring AAP access and fulfillment service..."
 ./scripts/prepare-aap.sh


### PR DESCRIPTION
## Summary
- Delete the `aap-bootstrap` job immediately after `oc apply -k` in `refresh-after-snapshot.sh`
- AAP configuration (job templates, inventories, credentials) persists in the AAP database through snapshots — re-running bootstrap is unnecessary
- The bootstrap job causes CI failures when its pods race the AAP operator rollout (503s) or crash due to container permission issues

## Context
All e2e-vmaas CI runs across fulfillment-service, osac-aap, and osac-installer have been failing. Root cause: `refresh-after-snapshot.sh` re-creates the bootstrap job via `oc apply -k`, and the job either crashes (permission error in the EE image) or races the AAP operator rollout (503s). In passing runs, the bootstrap runs harmlessly in the background without the script depending on it. In failing runs, it actively breaks the AAP project revision state.

## Test plan
- [ ] e2e-vmaas CI passes with this change
- [ ] Verify publish-templates still finds and publishes computeinstancetemplates without bootstrap