### PR TITLE
OSAC-1305: fix CI stability issues in installer scripts

### DIFF
--- a/scripts/create-hub-access-kubeconfig.sh
+++ b/scripts/create-hub-access-kubeconfig.sh
@@ -21,7 +21,7 @@ token=$(oc -n "$namespace" extract secret/hub-access --keys token --to - 2>/dev/
 
 echo "generating a kubeconfig for hub-access serviceaccount in $namespace namespace on $server_url"
 
-cat <<EOF >/tmp/kubeconfig.hub-access
+cat <<EOF >/tmp/kubeconfig.hub-access.${server_name}
 apiVersion: v1
 clusters:
 - cluster:

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -89,5 +89,43 @@ retry_command() {
     done
 }
 
+# HTTP request with retry. Outputs response body on success.
+# Returns 1 and prints ERROR to stderr on persistent failure.
+# Usage: http_retry <error_msg> <retries> <interval> [curl_args...]
+http_retry() {
+    local err_msg="$1" retries="$2" interval="$3"
+    shift 3
+    for attempt in $(seq 1 "$retries"); do
+        curl -ksS --fail-with-body "$@" && return 0
+        if (( attempt < retries )); then
+            echo "  http_retry: attempt ${attempt}/${retries} failed, retrying in ${interval}s..." >&2
+            sleep "$interval"
+        fi
+    done
+    echo "ERROR: ${err_msg}" >&2
+    return 1
+}
+
+# HTTP request with retry + jq parsing. Outputs parsed value on success.
+# Returns 1 and prints ERROR to stderr on persistent failure.
+# Usage: http_json <error_msg> <retries> <interval> <jq_filter> [curl_args...]
+http_json() {
+    local err_msg="$1" retries="$2" interval="$3" filter="$4"
+    shift 4
+    local result
+    for attempt in $(seq 1 "$retries"); do
+        if result=$(curl -ksS --fail-with-body "$@" | jq -r "$filter"); then
+            printf '%s\n' "$result"
+            return 0
+        fi
+        if (( attempt < retries )); then
+            echo "  http_json: attempt ${attempt}/${retries} failed, retrying in ${interval}s..." >&2
+            sleep "$interval"
+        fi
+    done
+    echo "ERROR: ${err_msg}" >&2
+    return 1
+}
+
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_LIB_DIR}/oc.sh"

--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -18,19 +18,15 @@ AAP_URL="https://${AAP_ROUTE_HOST}"
 # Get the AAP admin password
 AAP_ADMIN_PASSWORD=$(oc get secret osac-aap-admin-password -n ${INSTALLER_NAMESPACE} -o jsonpath='{.data.password}' | base64 -d)
 
