### PR TITLE
OSAC-1088: add chart-testing lint and helm template validation to PR CI

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -23,16 +23,30 @@ jobs:
       with:
         version: v3.17.0
 
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f  # v2.8.0
+
     - name: Build chart dependencies
       run: helm dependency build charts/osac/
 
-    - name: Lint umbrella chart
-      run: helm lint charts/osac/
+    - name: Run chart-testing lint
+      run: ct lint --all --config ct.yaml
 
-    - name: Template umbrella chart (dry-run)
-      run: helm template osac charts/osac/ --values values/development.yaml > /dev/null
+    - name: Template with CI values
+      run: |
+        set -euo pipefail
+        for f in charts/osac/ci/*-values.yaml; do
+          echo "--- helm template with $(basename "$f") ---"
+          helm template osac charts/osac/ --values "$f" > /dev/null
+        done
+
+    - name: Template with environment values
+      run: |
+        set -euo pipefail
+        for f in values/*.yaml; do
+          echo "--- helm template with $(basename "$f") ---"
+          helm template osac charts/osac/ --values "$f" > /dev/null
+        done
 
     - name: Validate values schema
-      run: |
-        # Ensure values.schema.json is valid JSON
-        python3 -m json.tool charts/osac/values.schema.json > /dev/null
+      run: python3 -m json.tool charts/osac/values.schema.json > /dev/null

--- a/charts/osac/ci/default-values.yaml
+++ b/charts/osac/ci/default-values.yaml
@@ -1,0 +1,27 @@
+# Default scenario: validates that the chart renders with minimal overrides.
+# Only sets values that subcharts mark as required.
+
+service:
+  auth:
+    issuerUrl: https://keycloak.example.com/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  idp:
+    url: https://keycloak.example.com
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -1,0 +1,56 @@
+# Full scenario: everything enabled, exercises all template branches.
+
+operator:
+  aap:
+    url: "https://aap.example.com/api/controller"
+    token: "test-token"
+    insecureSkipVerify: "true"
+    statusPollInterval: "30s"
+    templatePrefix: "osac"
+  fulfillment:
+    serverAddress: "fulfillment-api:8000"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+service:
+  variant: openshift
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:latest
+
+validation:
+  enabled: true
+
+dbMigrate:
+  enabled: true
+  image: ghcr.io/osac-project/fulfillment-service:latest
+  dbUrlFile: "/etc/fulfillment-service/db/url"

--- a/charts/osac/ci/no-aap-values.yaml
+++ b/charts/osac/ci/no-aap-values.yaml
@@ -1,0 +1,37 @@
+# No-AAP scenario: AAP managed externally, bootstrap and validation disabled.
+# Exercises the disabled-AAP template branches.
+
+service:
+  auth:
+    issuerUrl: https://keycloak.example.com/realms/osac
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  idp:
+    url: https://keycloak.example.com
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+
+aap:
+  aap:
+    instance:
+      enabled: false
+  bootstrap:
+    enabled: false
+
+validation:
+  enabled: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,3 @@
+chart-dirs:
+  - charts
+validate-maintainers: false


### PR DESCRIPTION
## Summary
- Add `ct lint --all` to the helm-lint workflow — validates Chart.yaml fields, values schema, and runs helm lint with CI values files
- Create three CI test-values files (`charts/osac/ci/`) covering default, full (all features + db-migrate), and no-AAP template branches
- Replace single `helm template` step with loops over both CI and environment values files, with explicit `set -euo pipefail`
- Add `ct.yaml` config at repo root

## Test plan
- [ ] helm-lint workflow passes on this PR
- [ ] `ct lint --all` picks up all three `*-values.yaml` files from `charts/osac/ci/`
- [ ] `helm template` succeeds for all CI and environment values files
- [ ] Template failure in any scenario fails the workflow (no silent swallowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Helm chart linting and validation in the CI/CD pipeline by adopting automated chart-testing tools for improved quality assurance.
  * Introduced multiple pre-configured Helm deployment value file scenarios to support different deployment configurations and use cases.
  * Added standardized chart testing configuration to enable consistent validation practices across the deployment and integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->