### PR TITLE
OSAC-1071: add centralized submodule bump workflow

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -15,33 +15,39 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.OSAC_BOT_PAT }}
 
-      - name: Find latest commits with published images
+      - name: Check latest commits have published images
         id: find
         env:
           GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
         run: |
-          find_latest_with_image() {
+          set -euo pipefail
+
+          check_image() {
             local repo=$1
             local image=$2
-
-            TOKEN=$(curl -sf "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
-
-            for sha in $(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=20" --jq '.[].sha'); do
-              tag="sha-${sha:0:7}"
-              code=$(curl -s -o /dev/null -w "%{http_code}" \
-                -H "Authorization: Bearer ${TOKEN}" \
-                "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
-              if [[ "${code}" == "200" ]]; then
-                echo "${sha}"
-                return 0
-              fi
-            done
-            return 1
+            local sha
+            sha=$(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=1" --jq '.[0].sha')
+            local tag="sha-${sha:0:7}"
+            local token
+            token=$(curl -sf "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
+            local code
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
+            if [[ "${code}" != "200" ]]; then
+              echo "ERROR: ${repo} latest main commit ${sha:0:7} has no published image (tag ${tag})" >&2
+              return 1
+            fi
+            echo "${sha}"
           }
 
-          echo "operator=$(find_latest_with_image osac-operator osac-operator)" >> "$GITHUB_OUTPUT"
-          echo "fulfillment=$(find_latest_with_image fulfillment-service fulfillment-service)" >> "$GITHUB_OUTPUT"
-          echo "aap=$(find_latest_with_image osac-aap osac-aap)" >> "$GITHUB_OUTPUT"
+          OPERATOR=$(check_image osac-operator osac-operator)
+          FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
+          AAP=$(check_image osac-aap osac-aap)
+
+          echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
+          echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
+          echo "aap=${AAP}" >> "$GITHUB_OUTPUT"
 
       - name: Update submodules
         id: update
@@ -53,10 +59,6 @@ jobs:
             local path=$1
             local name=$2
             local target=$3
-            if [[ -z "${target}" ]]; then
-              echo "WARNING: no image found for ${name}, skipping"
-              return
-            fi
             local current
             current=$(git -C "${path}" rev-parse HEAD)
             if [[ "${current}" == "${target}" ]]; then
@@ -77,12 +79,15 @@ jobs:
           update_submodule base/osac-aap osac-aap "${{ steps.find.outputs.aap }}"
 
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
-          # Write summary to file to preserve newlines
           echo -e "${summary}" > /tmp/bump-summary.txt
 
       - name: Sync image tags
         if: steps.update.outputs.changed == 'true'
         run: ./scripts/sync-image-tags.sh --fix
+
+      - name: Sync AuthConfig Rego
+        if: steps.update.outputs.changed == 'true'
+        run: pip install pyyaml && python3 scripts/sync-authconfig-rego.py --fix
 
       - name: Create or update PR
         if: steps.update.outputs.changed == 'true'
@@ -100,7 +105,7 @@ jobs:
           if [[ -n "${EXISTING}" ]]; then
             echo "Updated existing PR #${EXISTING}"
           else
-            BODY=$(cat <<'BODY_EOF'
+            BODY=$(cat <<BODY_EOF
           ## Automated submodule bump
 
           $(cat /tmp/bump-summary.txt)

--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -1,0 +1,117 @@
+name: Bump submodules
+
+on:
+  schedule:
+    - cron: '17 */3 * * *'
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+          token: ${{ secrets.OSAC_BOT_PAT }}
+
+      - name: Find latest commits with published images
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+        run: |
+          find_latest_with_image() {
+            local repo=$1
+            local image=$2
+
+            TOKEN=$(curl -sf "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
+
+            for sha in $(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=20" --jq '.[].sha'); do
+              tag="sha-${sha:0:7}"
+              code=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
+              if [[ "${code}" == "200" ]]; then
+                echo "${sha}"
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          echo "operator=$(find_latest_with_image osac-operator osac-operator)" >> "$GITHUB_OUTPUT"
+          echo "fulfillment=$(find_latest_with_image fulfillment-service fulfillment-service)" >> "$GITHUB_OUTPUT"
+          echo "aap=$(find_latest_with_image osac-aap osac-aap)" >> "$GITHUB_OUTPUT"
+
+      - name: Update submodules
+        id: update
+        run: |
+          changed=false
+          summary=""
+
+          update_submodule() {
+            local path=$1
+            local name=$2
+            local target=$3
+            if [[ -z "${target}" ]]; then
+              echo "WARNING: no image found for ${name}, skipping"
+              return
+            fi
+            local current
+            current=$(git -C "${path}" rev-parse HEAD)
+            if [[ "${current}" == "${target}" ]]; then
+              echo "${name}: already at ${target:0:7}"
+              return
+            fi
+            git -C "${path}" fetch origin
+            git -C "${path}" checkout "${target}"
+            changed=true
+            local count
+            count=$(git -C "${path}" rev-list --count "${current}..${target}" 2>/dev/null || echo "?")
+            summary="${summary}- **${name}**: ${current:0:7} → ${target:0:7} (${count} commits)\n"
+            echo "${name}: ${current:0:7} -> ${target:0:7}"
+          }
+
+          update_submodule base/osac-operator osac-operator "${{ steps.find.outputs.operator }}"
+          update_submodule base/osac-fulfillment-service fulfillment-service "${{ steps.find.outputs.fulfillment }}"
+          update_submodule base/osac-aap osac-aap "${{ steps.find.outputs.aap }}"
+
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+          # Write summary to file to preserve newlines
+          echo -e "${summary}" > /tmp/bump-summary.txt
+
+      - name: Sync image tags
+        if: steps.update.outputs.changed == 'true'
+        run: ./scripts/sync-image-tags.sh --fix
+
+      - name: Create or update PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+        run: |
+          BRANCH="auto/bump-submodules"
+          git config user.name "osac-dev-bot"
+          git config user.email "osac-dev-bot@users.noreply.github.com"
+          git add -A
+          git commit -m "bump submodules to latest with published images"
+          git push origin "HEAD:${BRANCH}" --force
+
+          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
+          if [[ -n "${EXISTING}" ]]; then
+            echo "Updated existing PR #${EXISTING}"
+          else
+            BODY=$(cat <<'BODY_EOF'
+          ## Automated submodule bump
+
+          $(cat /tmp/bump-summary.txt)
+
+          Only bumps to commits that have a published container image in GHCR.
+          Runs every 3 hours via [bump-submodules workflow](../actions/workflows/bump-submodules.yaml).
+          BODY_EOF
+          )
+            gh pr create \
+              --title "bump submodules" \
+              --body "${BODY}" \
+              --base main \
+              --head "${BRANCH}"
+          fi


### PR DESCRIPTION
## Summary

Replace the three independent per-repo bump-osac-installer.yaml workflows with a single centralized workflow in osac-installer.

### Problems with the current approach

1. **Bump without image**: The bump and image-build workflows are independent. When the image build fails (e.g. unit tests fail post-merge), the submodule is bumped to a commit whose container image was never published. This causes ImagePullBackOff in every subsequent CI run. Evidence: osac-operator PR #260 — image build failed, bump succeeded, broke osac-installer main.

2. **PR pile-up and conflicts**: Each repo creates its own bump PR. When multiple PRs merge close together, they conflict on kustomization.yaml and pile up.

3. **One PR per merge**: Every single merge creates a separate bump PR, even for trivial changes. Noise and merge fatigue.

### How the new workflow works

- Runs every 3 hours (and on manual dispatch)
- For each submodule, walks recent main commits and finds the latest one with a published container image in GHCR — never bumps to a missing image
- Updates all submodules + runs sync-image-tags.sh --fix in one PR
- Force-pushes to auto/bump-submodules — always exactly one open bump PR, no pile-up

### Follow-up

After this is working, remove the per-repo bump-osac-installer.yaml workflows from osac-operator, fulfillment-service, and osac-aap.

## Test plan

- [ ] Trigger workflow manually via workflow_dispatch
- [ ] Verify it finds the correct latest commits with images
- [ ] Verify it creates a PR with updated submodules + synced image tags
- [ ] Verify re-running force-pushes to the same PR instead of creating a new one

[OSAC-1071](https://redhat.atlassian.net/browse/OSAC-1071)

Co-Authored-By: Claude Code