### PR TITLE
Bump osac-aap: OSAC-894 rename massopencloud collections to osac namespace

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -27,12 +27,12 @@ images:
   newName: quay.io/sclorg/postgresql-15-c9s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-682f856
+  newTag: sha-5be2b1b
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-0255559
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-aa52ebd
+  newTag: sha-3171828
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -27,12 +27,12 @@ images:
   newName: quay.io/sclorg/postgresql-15-c9s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-5be2b1b
+  newTag: sha-682f856
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
-  newTag: sha-a2b8504
+  newTag: sha-0255559
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-3171828
+  newTag: sha-aa52ebd
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/docs/aap-configuration.md
+++ b/docs/aap-configuration.md
@@ -38,7 +38,7 @@ for CI pipelines.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `NETWORK_CLASS` | `esi` | Network backend (`netris` or `esi`) |
-| `NETWORK_STEPS_COLLECTION` | `massopencloud.steps` | Ansible collection for network steps |
+| `NETWORK_STEPS_COLLECTION` | `osac.steps` | Ansible collection for network steps |
 | `EXTERNAL_ACCESS_BASE_DOMAIN` | `box.massopen.cloud` | Base domain for cluster DNS records |
 | `EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS` | `box.massopen.cloud` | Comma-separated list of allowed domains |
 | `EXTERNAL_ACCESS_API_INTERNAL_NETWORK` | `hypershift` | Internal network for API access |

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -508,7 +508,7 @@ for full examples.
 # ConfigMap with non-sensitive settings
 oc create configmap cluster-fulfillment-ig \
   --from-literal=NETWORK_CLASS=esi \
-  --from-literal=NETWORK_STEPS_COLLECTION=massopencloud.steps \
+  --from-literal=NETWORK_STEPS_COLLECTION=osac.steps \
   --from-literal=EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud \
   --from-literal=EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud \
   --from-literal=EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift \
@@ -564,7 +564,7 @@ fulfillment endpoint to register templates with.
 
 ```bash
 oc create configmap publish-templates-ig \
-  --from-literal=OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud \
+  --from-literal=OSAC_TEMPLATE_COLLECTIONS=osac.templates \
   --from-literal=OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001 \
   -n ${NAMESPACE}
 ```

--- a/docs/network-backend.md
+++ b/docs/network-backend.md
@@ -11,7 +11,7 @@ see [AAP Configuration](aap-configuration.md).
 
 | `NETWORK_CLASS` | `NETWORK_STEPS_COLLECTION` | Description |
 |-----------------|---------------------------|-------------|
-| `esi` (default) | `massopencloud.steps` | ESI (Elastic System Infrastructure) |
+| `esi` (default) | `osac.steps` | ESI (Elastic System Infrastructure) |
 | `netris` | `netris.steps` | Netris controller API |
 
 ## Netris Configuration

--- a/overlays/caas-ci/files/osac-aap-configuration.env
+++ b/overlays/caas-ci/files/osac-aap-configuration.env
@@ -4,7 +4,7 @@
 
 # Network class: "esi" (default) or "netris"
 NETWORK_CLASS=esi
-NETWORK_STEPS_COLLECTION=massopencloud.steps
+NETWORK_STEPS_COLLECTION=osac.steps
 
 # External access / DNS
 EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -65,7 +65,7 @@ secretGenerator:
 configMapGenerator:
 - name: publish-templates-ig
   literals:
-    - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
+    - OSAC_TEMPLATE_COLLECTIONS=osac.templates
     - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 - name: cluster-fulfillment-ig
   options:
@@ -73,7 +73,7 @@ configMapGenerator:
       osac.openshift.io/project: osac-aap
   literals:
     - NETWORK_CLASS=esi
-    - NETWORK_STEPS_COLLECTION=massopencloud.steps
+    - NETWORK_STEPS_COLLECTION=osac.steps
     - EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
     - EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
     - EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -41,9 +41,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-a2b8504
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-0255559
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
-    - AAP_PROJECT_GIT_BRANCH=a2b85047c817c432dd8928c7b7861cc3f4f528db
+    - AAP_PROJECT_GIT_BRANCH=025555900172e345a339e81ec0120c3fbe9f2db6
 
 - name: cluster-fulfillment-ig
   options:

--- a/overlays/development/files/osac-aap-configuration.env
+++ b/overlays/development/files/osac-aap-configuration.env
@@ -4,7 +4,7 @@
 
 # Network class: "esi" (default) or "netris"
 NETWORK_CLASS=esi
