### PR TITLE
Fix sed -i incompatibility on macOS in refresh-after-snapshot

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -172,7 +172,11 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 # deployment, killing in-flight AAP jobs. The bootstrap job is redundant
 # on snapshot boot (AAP is already configured) and races the operator.
 # NOTE: if aap.yaml or job.yaml change, the snapshot must be recreated.
-sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
+if [[ "$(uname)" == "Darwin" ]]; then
+  sed -i '' '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
+else
+  sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
+fi
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
 
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"


### PR DESCRIPTION
## Summary
- `sed -i` on macOS requires an explicit empty backup extension (`sed -i ''`), unlike GNU sed on Linux
- Without it, macOS sed misinterprets the file path as a sed command, causing `undefined label` errors during `refresh-after-snapshot.sh` step 3 (kustomize overlay apply)
- Added platform detection (`uname`) to use the correct `sed -i` form on each OS

## Test plan
- [ ] Run `refresh-after-snapshot.sh` on macOS — verify no sed errors at step 3
- [ ] Run `refresh-after-snapshot.sh` on Linux — verify no regression

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform compatibility for build scripts, ensuring proper functionality on macOS and Unix-based systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->