### PR TITLE
OSAC-874: Remove EDA operator config and bump osac-operator submodule

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -32,7 +32,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-be521ed
+  newTag: sha-8c16fb9
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -32,7 +32,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-8c16fb9
+  newTag: sha-0217b64
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -27,10 +27,10 @@ images:
   newName: quay.io/sclorg/postgresql-18-c10s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-fef4d36
+  newTag: sha-1528878
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
-  newTag: sha-f9209f1
+  newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
   newTag: sha-be521ed
 - name: envoy

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -32,7 +32,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-50d1f27
+  newTag: sha-be521ed
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -27,10 +27,10 @@ images:
   newName: quay.io/sclorg/postgresql-18-c10s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-1528878
+  newTag: sha-fef4d36
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
-  newTag: sha-e2fd241
+  newTag: sha-f9209f1
 - name: ghcr.io/osac-project/osac-operator
   newTag: sha-be521ed
 - name: envoy

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -32,7 +32,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-b613d8d
+  newTag: sha-50d1f27
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -46,17 +46,6 @@
           "minimum": 1,
           "default": 1
         },
-        "provisioning": {
-          "type": "object",
-          "properties": {
-            "provider": {
-              "type": "string",
-              "description": "Provisioning provider",
-              "enum": ["aap", "eda"],
-              "default": "aap"
-            }
-          }
-        },
         "aap": {
           "type": "object",
           "description": "AAP connection settings for the operator",

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -19,8 +19,6 @@ operator:
     requests:
       cpu: 10m
       memory: 64Mi
-  provisioning:
-    provider: "aap"
   aap:
     url: ""
     token: ""

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -122,11 +122,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_MINIMUM_REQUEST_INTERVAL
-          value: "2m"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: OSAC_AAP_TOKEN
           valueFrom:
             secretKeyRef:

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -183,7 +183,6 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-e2e-ci:admin",
-                  "system:serviceaccount:osac-e2e-ci:controller",
                   "system:serviceaccount:osac-e2e-ci:template-publisher",
                   "system:serviceaccount:osac-e2e-ci:osac-operator-controller-manager",
                 }
@@ -367,6 +366,10 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
+                    "/osac.public.v1.PublicIPAttachments/Create",
+                    "/osac.public.v1.PublicIPAttachments/Delete",
+                    "/osac.public.v1.PublicIPAttachments/Get",
+                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -183,6 +183,7 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-e2e-ci:admin",
+                  "system:serviceaccount:osac-e2e-ci:controller",
                   "system:serviceaccount:osac-e2e-ci:template-publisher",
                   "system:serviceaccount:osac-e2e-ci:osac-operator-controller-manager",
                 }
@@ -366,10 +367,6 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
-                    "/osac.public.v1.PublicIPAttachments/Create",
-                    "/osac.public.v1.PublicIPAttachments/Delete",
-                    "/osac.public.v1.PublicIPAttachments/Get",
-                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -125,11 +125,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_PROVISIONING_PROVIDER
-          value: "aap"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: OSAC_AAP_TEMPLATE_PREFIX
           value: osac
       - op: add
@@ -156,11 +151,6 @@ patches:
         value:
           name: OSAC_AAP_STATUS_POLL_INTERVAL
           value: "30s"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_MINIMUM_REQUEST_INTERVAL
-          value: "2m"
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -201,7 +201,6 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-devel:admin",
-                  "system:serviceaccount:osac-devel:controller",
                   "system:serviceaccount:osac-devel:template-publisher",
                   "system:serviceaccount:osac-devel:osac-operator-controller-manager",
                 }
@@ -385,6 +384,10 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
+                    "/osac.public.v1.PublicIPAttachments/Create",
+                    "/osac.public.v1.PublicIPAttachments/Delete",
+                    "/osac.public.v1.PublicIPAttachments/Get",
+                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -201,6 +201,7 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-devel:admin",
+                  "system:serviceaccount:osac-devel:controller",
                   "system:serviceaccount:osac-devel:template-publisher",
                   "system:serviceaccount:osac-devel:osac-operator-controller-manager",
                 }
@@ -384,10 +385,6 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
-                    "/osac.public.v1.PublicIPAttachments/Create",
-                    "/osac.public.v1.PublicIPAttachments/Delete",
-                    "/osac.public.v1.PublicIPAttachments/Get",
-                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/hypershift2/kustomization.yaml
+++ b/overlays/hypershift2/kustomization.yaml
@@ -20,16 +20,20 @@ patches:
             containers:
             - name: manager
               env:
