### PR TITLE
fix refresh race: wait for kustomize rollouts before restarting pods

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -253,6 +253,17 @@ wait_aap_controller() {
         echo "Timed out waiting for AAP gateway API to respond"
         exit 1
     }
+    # Recert restarts the kube-apiserver, breaking the controller-task's
+    # in-cluster connections. The pod looks healthy but its scheduler can't
+    # launch jobs via container groups. Recycle the pod for fresh connections.
+    echo "[6/8] Recycling AAP controller-task pod..."
+    oc delete pod -n "${INSTALLER_NAMESPACE}" -l app.kubernetes.io/name=osac-aap-controller-task
+    oc wait pod -n "${INSTALLER_NAMESPACE}" -l app.kubernetes.io/name=osac-aap-controller-task \
+        --for=condition=Ready --timeout=300s
+    retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_ROUTE_HOST}"'/api/gateway/v1/)" == "200" ]]' || {
+        echo "Timed out waiting for AAP gateway after controller-task restart"
+        exit 1
+    }
     echo "[6/8] AAP controller Running, gateway responding"
 }
 

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -203,10 +203,17 @@ for cert in authorino fulfillment-controller fulfillment-grpc-server fulfillment
     oc wait --for=condition=Ready "certificate.cert-manager.io/${cert}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
+# Kustomize apply may have changed deployment images, triggering new rollouts
+# that run DB migrations. Wait for those to finish before restarting pods —
+# otherwise the restart kills pods mid-migration and leaves the DB dirty.
+for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+    oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+    pids+=($!)
+done
 failed=0
 for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
 wait ${pid_cdi} || failed=1
-if (( failed )); then echo "ERROR: TLS certificates not ready"; exit 1; fi
+if (( failed )); then echo "ERROR: TLS certificates or fulfillment rollouts not ready"; exit 1; fi
 echo "[4/8] TLS certificates ready, restarting fulfillment pods..."
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"


### PR DESCRIPTION
## Summary

Fixes a race condition in `refresh-after-snapshot.sh` where `oc rollout restart` in step [4/8] kills pods that were started by the kustomize apply in step [3/8], interrupting in-flight
DB migrations and leaving the database in a dirty state.

**What happens:**
1. Step [3/8] `oc apply -k` changes the fulfillment-service image → Kubernetes creates new pods that start running DB migration N
2. Step [4/8] waits for TLS certs, then does `oc rollout restart` → kills those pods mid-migration
3. DB is now `version: N, dirty: true` → every subsequent pod crashes with "Dirty database version N"
4. CrashLoopBackOff → rollout timeout → job fails

**Evidence from [this CI
run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/osac-project_osac-test-infra/45/pull-ci-osac-project-osac-test-infra-main-e2e-vmaas/2059314366636888064):**
- Old pod (from snapshot): `"version":43,"dirty":false` — clean
- First new pod (from kustomize apply): started migration 44, killed after ~1 second by `rollout restart`
- Second new pod (from restart): `"version":44,"dirty":true` → `Dirty database version 44. Fix and force version.` → CrashLoopBackOff

**Fix:** Wait for kustomize-triggered rollouts in parallel with the TLS cert waits, so migrations complete before the restart. Zero duration impact since both wait groups overlap.

## Test plan

- [ ] Retrigger the failing CI job on osac-test-infra PR #45 with this installer change
- [ ] Verify fulfillment-grpc-server completes migration before restart
- [ ] Verify no dirty DB state after refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Post-snapshot refresh now waits for fulfillment service rollouts in parallel with TLS certificate readiness, reducing deployment flakiness and ensuring services become available before continuing.
  * Improved restart flow for the AAP controller: the controller is restarted and awaited to be ready before re-checking the gateway, with clearer timeout/error messaging for post-restart gateway checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-installer/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->