### PR TITLE
NO-ISSUE: Ensure Authorino tokenreview RBAC for deployment namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,23 @@ Use Kustomize to manage your environment-specific configurations.
      ```
      emergency_service_accounts := {
        "system:serviceaccount:<project-name>:admin",
+       "system:serviceaccount:<project-name>:controller",
+       "system:serviceaccount:<project-name>:template-publisher",
+       "system:serviceaccount:<project-name>:osac-operator-controller-manager",
      }
      ```
      If this is not updated, the `admin` ServiceAccount will get `PermissionDenied` errors
      when calling private API methods (e.g., hub registration during `setup.sh`).
+   - The `authorino-tokenreview` ClusterRoleBinding grants Authorino permission to
+     validate Kubernetes service account tokens. It must include your namespace's
+     Authorino SA. **If using `setup.sh`**, this is handled automatically.
+     **If deploying manually**, patch the ClusterRoleBinding:
+     ```bash
+     oc patch clusterrolebinding authorino-tokenreview --type=json -p '[
+       {"op":"add","path":"/subjects/-","value":{"kind":"ServiceAccount","name":"authorino-authorino","namespace":"<project-name>"}}
+     ]'
+     ```
+     If this is not configured, all gRPC calls will fail with `Unauthenticated` errors.
    - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
      value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
      You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -312,6 +312,16 @@ fi
 # Wait for Authorino to be ready (gRPC auth depends on it)
 wait_for_resource deployment/authorino condition=Available 300 ${INSTALLER_NAMESPACE}
 
+# Ensure Authorino can perform token reviews (required for Kubernetes SA authentication)
+if oc get clusterrolebinding authorino-tokenreview &>/dev/null; then
+    if ! oc get clusterrolebinding authorino-tokenreview -o json | \
+        jq -e '.subjects[] | select(.name=="authorino-authorino" and .namespace=="'"${INSTALLER_NAMESPACE}"'")' &>/dev/null; then
+        echo "Adding ${INSTALLER_NAMESPACE} Authorino SA to authorino-tokenreview ClusterRoleBinding..."
+        oc patch clusterrolebinding authorino-tokenreview --type=json \
+            -p '[{"op":"add","path":"/subjects/-","value":{"kind":"ServiceAccount","name":"authorino-authorino","namespace":"'"${INSTALLER_NAMESPACE}"'"}}]'
+    fi
+fi
+
 # Wait for fulfillment stack to be ready before running prepare scripts
 wait_for_resource deployment/fulfillment-grpc-server condition=Available 300 ${INSTALLER_NAMESPACE}
 wait_for_resource deployment/fulfillment-ingress-proxy condition=Available 300 ${INSTALLER_NAMESPACE}


### PR DESCRIPTION
## Summary
- The `authorino-tokenreview` ClusterRoleBinding grants Authorino the `system:auth-delegator` role, which it needs to call the Kubernetes TokenReview API and validate service account tokens
- On shared clusters, this ClusterRoleBinding is created once and only contains the Authorino SA from the original namespace (e.g., `osac-devel`). When deploying OSAC to a different namespace, Authorino in that namespace lacks this permission and cannot authenticate any Kubernetes SA tokens
- This causes all gRPC calls using SA tokens to fail with `Unauthenticated` — including the hub registration step in `setup.sh`, which retries for 5 minutes before timing out
- Adds an idempotent step to `setup.sh` that patches the ClusterRoleBinding to include the deployment namespace's Authorino SA if not already present
- Documents both the `authorino-tokenreview` requirement and the full list of `emergency_service_accounts` SAs that need namespace updates in the README