-# Create an API token using basic auth against the AAP gateway
-AAP_RESPONSE=$(curl -sk -X POST \
-    -u "admin:${AAP_ADMIN_PASSWORD}" \
+AAP_TOKEN=$(http_json "Failed to create AAP API token (gateway may be rolling out)" 30 10 \
+    '.token // empty' \
+    -X POST -u "admin:${AAP_ADMIN_PASSWORD}" \
     -H "Content-Type: application/json" \
     -d '{"description": "osac-operator", "scope": "write"}' \
     "${AAP_URL}/api/gateway/v1/tokens/")
-AAP_TOKEN=$(echo "${AAP_RESPONSE}" | jq -r '.token') || {
-    echo "ERROR: AAP gateway returned non-JSON response: ${AAP_RESPONSE}"
-    exit 1
-}
 
 if [[ -z "${AAP_TOKEN}" || "${AAP_TOKEN}" == "null" ]]; then
-    echo "Failed to create AAP API token. Response: ${AAP_RESPONSE}"
+    echo "ERROR: AAP API token was empty"
     exit 1
 fi
 

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -13,79 +13,194 @@ INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-$(grep "^namespace:" "overlays/${INST
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 INSTALLER_CLUSTER_TEMPLATE=${INSTALLER_CLUSTER_TEMPLATE:-}
 
-# Create hub access kubeconfig
-./scripts/create-hub-access-kubeconfig.sh
+create_hub() {
+    ./scripts/create-hub-access-kubeconfig.sh
 
-# Login to fulfillment internal API and ensure hub exists with current kubeconfig.
-# The private API (osac.private.v1.*) is only available via the internal listener
-# (fulfillment-internal-api route, port 8001). The external listener
-# (fulfillment-api route, port 8000) only routes public API methods.
-FULFILLMENT_INTERNAL_API_URL=https://$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
-echo "Fulfillment internal API URL: ${FULFILLMENT_INTERNAL_API_URL}"
+    local fulfillment_url
+    fulfillment_url=https://$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
+    echo "Fulfillment internal API URL: ${fulfillment_url}"
 
-echo "Logging into fulfillment internal API..."
-retry_command 300 10 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address "${FULFILLMENT_INTERNAL_API_URL}"
+    echo "Logging into fulfillment internal API..."
+    retry_command 300 10 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address "${fulfillment_url}"
 
-echo "Deleting existing hub..."
-retry_command 300 10 osac delete hub hub
+    echo "Deleting existing hub..."
+    retry_command 300 10 osac delete hub hub
 
-echo "Creating hub..."
-retry_command 300 10 osac create hub --kubeconfig=/tmp/kubeconfig.hub-access --id hub --namespace "${INSTALLER_NAMESPACE}"
+    echo "Creating hub..."
+    local _server_name
+    _server_name=$(oc config view --minify --output jsonpath="{.clusters[*].cluster.server}")
+    _server_name=${_server_name#*.}; _server_name=${_server_name%%.*}
+    retry_command 300 10 osac create hub --kubeconfig="/tmp/kubeconfig.hub-access.${_server_name}" --id hub --namespace "${INSTALLER_NAMESPACE}"
+}
 
-if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; then
-    # Trigger a one-time publish-templates AAP job
+sync_aap_project() {
+    local AAP_ROUTE_HOST AAP_URL AAP_TOKEN JT_ID PROJECT_ID
+    local EXPECTED_BRANCH EXPECTED_URI
+
     AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
     AAP_URL="https://${AAP_ROUTE_HOST}"
     AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
-    echo "Waiting for AAP controller API and project sync..."
-    for attempt in $(seq 1 30); do
-        JT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
-            "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates" 2>/dev/null | jq -er '.results[0].id // empty' 2>/dev/null) && break
-        echo "  attempt ${attempt}/30 - AAP controller API not ready, retrying in 10s..."
+
+    echo "Waiting for AAP controller API..."
+    JT_ID=$(http_json "Failed to find osac-publish-templates job template" 30 10 \
+        '.results[0].id // empty' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates") || exit 1
+    [[ -z "${JT_ID}" ]] && { echo "ERROR: osac-publish-templates job template returned empty ID"; exit 1; }
+
+    PROJECT_ID=$(http_json "Failed to read job template ${JT_ID}" 6 10 \
+        '.project // empty' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/") || exit 1
+    [[ -z "${PROJECT_ID}" ]] && { echo "ERROR: Could not determine project ID from job template ${JT_ID}"; exit 1; }
+
+    EXPECTED_BRANCH=$(oc get secret config-as-code-ig -n "${INSTALLER_NAMESPACE}" \
+        -o jsonpath='{.data.AAP_PROJECT_GIT_BRANCH}' | base64 -d)
+    EXPECTED_URI=$(oc get secret config-as-code-ig -n "${INSTALLER_NAMESPACE}" \
+        -o jsonpath='{.data.AAP_PROJECT_GIT_URI}' | base64 -d)
+    [[ -z "${EXPECTED_BRANCH}" ]] && { echo "ERROR: AAP_PROJECT_GIT_BRANCH not set in config-as-code-ig secret"; exit 1; }
+    [[ -z "${EXPECTED_URI}" ]] && { echo "ERROR: AAP_PROJECT_GIT_URI not set in config-as-code-ig secret"; exit 1; }
+    echo "  Expected: ${EXPECTED_URI}@${EXPECTED_BRANCH}"
+
+    local CURRENT CURRENT_URL CURRENT_BRANCH
+    CURRENT=$(http_json "Failed to read project ${PROJECT_ID}" 6 10 \
+        '.' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/") || exit 1
+    CURRENT_URL=$(echo "${CURRENT}" | jq -r '.scm_url // empty')
+    CURRENT_BRANCH=$(echo "${CURRENT}" | jq -r '.scm_branch // empty')
+
+    if [[ "${CURRENT_URL}" != "${EXPECTED_URI}" || "${CURRENT_BRANCH}" != "${EXPECTED_BRANCH}" ]]; then
+        echo "  Project stale: ${CURRENT_URL}@${CURRENT_BRANCH} → ${EXPECTED_URI}@${EXPECTED_BRANCH}"
+        http_retry "Failed to patch project ${PROJECT_ID}" 12 10 \
+            -X PATCH -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+            "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/" \
+            -d "{\"scm_url\": \"${EXPECTED_URI}\", \"scm_branch\": \"${EXPECTED_BRANCH}\"}" || exit 1
+    else
+        echo "  Project already points to correct repo/branch"
+    fi
+
+    http_retry "Failed to trigger project update" 12 10 \
+        -X POST -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/update/" || exit 1
+    local _sync_start=${SECONDS} _proj_status=""
+    while (( SECONDS - _sync_start < 300 )); do
+        _proj_status=$(http_json "Failed to read project ${PROJECT_ID} status" 3 5 \
+            '.status // empty' \
+            -H "Authorization: Bearer ${AAP_TOKEN}" \
+            "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/") || continue
+        [[ "${_proj_status}" == "successful" ]] && break
+        if [[ "${_proj_status}" == "failed" || "${_proj_status}" == "error" ]]; then
+            echo "  Project sync failed (status: ${_proj_status}), forcing retry..."
+            http_retry "Failed to re-trigger project update" 6 10 \
+                -X POST -H "Authorization: Bearer ${AAP_TOKEN}" \
+                "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/update/" || exit 1
+        fi
         sleep 10
     done
-    [[ -z "${JT_ID:-}" ]] && { echo "Failed to find osac-publish-templates AAP job template after 30 attempts"; exit 1; }
-    PROJECT_ID=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
-        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/" 2>/dev/null | jq -r '.project // empty') || PROJECT_ID=""
-    if [[ -n "${PROJECT_ID}" ]]; then
-        echo "  Waiting for AAP project ${PROJECT_ID} to sync..."
-        retry_until 300 10 '[[ "$(curl -kfsS -H "Authorization: Bearer '"${AAP_TOKEN}"'" \
-            "'"${AAP_URL}"'/api/controller/v2/projects/'"${PROJECT_ID}"'/" 2>/dev/null \
-            | jq -r ".status // empty")" == "successful" ]]' || {
-            echo "WARNING: AAP project sync may not be complete"
-        }
+    [[ "${_proj_status}" == "successful" ]] || { echo "ERROR: AAP project sync failed after 300s (last status: ${_proj_status})"; exit 1; }
+
+    local SYNCED_REV
+    SYNCED_REV=$(http_json "Failed to read project ${PROJECT_ID} after sync" 6 10 \
+        '.scm_revision // empty' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/") || exit 1
+    echo "  AAP project synced to ${SYNCED_REV}"
+    if [[ "${EXPECTED_BRANCH}" =~ ^[0-9a-f]{40}$ && "${SYNCED_REV}" != "${EXPECTED_BRANCH}" ]]; then
+        echo "ERROR: AAP project synced to ${SYNCED_REV} but expected ${EXPECTED_BRANCH}"
+        exit 1
     fi
+}
+
+publish_templates() {
+    local AAP_ROUTE_HOST AAP_URL AAP_TOKEN JT_ID PROJECT_ID
+
+    AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
+    AAP_URL="https://${AAP_ROUTE_HOST}"
+    AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
+
+    JT_ID=$(http_json "Failed to query osac-publish-templates job template" 6 10 \
+        '.results[0].id // empty' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/?name=osac-publish-templates") || exit 1
+    [[ -z "${JT_ID}" ]] && { echo "ERROR: osac-publish-templates job template not found"; exit 1; }
+
+    PROJECT_ID=$(http_json "Failed to read job template ${JT_ID}" 6 10 \
+        '.project // empty' \
+        -H "Authorization: Bearer ${AAP_TOKEN}" \
+        "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/") || exit 1
+    [[ -z "${PROJECT_ID}" ]] && { echo "ERROR: Could not determine project ID from job template ${JT_ID}"; exit 1; }
+
     echo "Launching publish-templates AAP job (template ID: ${JT_ID})..."
-    JOB_ID=""
-    for attempt in $(seq 1 10); do
-        LAUNCH_ERR=$(mktemp)
-        JOB_RESPONSE=$(curl -ksS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
-            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" 2>"${LAUNCH_ERR}") && {
-            JOB_ID=$(echo "${JOB_RESPONSE}" | jq -r '.id // empty')
-            [[ -n "${JOB_ID}" && "${JOB_ID}" != "null" ]] && break
+    local JOB_SUCCEEDED=false JOB_ID JOB_STATUS
+    for job_attempt in $(seq 1 3); do
+        JOB_ID=$(http_json "Failed to launch publish-templates job" 10 10 \
+            '.id // empty' \
+            -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+            "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/") || exit 1
+        [[ -z "${JOB_ID}" ]] && { echo "ERROR: publish-templates job launch returned empty ID"; exit 1; }
+        echo "  Job ${JOB_ID} launched, waiting for completion..."
+
+        local _job_start=${SECONDS}
+        JOB_STATUS=""
+        while (( SECONDS - _job_start < 300 )); do
+            JOB_STATUS=$(http_json "Failed to poll job ${JOB_ID} status" 1 0 '.status // empty' \
+                -H "Authorization: Bearer ${AAP_TOKEN}" \
+                "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/") || true
+            [[ "${JOB_STATUS}" =~ ^(successful|failed|error|canceled)$ ]] && break
+            sleep 10
+        done
+        [[ ! "${JOB_STATUS}" =~ ^(successful|failed|error|canceled)$ ]] && {
+            echo "ERROR: Timed out waiting for publish-templates job ${JOB_ID}"
+            exit 1
         }
-        echo "  launch attempt ${attempt}/10 - retrying in 10s..."
-        HTTP_BODY=$(echo "${JOB_RESPONSE}" | jq -r '.playbook[0] // .detail // empty' 2>/dev/null)
-        [[ -n "${HTTP_BODY}" ]] && echo "    reason: ${HTTP_BODY}"
-        sleep 10
+
+        if [[ "${JOB_STATUS}" == "successful" ]]; then
+            JOB_SUCCEEDED=true
+            break
+        fi
+        echo "  Job ${JOB_ID} finished with status: ${JOB_STATUS} (attempt ${job_attempt}/3)"
+        curl -ksS -H "Authorization: Bearer ${AAP_TOKEN}" \
+            "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/stdout/?format=txt" 2>/dev/null | tail -10 || true
+        echo "  Forcing project update before retry..."
+        http_retry "Failed to trigger project update before retry" 6 10 \
+            -X POST -H "Authorization: Bearer ${AAP_TOKEN}" \
+            "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/update/" || exit 1
+        local _proj_start=${SECONDS} _proj_status=""
+        while (( SECONDS - _proj_start < 60 )); do
+            _proj_status=$(http_json "Failed to poll project ${PROJECT_ID} status" 1 0 '.status // empty' \
+                -H "Authorization: Bearer ${AAP_TOKEN}" \
+                "${AAP_URL}/api/controller/v2/projects/${PROJECT_ID}/") || true
+            [[ "${_proj_status}" == "successful" ]] && break
+            sleep 5
+        done
+        [[ "${_proj_status}" != "successful" ]] && { echo "ERROR: Project sync failed before retry"; exit 1; }
     done
-    [[ -z "${JOB_ID}" || "${JOB_ID}" == "null" ]] && { echo "ERROR: Failed to launch publish-templates job after 10 attempts"; exit 1; }
-    echo "  Job ${JOB_ID} launched, waiting for completion..."
-    retry_until 300 10 '[[ "$(curl -kfsS -H "Authorization: Bearer '"${AAP_TOKEN}"'" \
-        "'"${AAP_URL}"'/api/controller/v2/jobs/'"${JOB_ID}"'/" 2>/dev/null \
-        | jq -r ".status // empty")" =~ ^(successful|failed|error|canceled)$ ]]' || true
-    JOB_STATUS=$(curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
-        "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/" 2>/dev/null | jq -r '.status // empty') || JOB_STATUS=""
-    if [[ "${JOB_STATUS}" != "successful" ]]; then
-        echo "WARNING: publish-templates job ${JOB_ID} finished with status: ${JOB_STATUS}"
-        curl -kfsS -H "Authorization: Bearer ${AAP_TOKEN}" \
-            "${AAP_URL}/api/controller/v2/jobs/${JOB_ID}/stdout/?format=txt" 2>/dev/null | tail -30 || true
+    if [[ "${JOB_SUCCEEDED}" != "true" ]]; then
+        echo "ERROR: publish-templates job failed after 3 attempts"
+        exit 1
     fi
+}
+
+create_hub &
+pid_hub=$!
+sync_aap_project &
+pid_sync=$!
+
+hub_rc=0; sync_rc=0
+wait ${pid_hub} || hub_rc=$?
+wait ${pid_sync} || sync_rc=$?
+(( hub_rc )) && echo "ERROR: Hub creation failed (exit ${hub_rc})"
+(( sync_rc )) && echo "ERROR: AAP project sync failed (exit ${sync_rc})"
+(( hub_rc || sync_rc )) && exit 1
+
+if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; then
+    publish_templates
 
     if [[ -n "${INSTALLER_VM_TEMPLATE}" ]]; then
         echo "Waiting for computeinstancetemplate ${INSTALLER_VM_TEMPLATE} to be published..."
         retry_until 300 5 'osac get computeinstancetemplate "${INSTALLER_VM_TEMPLATE}" -o json >/dev/null 2>&1' || {
-            echo "Timed out waiting for computeinstancetemplate to exist"
+            echo "ERROR: Timed out waiting for computeinstancetemplate ${INSTALLER_VM_TEMPLATE}"
             exit 1
         }
     fi
@@ -93,7 +208,7 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; th
     if [[ -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; then
         echo "Waiting for clustertemplate ${INSTALLER_CLUSTER_TEMPLATE} to be published..."
         retry_until 300 5 'osac get clustertemplate "${INSTALLER_CLUSTER_TEMPLATE}" -o json >/dev/null 2>&1' || {
-            echo "Timed out waiting for clustertemplate to exist"
+            echo "ERROR: Timed out waiting for clustertemplate ${INSTALLER_CLUSTER_TEMPLATE}"
             exit 1
         }
     fi

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -49,17 +49,17 @@ pid_rt=$!
 # Recert triggers an AAP controller rollout on boot. Wait for it to finish
 # before mutating any resources, otherwise the operator cascade causes
 # multiple waves of rollouts that kill in-flight AAP jobs.
-oc rollout status deploy/osac-aap-controller-task -n "${INSTALLER_NAMESPACE}" --timeout=300s 2>/dev/null &
+oc rollout status deploy/osac-aap-controller-task -n "${INSTALLER_NAMESPACE}" --timeout=300s &
 pid_aap1=$!
-oc rollout status deploy/osac-aap-controller-web -n "${INSTALLER_NAMESPACE}" --timeout=300s 2>/dev/null &
+oc rollout status deploy/osac-aap-controller-web -n "${INSTALLER_NAMESPACE}" --timeout=300s &
 pid_aap2=$!
 
 failed=0
 wait ${pid_tm} || failed=1
 wait ${pid_kc} || failed=1
 wait ${pid_rt} || failed=1
-wait ${pid_aap1} || true
-wait ${pid_aap2} || true
+wait ${pid_aap1} || failed=1
+wait ${pid_aap2} || failed=1
 if (( failed )); then
     echo "ERROR: Cluster services did not stabilize within timeout"
     exit 1
@@ -95,7 +95,7 @@ keycloak_sync() {
     fi
 
     KC_URL="https://$(oc get route keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
-    retry_until 60 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} '"${KC_URL}"'/realms/osac)" == "200" ]]' || {
+    retry_until 300 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} '"${KC_URL}"'/realms/osac)" == "200" ]]' || {
         echo "Timed out waiting for Keycloak"
         exit 1
     }
@@ -164,20 +164,17 @@ failed=0
 wait ${pid_creds} || failed=1
 if (( failed )); then echo "ERROR: Failed to create fulfillment credentials"; exit 1; fi
 
+oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=0 2>/dev/null || true
 echo "[3/9] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
-# Exclude the AnsibleAutomationPlatform CR and bootstrap job from the apply.
-# Both already exist on the cluster from the snapshot. Re-applying the CR
-# triggers the AAP operator to reconcile and roll the controller-task
-# deployment, killing in-flight AAP jobs. The bootstrap job is redundant
-# on snapshot boot (AAP is already configured) and races the operator.
-# NOTE: if aap.yaml or job.yaml change, the snapshot must be recreated.
-if [[ "$(uname)" == "Darwin" ]]; then
-  sed -i '' '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
-else
-  sed -i '/aap\.yaml/d; /job\.yaml/d' base/osac-aap/config/base/kustomization.yaml
-fi
+# Exclude only the bootstrap job — it's redundant on snapshot boot and races
+# the operator. The AnsibleAutomationPlatform CR (aap.yaml) IS included because
+# it carries probe settings (task_readiness_period). Including it consolidates
+# operator triggers into one reconciliation instead of a separate oc patch.
+sed '/job\.yaml/d' base/osac-aap/config/base/kustomization.yaml > base/osac-aap/config/base/kustomization.yaml.tmp \
+    && mv base/osac-aap/config/base/kustomization.yaml.tmp base/osac-aap/config/base/kustomization.yaml
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
+oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=0 2>/dev/null || true
 
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 PULL_SECRET="${REPO_ROOT}/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
@@ -293,7 +290,9 @@ done
 # Kustomize apply may have changed deployment images, triggering new rollouts
 # that run DB migrations. Wait for those to finish before restarting pods —
 # otherwise the restart kills pods mid-migration and leaves the DB dirty.
-for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+# fulfillment-controller is excluded — it was scaled down to prevent
+# crash-loops while Keycloak/certs stabilize; it starts after certs are ready.
+for deploy in fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
@@ -302,6 +301,7 @@ for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
 wait ${pid_cdi} || failed=1
 if (( failed )); then echo "ERROR: TLS certificates or fulfillment rollouts not ready"; exit 1; fi
 echo "[5/9] TLS certificates ready, restarting pods..."
+oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=1
 for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done
@@ -349,21 +349,6 @@ wait_aap_controller() {
         echo "Timed out waiting for AAP gateway API to respond"
         exit 1
     }
-    # Recert restarts the kube-apiserver, breaking the controller-task's
-    # in-cluster connections. The pod looks healthy but its scheduler can't
-    # launch jobs via container groups. Recycle the pod for fresh connections.
-    echo "[7/9] Recycling AAP controller-task pod..."
-    oc delete pod -n "${INSTALLER_NAMESPACE}" -l app.kubernetes.io/name=osac-aap-controller-task
-    oc wait pod -n "${INSTALLER_NAMESPACE}" -l app.kubernetes.io/name=osac-aap-controller-task \
-        --for=condition=Ready --timeout=300s
-    retry_until 120 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} https://'"${AAP_ROUTE_HOST}"'/api/gateway/v1/)" == "200" ]]' || {
-        echo "Timed out waiting for AAP gateway after controller-task restart"
-        exit 1
-    }
-    # Component overrides can trigger AAP operator reconciliation that creates a
-    # new controller-task pod AFTER our recycle. Wait for the deployment to
-    # stabilize so we don't launch jobs on a half-ready pod.
-    oc rollout status deploy/osac-aap-controller-task -n "${INSTALLER_NAMESPACE}" --timeout=300s
     echo "[7/9] AAP controller Running, gateway responding"
 }
 

--- a/scripts/setup-caas-agents.sh
+++ b/scripts/setup-caas-agents.sh
@@ -31,21 +31,40 @@ CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 echo "Node IP: ${NODE_IP}"
 echo "Cluster domain: ${CLUSTER_DOMAIN}"
 
+SUBNET_PREFIX=$(echo "${NODE_IP}" | cut -d. -f1-3)
+cat <<METALLBEOF | oc apply -f -
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: caas-address-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - ${SUBNET_PREFIX}.240-${SUBNET_PREFIX}.250
+  autoAssign: true
+METALLBEOF
+echo "MetalLB IPAddressPool configured for ${SUBNET_PREFIX}.240-${SUBNET_PREFIX}.250"
+
 echo "[1/6] Registering '${AGENT_RESOURCE_CLASS}' host type in fulfillment service..."
 INTERNAL_API="https://$(oc get route fulfillment-internal-api -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.status.ingress[0].host}')"
 TOKEN=$(oc create token -n "${INSTALLER_NAMESPACE}" admin)
-HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -X POST "${INTERNAL_API}/api/private/v1/host_types" \
+RESPONSE_BODY=$(mktemp)
+HTTP_CODE=$(curl -sk -w "%{http_code}" -X POST "${INTERNAL_API}/api/private/v1/host_types" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \
-    -d "{\"id\": \"${AGENT_RESOURCE_CLASS}\", \"title\": \"CI Worker\", \"description\": \"Worker nodes for CI testing\"}")
+    -d "{\"id\": \"${AGENT_RESOURCE_CLASS}\", \"title\": \"CI Worker\", \"description\": \"Worker nodes for CI testing\"}" \
+    -o "${RESPONSE_BODY}") || true
 if [[ "${HTTP_CODE}" == "200" || "${HTTP_CODE}" == "201" ]]; then
     echo "  Host type '${AGENT_RESOURCE_CLASS}' created"
 elif [[ "${HTTP_CODE}" == "409" ]]; then
     echo "  Host type '${AGENT_RESOURCE_CLASS}' already exists"
 else
     echo "  ERROR: Failed to create host type (HTTP ${HTTP_CODE})"
+    cat "${RESPONSE_BODY}"
+    rm -f "${RESPONSE_BODY}"
     exit 1
 fi
+rm -f "${RESPONSE_BODY}"
 
 echo "[2/6] Creating agent namespace and CAPI provider role..."
 oc create namespace "${AGENT_NAMESPACE}" --dry-run=client -o yaml | oc apply -f -
@@ -81,7 +100,8 @@ EOF
 
 echo "Waiting for discovery ISO URL..."
 retry_until 300 5 '[[ -n "$(oc get infraenv ${AGENT_NAMESPACE} -n ${AGENT_NAMESPACE} -o jsonpath="{.status.isoDownloadURL}" 2>/dev/null)" ]]' || {
-    echo "Timed out waiting for ISO URL"
+    echo "Timed out waiting for ISO URL. Current InfraEnv state:"
+    oc get infraenv "${AGENT_NAMESPACE}" -n "${AGENT_NAMESPACE}" -o yaml 2>&1 || true
     exit 1
 }
 ISO_URL=$(oc get infraenv "${AGENT_NAMESPACE}" -n "${AGENT_NAMESPACE}" -o jsonpath='{.status.isoDownloadURL}')
@@ -108,10 +128,21 @@ echo "[5/6] Creating agent VM..."
 timeout -s 9 10m ssh -F "${SSH_CONFIG}" ci_machine bash -s <<SSHEOF
 set -euo pipefail
 
+dnf install -y virt-install
+
 mkdir -p ${AGENT_VM_STORAGE_DIR}
 
+echo "Waiting for assisted-image-service to be ready..."
+for attempt in \$(seq 1 30); do
+    HTTP_CODE=\$(curl -k -s -o /dev/null -w "%{http_code}" -L '${ISO_URL}') || true
+    [[ "\${HTTP_CODE}" == "200" ]] && break
+    echo "  attempt \${attempt}/30 - HTTP \${HTTP_CODE}, retrying in 10s..."
+    sleep 10
+done
+[[ "\${HTTP_CODE}" != "200" ]] && { echo "ERROR: assisted-image-service not ready after 30 attempts (last HTTP \${HTTP_CODE})"; exit 1; }
+
 echo "Downloading discovery ISO..."
-curl -k -L --fail -o ${AGENT_VM_STORAGE_DIR}/discovery.iso '${ISO_URL}'
+curl -k -L --fail-with-body -o ${AGENT_VM_STORAGE_DIR}/discovery.iso '${ISO_URL}'
 
 virsh destroy ${AGENT_VM_NAME} 2>/dev/null || true
 virsh undefine ${AGENT_VM_NAME} 2>/dev/null || true
@@ -135,7 +166,9 @@ SSHEOF
 
 echo "[6/6] Waiting for agent to register..."
 retry_until 600 10 '[[ $(oc get agent -n ${AGENT_NAMESPACE} --no-headers 2>/dev/null | wc -l) -gt 0 ]]' || {
-    echo "Timed out waiting for agent to register"
+    echo "Timed out waiting for agent to register. Current state:"
+    oc get infraenv -n "${AGENT_NAMESPACE}" -o yaml 2>&1 || true
+    oc get agent -n "${AGENT_NAMESPACE}" -o yaml 2>&1 || true
     exit 1
 }
 

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -269,7 +269,7 @@ echo ""
 if timeout 10 oc get crd networkattachmentdefinitions.k8s.cni.cncf.io &>/dev/null; then
     timeout 30 oc delete networkattachmentdefinition default -n openshift-ovn-kubernetes --ignore-not-found
 fi
-rm -f /tmp/kubeconfig.hub-access
+rm -f /tmp/kubeconfig.hub-access*
 
 echo "Cleaning up stale API services..."
 for api in $(timeout 10 oc get apiservice --no-headers 2>/dev/null | awk '/False/ {print $1}'); do


### PR DESCRIPTION
## Summary

- **prepare-fulfillment-service.sh**: Replace silent error swallowing with fail-fast `http_json`/`http_retry` wrappers. Detect and fix stale AAP projects after snapshot boot. Retry failed project syncs and publish-templates jobs.
- **refresh-after-snapshot.sh**: Scale fulfillment-controller to 0 during refresh to prevent OIDC cache poisoning. Remove manual controller-task pod recycle that raced with operator rollouts. Include aap.yaml in kustomize apply to consolidate operator triggers. Increase Keycloak timeout. Fix error handling.
- **create-hub-access-kubeconfig.sh + teardown.sh**: Per-cluster kubeconfig path to prevent concurrent collisions.
- **setup-caas-agents.sh**: Auto-configure MetalLB, wait for assisted-image-service, better error reporting.
- **lib.sh**: New `http_retry` and `http_json` helpers with `--fail-with-body`, structured retry, and visible curl diagnostics.

## Test plan

- [ ] `./scripts/kustomize-build-all.sh` passes (verified locally)
- [ ] Deploy on a snapshot-booted cluster and run full refresh + test cycle
- [ ] Verify publish-templates job recovers from receptor worker failures (kill controller-task mid-job)

## Related

- Jira: [OSAC-1305](https://redhat.atlassian.net/browse/OSAC-1305)
- Epic: [OSAC-785](https://redhat.atlassian.net/browse/OSAC-785) (e2e-ci-enhancements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retryable HTTP utilities for resilient network calls
  * Automated template publishing and project synchronization workflows

* **Improvements**
  * Concurrent preparation steps and stricter rollout/wait handling
  * Better network provisioning for agent VMs via dynamic subnet allocation
  * Enhanced error diagnostics, longer/reliable timeouts, and clearer logs
  * Expanded cleanup of temporary kubeconfig files and more robust ISO download/installation steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->