### PR TITLE
OSAC-1282: sync helm values image tags with submodule commits

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -99,14 +99,20 @@ jobs:
           git config user.name "osac-dev-bot"
           git config user.email "osac-dev-bot@users.noreply.github.com"
           git add -A
+
+          # Skip if bump branch already has identical content
+          git fetch origin "${BRANCH}" || true
+          EXISTING_TREE=$(git rev-parse "refs/remotes/origin/${BRANCH}^{tree}" || echo "")
+          NEW_TREE=$(git write-tree)
+          if [[ -n "${EXISTING_TREE}" && "${NEW_TREE}" == "${EXISTING_TREE}" ]]; then
+            echo "Bump branch already up to date, skipping"
+            exit 0
+          fi
+
           git commit -m "bump submodules to latest with published images"
           git push origin "HEAD:${BRANCH}" --force
 
-          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
-          if [[ -n "${EXISTING}" ]]; then
-            echo "Updated existing PR #${EXISTING}"
-          else
-            BODY=$(cat <<BODY_EOF
+          BODY=$(cat <<BODY_EOF
           ## Automated submodule bump
 
           $(cat /tmp/bump-summary.txt)
@@ -115,6 +121,12 @@ jobs:
           Runs every 3 hours via [bump-submodules workflow](../actions/workflows/bump-submodules.yaml).
           BODY_EOF
           )
+
+          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
+          if [[ -n "${EXISTING}" ]]; then
+            gh pr edit "${EXISTING}" --body "${BODY}"
+            echo "Updated existing PR #${EXISTING}"
+          else
             gh pr create \
               --title "bump submodules" \
               --body "${BODY}" \

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -67,6 +67,55 @@ for overlay in "${CI_OVERLAYS[@]}"; do
   done
 done
 
+# --- Helm values files ---
+# Sync image tags in values/*.yaml with submodule commits.
+# Skips files that use :latest (e.g. development.yaml).
+
+operator_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-operator | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
+fulfillment_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-fulfillment-service | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
+
+for values_file in "${REPO_ROOT}"/values/*.yaml; do
+  [[ ! -f "${values_file}" ]] && continue
+  name=$(basename "${values_file}")
+  grep -q "sha-" "${values_file}" || continue
+
+  for pair in \
+    "osac-operator:tag ${operator_tag}" \
+    "fulfillment-service:inline ${fulfillment_tag}" \
+    "osac-aap:inline ${aap_tag}"; do
+    component="${pair%%:*}"
+    rest="${pair#*:}"
+    mode="${rest%% *}"
+    expected="${rest#* }"
+
+    if [[ "${mode}" == "tag" ]]; then
+      current=$(grep -A1 "repository: ghcr.io/osac-project/${component}$" "${values_file}" | grep "tag:" | awk '{print $2}')
+      [[ -z "${current}" ]] && continue
+      if [[ "${current}" == "${expected}" ]]; then
+        echo "${name} ${component}: OK (${expected})"
+      elif [[ "${1:-}" == "--fix" ]]; then
+        sed -i "/repository: ghcr.io\/osac-project\/${component}$/{n;s|tag: .*|tag: ${expected}|}" "${values_file}"
+        echo "${name} ${component}: FIXED ${current} -> ${expected}"
+      else
+        echo "${name} ${component}: MISMATCH current=${current} expected=${expected}"
+        errors=$((errors + 1))
+      fi
+    else
+      current=$(grep -o "${component}:sha-[a-f0-9]\{7\}" "${values_file}" | head -1 | sed "s/${component}://")
+      [[ -z "${current}" ]] && continue
+      if [[ "${current}" == "${expected}" ]]; then
+        echo "${name} ${component}: OK (${expected})"
+      elif [[ "${1:-}" == "--fix" ]]; then
+        sed -i "s|${component}:sha-[a-f0-9]\{7\}|${component}:${expected}|g" "${values_file}"
+        echo "${name} ${component}: FIXED ${current} -> ${expected}"
+      else
+        echo "${name} ${component}: MISMATCH current=${current} expected=${expected}"
+        errors=$((errors + 1))
+      fi
+    fi
+  done
+done
+
 if [[ ${errors} -gt 0 ]]; then
   echo ""
   echo "Run '$0 --fix' to update the tags automatically."

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -73,6 +73,7 @@ done
 
 operator_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-operator | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 fulfillment_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-fulfillment-service | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
+aap_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-aap | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 
 for values_file in "${REPO_ROOT}"/values/*.yaml; do
   [[ ! -f "${values_file}" ]] && continue


### PR DESCRIPTION
## Summary

- `sync-image-tags.sh` only synced `base/kustomization.yaml` and overlay env vars — helm `values/*.yaml` files were pinned independently and had drifted
- Extend the script to also update image SHAs in `values/*.yaml`, covering both the operator's `tag:` field and the inline `image:tag` format (fulfillment-service, osac-aap)
- Skips files using `:latest` (e.g. `development.yaml`)
- The bump-submodules workflow already calls `sync-image-tags.sh --fix`, so helm values will stay in sync automatically going forward

Jira: [OSAC-1282](https://redhat.atlassian.net/browse/OSAC-1282)

## Test plan

- [x] `sync-image-tags.sh` detects all mismatches in check mode
- [x] `sync-image-tags.sh --fix` updates all values files correctly
- [x] Re-running check mode after fix shows all OK
- [x] `development.yaml` (uses `:latest`) is skipped
- [ ] bump-submodules workflow syncs values files on next run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized submodule update automation workflow to skip redundant operations when no changes are detected, reducing unnecessary commits
  * Enhanced Helm chart configuration management with automated synchronization and validation of container image version tags
  * Improved pull request handling for submodule updates with direct editing of existing PRs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->