### PR TITLE
NO_ISSUE: fix three boot failure patterns in refresh script

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -46,12 +46,28 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; th
     done
     [[ -z "${JT_ID:-}" ]] && { echo "Failed to find osac-publish-templates AAP job template after 30 attempts"; exit 1; }
     echo "Launching publish-templates AAP job (template ID: ${JT_ID})..."
+    JOB_ID=""
     for attempt in $(seq 1 10); do
-        curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
-            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" >/dev/null 2>&1 && break
+        JOB_RESPONSE=$(curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" 2>/dev/null) && {
+            JOB_ID=$(echo "${JOB_RESPONSE}" | jq -r '.id // empty')
+            break
+        }
         echo "  launch attempt ${attempt}/10 - retrying in 10s..."
         sleep 10
     done
+    [[ -z "${JOB_ID}" ]] && { echo "ERROR: Failed to launch publish-templates job after 10 attempts"; exit 1; }
+    echo "  Job ${JOB_ID} launched, waiting for completion..."
+    retry_until 300 10 '[[ "$(curl -kfsS -H "Authorization: Bearer '"${AAP_TOKEN}"'" \
+        "'"${AAP_URL}"'/api/controller/v2/jobs/'"${JOB_ID}"'/" 2>/dev/null \
+        | jq -r ".status // empty")" =~ ^(successful|failed|error|canceled)$ ]]' || true
+    JOB_STATUS=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/" 2>/dev/null | jq -r '.status // empty') || JOB_STATUS=""
+    if [[ "${JOB_STATUS}" != "successful" ]]; then
+        echo "WARNING: publish-templates job ${JOB_ID} finished with status: ${JOB_STATUS}"
+        curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
+            "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/stdout/?format=txt" 2>/dev/null | tail -30 || true
+    fi
 
     if [[ -n "${INSTALLER_VM_TEMPLATE}" ]]; then
         echo "Waiting for computeinstancetemplate ${INSTALLER_VM_TEMPLATE} to be published..."

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -175,6 +175,21 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
+PULL_SECRET="/installer/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
+img_check_pids=()
+img_check_imgs=()
+img_check_logs=()
+while IFS= read -r img; do
+    [[ -z "${img}" ]] && continue
+    img_check_imgs+=("${img}")
+    log_file="$(mktemp)"
+    img_check_logs+=("${log_file}")
+    oc image info "${img}" -a "${PULL_SECRET}" &>"${log_file}" &
+    img_check_pids+=($!)
+done < <(oc get deploy,statefulset -n "${INSTALLER_NAMESPACE}" \
+    -o jsonpath='{range .items[*]}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{end}' \
+    | sort -u | grep 'ghcr\.io/osac-project')
+
 # After recert, cert-manager reissues TLS certificates with the new cluster CA.
 # Pods that start before certs are ready crash loading the CA file. Wait for all
 # certificates to be reissued, then restart pods so they mount fresh secrets.
@@ -206,6 +221,25 @@ refresh_cdi_certificates() {
     echo "  CDI certificates refreshed"
 }
 
+refresh_metallb_certificates() {
+    # After recert, the MetalLB webhook server still has certs signed by the old
+    # CA. Delete the OLM-managed cert secret so it gets regenerated, then restart
+    # the webhook server pod to pick up the new cert.
+    if ! oc get crd ipaddresspools.metallb.io &>/dev/null; then
+        return 0
+    fi
+    echo "  Refreshing MetalLB webhook certificates..."
+    oc delete secret metallb-operator-webhook-server-cert -n metallb-system --ignore-not-found
+    oc delete pod -n metallb-system -l control-plane=controller-manager --ignore-not-found 2>/dev/null || true
+    oc delete pod -n metallb-system -l component=webhook-server --ignore-not-found 2>/dev/null || true
+    retry_until 120 5 '[[ "$(oc get deploy metallb-operator-webhook-server -n metallb-system -o jsonpath='"'"'{.status.readyReplicas}'"'"' 2>/dev/null)" == "1" ]]' || {
+        echo "WARNING: MetalLB webhook server did not become ready, continuing anyway"
+    }
+    echo "  MetalLB webhook certificates refreshed"
+}
+
+refresh_metallb_certificates
+
 echo "[4/9] Reconfiguring MetalLB for current subnet..."
 if oc get crd ipaddresspools.metallb.io &>/dev/null; then
     NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
@@ -225,6 +259,14 @@ METALLBEOF
 else
     echo "  MetalLB not installed, skipping"
 fi
+
+for i in "${!img_check_pids[@]}"; do
+    if ! wait "${img_check_pids[$i]}"; then
+        echo "ERROR: Image preflight failed for: ${img_check_imgs[$i]}"
+        tail -5 "${img_check_logs[$i]}" 2>/dev/null || true
+        exit 1
+    fi
+done
 
 echo "[5/9] Waiting for TLS certificates and restarting pods..."
 refresh_cdi_certificates &
@@ -306,6 +348,10 @@ wait_aap_controller() {
         echo "Timed out waiting for AAP gateway after controller-task restart"
         exit 1
     }
+    # Component overrides can trigger AAP operator reconciliation that creates a
+    # new controller-task pod AFTER our recycle. Wait for the deployment to
+    # stabilize so we don't launch jobs on a half-ready pod.
+    oc rollout status deploy/osac-aap-controller-task -n "${INSTALLER_NAMESPACE}" --timeout=300s
     echo "[7/9] AAP controller Running, gateway responding"
 }
 


### PR DESCRIPTION
## Summary

Addresses 66% of CI boot failures (52 failures in 7 days across all OSAC repos):

- **MetalLB webhook TLS (13%)**: After recert rotates the cluster CA, the MetalLB webhook server still has certs signed by the old CA, causing x509 errors when patching the IPAddressPool. Adds cert rotation before the patch, following the existing CDI pattern.
- **Image availability check (13%)**: After kustomize apply, verifies all deployment/statefulset images exist in the registry (parallel checks). Fails immediately if any image is missing instead of waiting for rollout timeouts. Checks run in background during MetalLB cert refresh and are collected before step [5/9].
- **AAP template publishing timeout (40%)**: Component image overrides trigger AAP operator reconciliation that creates a new controller-task pod *after* the refresh script's recycle at step [7/9]. Adds `oc rollout status` on the deployment to catch second rollouts. In `prepare-fulfillment-service.sh`, replaces fire-and-forget job launch with status-aware polling — captures job ID, waits for completion, logs stdout on failure.

## Test plan

- [x] `bash -n` syntax check passes on both scripts
- [ ] CI e2e-vmaas passes with these changes
- [ ] Monitor ci-obs for reduced BOOT failure rates over the next few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job execution: enhanced retrying, launch tracking, active completion polling, status warnings, and log tailing
  * Added pre-flight container image availability checks with concurrent validation to fail fast on missing images

* **Chores**
  * Automated certificate refresh and webhook pod restart after recertification
  * Ensured controller-task rollout readiness before proceeding to avoid premature operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->