### PR TITLE
NO-ISSUE: Upgrade PostgreSQL from 15 to 18

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -24,7 +24,7 @@ images:
   newName: docker.io/gomplate/gomplate
   newTag: latest
 - name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
+  newName: quay.io/sclorg/postgresql-18-c10s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
   newTag: sha-1528878

--- a/prerequisites/keycloak/database/statefulset.yaml
+++ b/prerequisites/keycloak/database/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           fi
       containers:
       - name: server
-        image: quay.io/sclorg/postgresql-15-c9s:latest
+        image: quay.io/sclorg/postgresql-18-c10s:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_USER

--- a/prerequisites/keycloak/kustomization.yaml
+++ b/prerequisites/keycloak/kustomization.yaml
@@ -26,5 +26,5 @@ images:
   newName: quay.io/keycloak/keycloak
   newTag: latest
 - name: postgres
-  newName: quay.io/sclorg/postgresql-15-c9s
+  newName: quay.io/sclorg/postgresql-18-c10s
   newTag: latest


### PR DESCRIPTION
## Summary

- Update the PostgreSQL container image from `postgresql-15-c9s` to
  `postgresql-18-c10s` in the base kustomization and the Keycloak database
  prerequisite.
- Aligns the installer with the corresponding upgrade in the
  fulfillment-service (https://github.com/osac-project/fulfillment-service/pull/628).

## Merge order

This change should ideally be merged before
https://github.com/osac-project/fulfillment-service/pull/628, so that the
installer already references the correct PostgreSQL version by the time the
fulfillment-service starts requiring PostgreSQL 18 features.

## Test plan

- [ ] Verify `kustomize build` succeeds for all overlays
- [ ] Verify Keycloak database starts correctly with the new image

Assisted-by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded PostgreSQL from version 15 to version 18 across the deployment.
  * Updated the database image used by the Keycloak database component to the new PostgreSQL 18 image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->