-              - name: OSAC_CLUSTER_CREATE_WEBHOOK
-                value: http://osac-eda-service:5000/create-hosted-cluster
-              - name: OSAC_CLUSTER_DELETE_WEBHOOK
-                value: http://osac-eda-service:5000/delete-hosted-cluster
-              - name: OSAC_VM_CREATE_WEBHOOK
-                value: http://osac-eda-service:5000/create-vm
-              - name: OSAC_VM_DELETE_WEBHOOK
-                value: http://osac-eda-service:5000/delete-vm
-              - name: OSAC_MINIMUM_REQUEST_INTERVAL
-                value: "2m"
+              - name: OSAC_AAP_TEMPLATE_PREFIX
+                value: osac
+              - name: OSAC_AAP_URL
+                value: "https://osac-aap-osac.apps.hypershift2.nerc.mghpcc.org/api/controller"
+              - name: OSAC_AAP_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: osac-aap-api-token
+                    key: token
+                    optional: true
+              - name: OSAC_AAP_INSECURE_SKIP_VERIFY
+                value: "true"
+              - name: OSAC_AAP_STATUS_POLL_INTERVAL
+                value: "30s"
               - name: OSAC_FULFILLMENT_SERVER_ADDRESS
                 value: fulfillment-internal-api:8001
 

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -162,11 +162,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_PROVISIONING_PROVIDER
-          value: "aap"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: OSAC_AAP_TEMPLATE_PREFIX
           value: osac
       - op: add
@@ -193,11 +188,6 @@ patches:
         value:
           name: OSAC_AAP_STATUS_POLL_INTERVAL
           value: "30s"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: OSAC_MINIMUM_REQUEST_INTERVAL
-          value: "2m"
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -255,7 +255,6 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-integration:admin",
-                  "system:serviceaccount:osac-integration:controller",
                   "system:serviceaccount:osac-integration:template-publisher",
                   "system:serviceaccount:osac-integration:osac-operator-controller-manager",
                 }
@@ -439,6 +438,10 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
+                    "/osac.public.v1.PublicIPAttachments/Create",
+                    "/osac.public.v1.PublicIPAttachments/Delete",
+                    "/osac.public.v1.PublicIPAttachments/Get",
+                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -255,6 +255,7 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-integration:admin",
+                  "system:serviceaccount:osac-integration:controller",
                   "system:serviceaccount:osac-integration:template-publisher",
                   "system:serviceaccount:osac-integration:osac-operator-controller-manager",
                 }
@@ -438,10 +439,6 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
-                    "/osac.public.v1.PublicIPAttachments/Create",
-                    "/osac.public.v1.PublicIPAttachments/Delete",
-                    "/osac.public.v1.PublicIPAttachments/Get",
-                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -110,11 +110,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: OSAC_MINIMUM_REQUEST_INTERVAL
-          value: "2m"
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: OSAC_AAP_TOKEN
           valueFrom:
             secretKeyRef:

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -171,7 +171,6 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-e2e-ci:admin",
-                  "system:serviceaccount:osac-e2e-ci:controller",
                   "system:serviceaccount:osac-e2e-ci:template-publisher",
                   "system:serviceaccount:osac-e2e-ci:osac-operator-controller-manager",
                 }
@@ -355,6 +354,10 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
+                    "/osac.public.v1.PublicIPAttachments/Create",
+                    "/osac.public.v1.PublicIPAttachments/Delete",
+                    "/osac.public.v1.PublicIPAttachments/Get",
+                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -171,6 +171,7 @@ patches:
                 # of emergency situations where it isn't possible to get a valid JWT token from the identity provider.
                 emergency_service_accounts := {
                   "system:serviceaccount:osac-e2e-ci:admin",
+                  "system:serviceaccount:osac-e2e-ci:controller",
                   "system:serviceaccount:osac-e2e-ci:template-publisher",
                   "system:serviceaccount:osac-e2e-ci:osac-operator-controller-manager",
                 }
@@ -354,10 +355,6 @@ patches:
                     "/osac.public.v1.SecurityGroups/Get",
                     "/osac.public.v1.SecurityGroups/List",
                     "/osac.public.v1.SecurityGroups/Update",
-                    "/osac.public.v1.PublicIPAttachments/Create",
-                    "/osac.public.v1.PublicIPAttachments/Delete",
-                    "/osac.public.v1.PublicIPAttachments/Get",
-                    "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -88,3 +88,6 @@ retry_command() {
         attempt=$(( attempt + 1 ))
     done
 }
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${_LIB_DIR}/oc.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
-source "${SCRIPT_DIR}/oc.sh"
 
 # Deploy mode: "helm" (default) or "kustomize" (legacy)
 DEPLOY_MODE=${DEPLOY_MODE:-"helm"}

