### PR TITLE
OSAC-837: add PublicIPAttachment RBAC for hub-access

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -142,6 +142,24 @@ rules:
       - publicips/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicipattachments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - publicipattachments/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

[OSAC-837](https://redhat.atlassian.net/browse/OSAC-837): Grant the hub-access ClusterRole permissions for publicipattachments and
publicipattachments/status so the fulfillment-service can manage PublicIPAttachment
CRs on the hub cluster.

## Why

The fulfillment-service reconciler needs Kubernetes RBAC permissions to create, watch,
and manage PublicIPAttachment CRs. Without these entries, the reconciler would get
403 Forbidden errors when trying to sync attachments to the cluster.

## Testing

```bash
# Verify kustomize build still works
kustomize build base/
```

YAML-only change following the exact pattern used by publicips and publicippools entries.

## Related PRs

- osac-project/osac-operator#267: [OSAC-837](https://redhat.atlassian.net/browse/OSAC-837) feedback controller
- osac-project/fulfillment-service: [OSAC-837](https://redhat.atlassian.net/browse/OSAC-837) OPA authconfig entries

## Ticket

[OSAC-837](https://redhat.atlassian.net/browse/OSAC-837)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated access control policies to grant additional permissions for managing public IP attachments, including create, delete, read, update, and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->