### PR TITLE
OSAC-1243: remap keycloak init container postgres image to quay.io

### DIFF
--- a/prerequisites/keycloak/kustomization.yaml
+++ b/prerequisites/keycloak/kustomization.yaml
@@ -25,3 +25,6 @@ images:
 - name: keycloak
   newName: quay.io/keycloak/keycloak
   newTag: latest
+- name: postgres
+  newName: quay.io/sclorg/postgresql-15-c9s
+  newTag: latest


### PR DESCRIPTION
## Summary

- The `wait-for-database` init container in `prerequisites/keycloak/service/deployment.yaml` uses the bare image `postgres`, which resolves to `docker.io/library/postgres:latest`
- The `prerequisites/keycloak/` kustomize tree is a separate root from `base/`, so the `postgres → quay.io/sclorg/postgresql-15-c9s` remap in `base/kustomization.yaml` never reaches it
- On clusters without Docker Hub credentials this hits the unauthenticated pull rate limit, causing Keycloak `Init:ImagePullBackOff` → fulfillment-controller `CrashLoopBackOff` → entire stack down

Adds the missing `postgres` image remap to `prerequisites/keycloak/kustomization.yaml`, matching the existing pattern in `base/`.

Introduced in PR #36 (commit `94e79db`) — the database StatefulSet in the same PR already uses `quay.io/sclorg/postgresql-15-c9s:latest`, but the init container was missed.

## Test plan

- [x] `kustomize build prerequisites/keycloak/` renders `quay.io/sclorg/postgresql-15-c9s:latest` for the init container
- [ ] Deploy on SNO cluster without Docker Hub credentials — Keycloak starts successfully

Jira: [OSAC-1243](https://redhat.atlassian.net/browse/OSAC-1243)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configuration for Keycloak prerequisites to properly reference PostgreSQL database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->