### PR TITLE
OSAC-1155: fix CI boot failures in refresh script

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -37,7 +37,7 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; th
     AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
     AAP_URL="https://${AAP_ROUTE_HOST}"
     AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
-    echo "Waiting for AAP controller API to be ready..."
+    echo "Waiting for AAP controller API and project sync..."
     for attempt in $(seq 1 30); do
         JT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
             "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates" 2>/dev/null | jq -er '.results[0].id // empty' 2>/dev/null) && break
@@ -45,18 +45,31 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; th
         sleep 10
     done
     [[ -z "${JT_ID:-}" ]] && { echo "Failed to find osac-publish-templates AAP job template after 30 attempts"; exit 1; }
+    PROJECT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/" 2>/dev/null | jq -r '.project // empty') || PROJECT_ID=""
+    if [[ -n "${PROJECT_ID}" ]]; then
+        echo "  Waiting for AAP project ${PROJECT_ID} to sync..."
+        retry_until 300 10 '[[ "$(curl -kfsS -H "Authorization: Bearer '"${AAP_TOKEN}"'" \
+            "'"${AAP_URL}"'/api/controller/v2/projects/'"${PROJECT_ID}"'/" 2>/dev/null \
+            | jq -r ".status // empty")" == "successful" ]]' || {
+            echo "WARNING: AAP project sync may not be complete"
+        }
+    fi
     echo "Launching publish-templates AAP job (template ID: ${JT_ID})..."
     JOB_ID=""
     for attempt in $(seq 1 10); do
-        JOB_RESPONSE=$(curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
-            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" 2>/dev/null) && {
+        LAUNCH_ERR=$(mktemp)
+        JOB_RESPONSE=$(curl -ksS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" 2>"${LAUNCH_ERR}") && {
             JOB_ID=$(echo "${JOB_RESPONSE}" | jq -r '.id // empty')
-            break
+            [[ -n "${JOB_ID}" && "${JOB_ID}" != "null" ]] && break
         }
         echo "  launch attempt ${attempt}/10 - retrying in 10s..."
+        HTTP_BODY=$(echo "${JOB_RESPONSE}" | jq -r '.playbook[0] // .detail // empty' 2>/dev/null)
+        [[ -n "${HTTP_BODY}" ]] && echo "    reason: ${HTTP_BODY}"
         sleep 10
     done
-    [[ -z "${JOB_ID}" ]] && { echo "ERROR: Failed to launch publish-templates job after 10 attempts"; exit 1; }
+    [[ -z "${JOB_ID}" || "${JOB_ID}" == "null" ]] && { echo "ERROR: Failed to launch publish-templates job after 10 attempts"; exit 1; }
     echo "  Job ${JOB_ID} launched, waiting for completion..."
     retry_until 300 10 '[[ "$(curl -kfsS -H "Authorization: Bearer '"${AAP_TOKEN}"'" \
         "'"${AAP_URL}"'/api/controller/v2/jobs/'"${JOB_ID}"'/" 2>/dev/null \

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -175,7 +175,7 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
-PULL_SECRET="/installer/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
+PULL_SECRET="${SCRIPT_DIR}/../overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
 img_check_pids=()
 img_check_imgs=()
 img_check_logs=()
@@ -212,12 +212,16 @@ refresh_cdi_certificates() {
         oc delete secret "${secret}" -n openshift-cnv --ignore-not-found
     done
     oc delete pod -n openshift-cnv -l app=cdi-operator --ignore-not-found
-    oc rollout status deploy/cdi-operator -n openshift-cnv --timeout=300s
+    retry_command 300 10 oc rollout status deploy/cdi-operator -n openshift-cnv --timeout=120s
     for deploy in cdi-deployment cdi-apiserver cdi-uploadproxy; do
         oc rollout restart "deploy/${deploy}" -n openshift-cnv 2>/dev/null || true
     done
-    oc rollout status deploy/cdi-deployment -n openshift-cnv --timeout=300s
-    oc rollout status deploy/cdi-apiserver -n openshift-cnv --timeout=300s
+    retry_command 300 10 oc rollout status deploy/cdi-deployment -n openshift-cnv --timeout=120s &
+    local pid_cdi_deploy=$!
+    retry_command 300 10 oc rollout status deploy/cdi-apiserver -n openshift-cnv --timeout=120s &
+    local pid_cdi_api=$!
+    wait ${pid_cdi_deploy}
+    wait ${pid_cdi_api}
     echo "  CDI certificates refreshed"
 }
 
@@ -232,8 +236,8 @@ refresh_metallb_certificates() {
     oc delete secret metallb-operator-webhook-server-cert -n metallb-system --ignore-not-found
     oc delete pod -n metallb-system -l control-plane=controller-manager --ignore-not-found 2>/dev/null || true
     oc delete pod -n metallb-system -l component=webhook-server --ignore-not-found 2>/dev/null || true
-    retry_until 120 5 '[[ "$(oc get deploy metallb-operator-webhook-server -n metallb-system -o jsonpath='"'"'{.status.readyReplicas}'"'"' 2>/dev/null)" == "1" ]]' || {
-        echo "WARNING: MetalLB webhook server did not become ready, continuing anyway"
+    retry_until 120 5 '[[ -n "$(oc get endpoints metallb-operator-webhook-server-service -n metallb-system -o jsonpath='"'"'{.subsets[*].addresses[*].ip}'"'"' 2>/dev/null)" ]]' || {
+        echo "WARNING: MetalLB webhook service has no endpoints, continuing anyway"
     }
     echo "  MetalLB webhook certificates refreshed"
 }
@@ -245,7 +249,8 @@ if oc get crd ipaddresspools.metallb.io &>/dev/null; then
     NODE_IP=$(oc get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
     SUBNET_PREFIX=$(echo "${NODE_IP}" | cut -d. -f1-3)
     echo "  Node IP: ${NODE_IP}, configuring pool: ${SUBNET_PREFIX}.240-${SUBNET_PREFIX}.250"
-    cat <<METALLBEOF | oc apply -f -
+    METALLB_YAML=$(mktemp)
+    cat > "${METALLB_YAML}" <<METALLBEOF
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -256,6 +261,7 @@ spec:
     - ${SUBNET_PREFIX}.240-${SUBNET_PREFIX}.250
   autoAssign: true
 METALLBEOF
+    retry_command 120 10 oc apply -f "${METALLB_YAML}"
 else
     echo "  MetalLB not installed, skipping"
 fi


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/OSAC-1155

Follow-up to PR #206. Addresses remaining boot failure patterns found in post-merge CI analysis:

- **MetalLB webhook TLS**: Wait for Service endpoints (not just pod readiness) before patching IPAddressPool. Fixes race where pod is Ready but Service has no endpoints yet.
- **AAP publish-templates**: Wait for AAP project sync before launching job. Log HTTP error body on launch failure (was silently swallowed by `2>/dev/null`). Fixes `Missing a revision to run due to failed project update` errors.
- **CDI rollout retry**: Wrap `oc rollout status` calls with `retry_command` to handle transient API server timeouts under load. Run CDI deployment waits in parallel instead of sequentially.

## Test plan

- [x] `bash -n` syntax check passes on both scripts
- [ ] CI e2e-vmaas passes
- [ ] Monitor ci-obs for reduced BOOT failure rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Waits for controller API and associated project sync before launching publish jobs.
  * Hardened job launch flow with stronger validation, logging of failure reasons, and bounded retry behavior (fails after 10 attempts if unresolved).
  * More robust readiness checks using concurrent waits and endpoint-based validation for load‑balancer webhook.
  * Updated pull-secret path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->