### PR TITLE
OSAC-1279: fix bump-submodules image check for OCI manifests

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -33,6 +33,7 @@ jobs:
             local code
             code=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
               "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
             if [[ "${code}" != "200" ]]; then
               echo "ERROR: ${repo} latest main commit ${sha:0:7} has no published image (tag ${tag})" >&2


### PR DESCRIPTION
## Summary

- The `bump-submodules` workflow has never succeeded (42/42 runs failed) because the GHCR manifest check uses `Accept: */*`, which returns 404 for OCI-format images
- `osac-aap` is built with podman (OCI format) while the other two repos use docker (Docker format) — only osac-aap is affected
- Adds an explicit `Accept` header covering both OCI and Docker manifest formats

## Root Cause

GHCR requires an OCI-compatible `Accept` header to serve OCI manifests. Without it, the registry returns 404 even though the image exists. The `check_image` function's `curl` call had no `Accept` header, so it defaulted to `*/*`.

Jira: [OSAC-1279](https://redhat.atlassian.net/browse/OSAC-1279)

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` and confirm it passes
- [ ] Verify the workflow creates a submodule bump PR on the next scheduled run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the image verification process in the CI/CD pipeline to ensure more reliable detection of published container images during automated submodule updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->