--- a/scripts/sync-authconfig-rego.py
+++ b/scripts/sync-authconfig-rego.py
@@ -76,11 +76,11 @@ def build_overlay_rego(base_rego: str, namespace: str) -> str:
     rego = base_rego.replace("system:serviceaccount:osac:", f"system:serviceaccount:{namespace}:")
 
     extra = "\n".join(f'  "system:serviceaccount:{namespace}:{sa}",' for sa in EXTRA_EMERGENCY_SAS)
-    pattern = f'"system:serviceaccount:{namespace}:controller",\n}}'
+    pattern = f'"system:serviceaccount:{namespace}:admin",\n}}'
     if pattern not in rego:
         print(f"ERROR: injection point not found in base Rego. Base format may have changed.", file=sys.stderr)
         sys.exit(1)
-    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:controller",\n{extra}\n}}')
+    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:admin",\n{extra}\n}}')
     return rego
 
 

--- a/scripts/sync-authconfig-rego.py
+++ b/scripts/sync-authconfig-rego.py
@@ -76,11 +76,11 @@ def build_overlay_rego(base_rego: str, namespace: str) -> str:
     rego = base_rego.replace("system:serviceaccount:osac:", f"system:serviceaccount:{namespace}:")
 
     extra = "\n".join(f'  "system:serviceaccount:{namespace}:{sa}",' for sa in EXTRA_EMERGENCY_SAS)
-    pattern = f'"system:serviceaccount:{namespace}:admin",\n}}'
+    pattern = f'"system:serviceaccount:{namespace}:controller",\n}}'
     if pattern not in rego:
         print(f"ERROR: injection point not found in base Rego. Base format may have changed.", file=sys.stderr)
         sys.exit(1)
-    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:admin",\n{extra}\n}}')
+    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:controller",\n{extra}\n}}')
     return rego
 
 


### PR DESCRIPTION
## Summary

Aligns osac-installer with AAP-only operator provisioning: removes EDA webhook and provider-selection config from the umbrella Helm chart and all overlays, migrates hypershift2 to AAP direct, and bumps the **osac-operator** submodule to the merged #272 commit on `main`.

## Changes

- Delete `operator.provisioning` from umbrella chart values and schema
- Remove `OSAC_PROVISIONING_PROVIDER`, EDA webhook env vars, and `OSAC_MINIMUM_REQUEST_INTERVAL` from overlays
- Migrate `overlays/hypershift2` from EDA webhooks to AAP direct configuration
- Bump `base/osac-operator` → `0217b64` (`sha-0217b64` image tag; [osac-operator#272](https://github.com/osac-project/osac-operator/pull/272) merge on `main`)
- Propagate `OC_IMPERSONATE` to installer scripts via `lib.sh`
- **Out of scope:** fulfillment-service and osac-aap submodules left at prior pins (`1528878`, `e2fd241`)

## Related PRs

- **Merged:** https://github.com/osac-project/osac-operator/pull/272
- **Companion:** https://github.com/osac-project/docs/pull/31

## Jira

https://redhat.atlassian.net/browse/OSAC-874

## Validation (2026-06-04, HEAD `a6bce03`)

- [x] Rebased onto `origin/main` (`09515dc`) — 0 commits behind
- [x] Operator submodule pinned to post-merge `main` (`0217b64`)
- [x] `make helm-lint` — pass
- [x] `python3 scripts/sync-authconfig-rego.py` — pass (fulfillment pin unchanged)
- [x] Grep: no `OSAC_PROVISIONING_PROVIDER` or operator EDA webhook env in installer
- [ ] `e2e-vmaas` — requires `ghcr.io/osac-project/osac-operator:sha-0217b64` on registry (from main `ci/prow/images`)

## Notes

- Manifest-only — no live cluster rollout
- After merge, `base/osac-operator` tracks `origin/main` at the #272 merge commit; bump again when main moves forward
- `aap.instance.eda` in Helm values unchanged (AAP product component, not operator provider)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable AAP integration (URL, token, insecure TLS, polling interval, template prefix) and fulfillment integration settings.
  * Added operator resource requests (CPU/memory).

* **Chores**
  * Updated operator image to a new tag and set image pull policy to Always across deployments.
  * Consolidated runtime env configuration for controller enablement and integrations.

* **Breaking Changes**
  * Removed the previous provisioning/provider Helm value; operator now uses direct AAP configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
