### PR TITLE
NO-ISSUE: discover fulfillment certificates and deployments by label in refresh script

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -59,7 +59,7 @@ if [[ -n "${INSTALLER_VM_TEMPLATE}" || -n "${INSTALLER_CLUSTER_TEMPLATE}" ]]; th
     JOB_ID=""
     for attempt in $(seq 1 10); do
         LAUNCH_ERR=$(mktemp)
-        JOB_RESPONSE=$(curl -ksS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
+        JOB_RESPONSE=$(curl -kfsS -X POST -H "Authorization: Bearer ${AAP_TOKEN}" -H "Content-Type: application/json" \
             "${AAP_URL}/api/controller/v2/job_templates/${JT_ID}/launch/" 2>"${LAUNCH_ERR}") && {
             JOB_ID=$(echo "${JOB_RESPONSE}" | jq -r '.id // empty')
             [[ -n "${JOB_ID}" && "${JOB_ID}" != "null" ]] && break

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -280,20 +280,39 @@ for i in "${!img_check_pids[@]}"; do
     fi
 done
 
+# Discover fulfillment deployments by label instead of maintaining a hardcoded
+# list. The app=fulfillment-service label is set by kustomize on all
+# fulfillment-service resources, so new deployments are picked up automatically.
+read -ra FULFILLMENT_DEPLOYS <<< \
+    "$(oc get deploy -n "${INSTALLER_NAMESPACE}" -l app=fulfillment-service \
+       -o jsonpath='{.items[*].metadata.name}')"
+if [[ ${#FULFILLMENT_DEPLOYS[@]} -eq 0 || -z "${FULFILLMENT_DEPLOYS[0]}" ]]; then
+    echo "ERROR: No deployments found with label app=fulfillment-service in namespace ${INSTALLER_NAMESPACE}"
+    exit 1
+fi
+echo "  Fulfillment deployments: ${FULFILLMENT_DEPLOYS[*]}"
+
 echo "[5/9] Waiting for TLS certificates and restarting pods..."
 refresh_cdi_certificates &
 pid_cdi=$!
 pids=()
-for cert in authorino fulfillment-controller fulfillment-grpc-server fulfillment-api \
-            fulfillment-rest-gateway fulfillment-database-client fulfillment-database-server \
-            osac-console-proxy; do
-    oc wait --for=condition=Ready "certificate.cert-manager.io/${cert}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
+read -ra fs_certs <<< \
+    "$(oc get certificates.cert-manager.io -n "${INSTALLER_NAMESPACE}" \
+       -l app=fulfillment-service -o jsonpath='{.items[*].metadata.name}')"
+if [[ ${#fs_certs[@]} -eq 0 || -z "${fs_certs[0]}" ]]; then
+    echo "ERROR: No certificates found with label app=fulfillment-service in namespace ${INSTALLER_NAMESPACE}"
+    exit 1
+fi
+echo "  Certificates to wait for: ${fs_certs[*]}"
+for cert in "${fs_certs[@]}"; do
+    oc wait --for=condition=Ready "certificate.cert-manager.io/${cert}" \
+        -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
 # Kustomize apply may have changed deployment images, triggering new rollouts
 # that run DB migrations. Wait for those to finish before restarting pods —
 # otherwise the restart kills pods mid-migration and leaves the DB dirty.
-for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
@@ -302,7 +321,7 @@ for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
 wait ${pid_cdi} || failed=1
 if (( failed )); then echo "ERROR: TLS certificates or fulfillment rollouts not ready"; exit 1; fi
 echo "[5/9] TLS certificates ready, restarting pods..."
-for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done
 if oc get deploy assisted-service -n multicluster-engine &>/dev/null; then
@@ -315,7 +334,7 @@ fi
 
 wait_fulfillment_rollouts() {
     pids=()
-    for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+    for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
         oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
         pids+=($!)
     done
@@ -388,11 +407,11 @@ echo "[8/9] Configuring AAP access and fulfillment service..."
 ./scripts/prepare-fulfillment-service.sh
 
 echo "[9/9] Restarting fulfillment pods and configuring tenant..."
-for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done
 pids=()
-for deploy in fulfillment-controller fulfillment-grpc-server fulfillment-rest-gateway fulfillment-ingress-proxy; do
+for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done


### PR DESCRIPTION
Otherwise the CI fails if new certs are added,  such as here: https://github.com/osac-project/fulfillment-service/pull/631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deployment refresh now dynamically discovers fulfillment services and drives rollout/restart sequencing from the discovered set, improving scalability and reliability.
* **Bug Fixes**
  * TLS phase now waits for related certificates to reach Ready and fails explicitly if no matching deployments or certificates are found.
  * Job-launch requests now fail on non-success HTTP responses to surface errors promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->