### PR TITLE
NO-ISSUE: Bump osac-operator to b613d8d

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -32,7 +32,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-e2fd241
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-cc4e026
+  newTag: sha-b613d8d
 - name: envoy
   newName: docker.io/envoyproxy/envoy
   newTag: v1.33.0


### PR DESCRIPTION
## Summary
- Bumps `osac-operator` submodule from `cc4e026` to `b613d8d`
- Updates image tag to `sha-b613d8d`

### Included PRs
- #277: Bump the go-dependencies group with 10 updates
- #274: Add rgolangh to OWNERS and reviewers list
- #276: Run make test-kustomize in build-image workflow
- #269: [OSAC-179](https://redhat.atlassian.net/browse/OSAC-179): remove deprecated storageclass
- #267: [OSAC-837](https://redhat.atlassian.net/browse/OSAC-837): feedback RBAC
- #273: Helm CRD drift check
- #271: 1.26 toolchain
- #268: [OSAC-1071](https://redhat.atlassian.net/browse/OSAC-1071): remove bump-osac-installer workflow
- #264: Run go fix after update to go 1.26

## Test plan
- [ ] CI kustomize build passes for all overlays
- [ ] e2e vmaas test job passes
- [x] Manual deployment updates osac-operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator component to reference a newer build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->