-NETWORK_STEPS_COLLECTION=massopencloud.steps
+NETWORK_STEPS_COLLECTION=osac.steps
 
 # External access / DNS
 EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -65,7 +65,7 @@ secretGenerator:
 configMapGenerator:
 - name: publish-templates-ig
   literals:
-    - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
+    - OSAC_TEMPLATE_COLLECTIONS=osac.templates
     - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 - name: cluster-fulfillment-ig
   options:
@@ -73,7 +73,7 @@ configMapGenerator:
       osac.openshift.io/project: osac-aap
   literals:
     - NETWORK_CLASS=esi
-    - NETWORK_STEPS_COLLECTION=massopencloud.steps
+    - NETWORK_STEPS_COLLECTION=osac.steps
     - EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
     - EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
     - EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift

--- a/overlays/osac-integration/files/osac-aap-configuration.env
+++ b/overlays/osac-integration/files/osac-aap-configuration.env
@@ -4,7 +4,7 @@
 
 # Network class: "esi" (default) or "netris"
 NETWORK_CLASS=esi
-NETWORK_STEPS_COLLECTION=massopencloud.steps
+NETWORK_STEPS_COLLECTION=osac.steps
 
 # External access / DNS
 EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -41,9 +41,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-a2b8504
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-0255559
     - AAP_PROJECT_GIT_URI="https://github.com/osac-project/osac-aap"
-    - AAP_PROJECT_GIT_BRANCH=a2b85047c817c432dd8928c7b7861cc3f4f528db
+    - AAP_PROJECT_GIT_BRANCH=025555900172e345a339e81ec0120c3fbe9f2db6
 
 - name: cluster-fulfillment-ig
   options:

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -60,7 +60,7 @@ configMapGenerator:
       osac.openshift.io/project: osac-aap
   literals:
     - NETWORK_CLASS=esi
-    - NETWORK_STEPS_COLLECTION=massopencloud.steps
+    - NETWORK_STEPS_COLLECTION=osac.steps
     - EXTERNAL_ACCESS_BASE_DOMAIN=box.massopen.cloud
     - EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS=box.massopen.cloud
     - EXTERNAL_ACCESS_API_INTERNAL_NETWORK=hypershift
@@ -70,7 +70,7 @@ configMapGenerator:
 
 - name: publish-templates-ig
   literals:
-    - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
+    - OSAC_TEMPLATE_COLLECTIONS=osac.templates
     - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 
 images:

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -58,7 +58,7 @@ secretGenerator:
 configMapGenerator:
 - name: publish-templates-ig
   literals:
-    - OSAC_TEMPLATE_COLLECTIONS=osac.templates,osac.massopencloud
+    - OSAC_TEMPLATE_COLLECTIONS=osac.templates
     - OSAC_FULFILLMENT_SERVICE_URI=https://fulfillment-internal-api:8001
 
 images:

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -41,9 +41,9 @@ secretGenerator:
   options:
     disableNameSuffixHash: true
   literals:
-    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-a2b8504
+    - AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:sha-0255559
     - AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap
-    - AAP_PROJECT_GIT_BRANCH=a2b85047c817c432dd8928c7b7861cc3f4f528db
+    - AAP_PROJECT_GIT_BRANCH=025555900172e345a339e81ec0120c3fbe9f2db6
 
 - name: cluster-fulfillment-ig
   options:


### PR DESCRIPTION
## Summary
- Bump `base/osac-aap` submodule to pick up https://github.com/osac-project/osac-aap/pull/309
- Sync CI overlay AAP EE image tags and git branch pins to `sha-0255559`
- Align installer overlay configuration with the collection rename:
  - `massopencloud.steps` → `osac.steps`
  - Remove `osac.massopencloud` from `OSAC_TEMPLATE_COLLECTIONS` (removed from osac-aap in #309)

## Context
The auto bump workflow in osac-aap did not open this PR because the squash merge commit was not associated with PR #309 by the bot lookup.

## Follow-up
MOC-specific templates previously in `osac.massopencloud` will need to be wired in via `osac-massopencloud-templates` as a separate dependency (tracked separately from [OSAC-894](https://redhat.atlassian.net/browse/OSAC-894)).

## Test plan
- [ ] `scripts/sync-image-tags.sh` passes on this branch
- [ ] CI overlays build with `kustomize build overlays/vmaas-ci`

Original PR: https://github.com/osac-project/osac-aap/pull/309
Merge commit: `025555900172e345a339e81ec0120c3fbe9f2db6`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions for fulfillment service, AAP, and operator components.
  * Updated AAP submodule reference.

* **Configuration Updates**
  * Updated default network collection configuration across development and integration environments.
  * Updated template collection defaults to use consolidated naming scheme.
  * Updated documentation to reflect configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-installer/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->