### PR TITLE
Fix Kustomize deploy when console-proxy uses shared osac namespace

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -284,5 +284,31 @@ check_postgres_prerequisites() {
     echo "PostgreSQL prerequisites satisfied."
 }
 
+# Overlays using console-proxy-shared-dev deploy console-proxy to the fixed
+# "osac" namespace while the rest of the stack lives in the overlay namespace
+# (e.g. osac-devel). Ensure that namespace exists before applying manifests.
+ensure_console_proxy_namespace() {
+    local overlay="${1:-development}"
+    if [[ "${overlay}" == *..* || "${overlay}" == */* ]] || \
+       [[ ! "${overlay}" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        echo "ERROR: invalid overlay name: ${overlay}"
+        exit 1
+    fi
+    if ! grep -q 'console-proxy-shared-dev' "overlays/${overlay}/kustomization.yaml" 2>/dev/null; then
+        return
+    fi
+    wait_for_namespace_cleanup osac
+    if oc get namespace osac &>/dev/null; then
+        return
+    fi
+    echo "Creating shared console-proxy namespace osac..."
+    if ! oc create namespace osac; then
+        oc get namespace osac &>/dev/null || {
+            echo "ERROR: failed to create namespace osac"
+            exit 1
+        }
+    fi
+}
+
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_LIB_DIR}/oc.sh"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -366,6 +366,7 @@ if [[ "${DEPLOY_MODE}" == "helm" ]]; then
         --wait
 else
     # --- Kustomize deployment mode (legacy) ---
+    ensure_console_proxy_namespace "${INSTALLER_KUSTOMIZE_OVERLAY}"
     echo "Deploying OSAC using Kustomize..."
     oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}" --server-side --force-conflicts
 


### PR DESCRIPTION
Overlays with the console-proxy-shared-dev component (e.g. development) deploy the main OSAC stack into the overlay namespace (osac-devel) but pin console-proxy to the cluster-wide osac namespace. Kustomize only creates osac-devel, so oc apply -k failed at the end with "namespaces osac not found" when applying console-proxy ServiceAccount, Deployment, and Certificate resources.
Thus, create the osac namespace before Kustomize apply when the overlay uses console-proxy-shared-dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment setup to automatically validate and initialize required namespace configuration when using Kustomize-based deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->