### PR TITLE
NO-ISSUE: Pass INSTALLER_NAMESPACE to post-deploy scripts in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -320,13 +320,13 @@ wait_for_resource deployment/fulfillment-ingress-proxy condition=Available 300 $
 oc project ${INSTALLER_NAMESPACE}
 
 # Create AAP API token for the OSAC operator
-./scripts/prepare-aap.sh
+INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-aap.sh
 
 # Setup OSAC CLI, register hub
-./scripts/prepare-fulfillment-service.sh
+INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-fulfillment-service.sh
 
 # Prepare tenant
-./scripts/prepare-tenant.sh
+INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-tenant.sh
 
 echo ""
 echo "=== Setup complete ==="


### PR DESCRIPTION
## Summary
- Pass `INSTALLER_NAMESPACE` explicitly to `prepare-aap.sh`, `prepare-fulfillment-service.sh`, and `prepare-tenant.sh` in `setup.sh`
- Without this, the scripts fall back to grepping the kustomize overlay file for the namespace, which fails or returns the wrong value in `DEPLOY_MODE=helm`
- Matches the pattern already used for `aap-configuration.sh` (line 292)

## Test plan
- [ ] Run `DEPLOY_MODE=helm INSTALLER_NAMESPACE=osac-e2e-ci ./scripts/setup.sh` and verify post-deploy scripts use the correct namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced setup script to properly pass environment variables to preparation steps during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-installer/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->