### PR TITLE
OSAC-1279: fix sync-authconfig-rego injection point

### DIFF
--- a/scripts/sync-authconfig-rego.py
+++ b/scripts/sync-authconfig-rego.py
@@ -76,11 +76,11 @@ def build_overlay_rego(base_rego: str, namespace: str) -> str:
     rego = base_rego.replace("system:serviceaccount:osac:", f"system:serviceaccount:{namespace}:")
 
     extra = "\n".join(f'  "system:serviceaccount:{namespace}:{sa}",' for sa in EXTRA_EMERGENCY_SAS)
-    pattern = f'"system:serviceaccount:{namespace}:controller",\n}}'
+    pattern = f'"system:serviceaccount:{namespace}:admin",\n}}'
     if pattern not in rego:
         print(f"ERROR: injection point not found in base Rego. Base format may have changed.", file=sys.stderr)
         sys.exit(1)
-    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:controller",\n{extra}\n}}')
+    rego = rego.replace(pattern, f'"system:serviceaccount:{namespace}:admin",\n{extra}\n}}')
     return rego
 
 


### PR DESCRIPTION
## Summary

- The `sync-authconfig-rego.py` script hardcoded `controller` as the injection point for extra overlay service accounts in `emergency_service_accounts`
- The base Rego (in fulfillment-service) removed `controller` from that set, leaving only `admin`
- This caused the script to fail with `ERROR: injection point not found in base Rego`
- The bump-submodules workflow hit this after #225 fixed the image check — it was previously masked

## Fix

Update the injection point from `controller` to `admin` (the current last entry in the base set).

Jira: [OSAC-1279](https://redhat.atlassian.net/browse/OSAC-1279)

## Test plan

- [x] `python3 scripts/sync-authconfig-rego.py` passes in check mode
- [x] `python3 scripts/sync-authconfig-rego.py --fix` passes in fix mode
- [ ] Trigger bump-submodules workflow manually — should pass end-to-end