### PR TITLE
NO-ISSUE: Fix wrong pull secret file path in refresh-after-snapshot.sh script

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -175,7 +175,9 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
-PULL_SECRET="/installer/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+PULL_SECRET="${REPO_ROOT}/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
+[[ -f "${PULL_SECRET}" ]] || { echo "ERROR: Pull secret not found: ${PULL_SECRET}" >&2; exit 1; }
 img_check_pids=()
 img_check_imgs=()
 img_check_logs=()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script to resolve image pull secret location relative to the current working directory instead of using a fixed absolute path, improving flexibility for different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->