### PR TITLE
Add CLI prerequisite checks and install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ target Hub cluster.
 |---------------|-----------------|----------------------|
 | **Platform** | Red Hat OpenShift Container Platform (OCP) 4.17 or later | Must have cluster admin access to the hub cluster. |
 | **Operators** | Red Hat Advanced Cluster Management (RHACM) 2.18+<br>Red Hat OpenShift Virtualization (OCP-Virt) 4.17+<br>Red Hat Ansible Automation Platform (AAP) 2.5+ | These must be installed and running prior to OSAC installation. |
-| **CLI Tools** | `oc` (OpenShift CLI) v4.17+<br>`kubectl` (optional)<br>`kustomize` v5.x<br>`git` | Ensure all CLIs are available in your `PATH`. |
+| **CLI Tools** | `oc` (OpenShift CLI) v4.17+<br>`helm` v3.x (helm mode, default)<br>`kustomize` v5.x (kustomize mode)<br>`jq`<br>`git` | Ensure all CLIs are available in your `PATH`. See [Helm deployment guide](docs/helm-deployment-guide.md#install-cli-tools) for install instructions. |
 | **Container Registry Access** | `registry.redhat.io` and `quay.io` | Verify credentials and pull secrets are valid in the target cluster namespace. |
 | **Network / DNS** | Ingress route configured for OSAC services | Required for external access to fulfillment API and AAP UI. |
 | **Authentication / IDM** | Organization Identity Provider (e.g., Keycloak, LDAP, RH-SSO) | Used for tenant and user identity mapping. |

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -6,6 +6,7 @@ using the Helm umbrella chart. Covers VMaaS and CaaS profiles.
 ## Table of Contents
 
 - [Before You Begin](#before-you-begin)
+- [Install CLI tools](#install-cli-tools)
 - [Phase 1: Cluster Prerequisites](#phase-1-cluster-prerequisites)
   - [1.1 Storage (LVMS)](#11-storage-lvms)
   - [1.2 Ingress (MetalLB)](#12-ingress-metallb)
@@ -52,6 +53,27 @@ using the Helm umbrella chart. Covers VMaaS and CaaS profiles.
 | Network | Outbound access to github.com, ghcr.io, quay.io, registry.redhat.io |
 | Storage | A default StorageClass (or install LVMS below) |
 | AAP license | Subscription manifest (`license.zip`) from [Red Hat Customer Portal](https://access.redhat.com/) |
+
+### Install CLI tools
+
+Helm 3 is required on the machine running `setup.sh` or `make helm-*` targets
+(it is not installed onto the cluster). Install the CLI tools listed above if
+they are not already in your `PATH`:
+
+```bash
+# RHEL / Fedora
+sudo dnf install helm jq
+
+# Or install Helm directly: https://helm.sh/docs/intro/install/
+```
+
+Verify:
+
+```bash
+helm version --short
+oc whoami
+jq --version
+```
 
 ### Clone and Verify
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Require a command to be available in PATH.
+# Usage: require_command <command> [install_hint]
+require_command() {
+    local cmd="$1"
+    local hint="${2:-}"
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        echo "ERROR: '${cmd}' not found in PATH."
+        [[ -n "${hint}" ]] && echo "${hint}"
+        exit 1
+    fi
+}
+
 # Retry a condition until it succeeds or times out, optionally running a command each iteration
 # Usage: retry_until <timeout_seconds> <interval_seconds> <condition_command> [loop_command]
 # Returns: 0 on success, 1 on timeout

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,6 +35,14 @@ MCE_SERVICE=${MCE_SERVICE:-${EXTRA_SERVICES}}
 # Setup phase: "all" (default), "prerequisites" (infra operators only), or "deploy" (skip infra operators)
 SETUP_PHASE=${SETUP_PHASE:-"all"}
 
+require_command oc "Install the OpenShift CLI: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html"
+require_command jq "Install jq: https://jqlang.org/download/"
+if [[ "${DEPLOY_MODE}" == "helm" ]]; then
+    require_command helm "Install Helm 3: https://helm.sh/docs/intro/install/"
+elif [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
+    require_command kustomize "Install kustomize: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+fi
+
 echo "=== Setting up OSAC deployment ==="
 echo "Deploy mode: ${DEPLOY_MODE}"
 if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then


### PR DESCRIPTION
Fail fast in setup.sh when oc, jq, or the deploy-mode tool (helm/kustomize) is missing, and document how to install them.