### PR TITLE
Improve error reporting in post-install prepare scripts

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -61,6 +61,35 @@ wait_for_resource() {
     oc wait --for="${condition}" "${resource}" ${ns_args[@]+"${ns_args[@]}"} --timeout="${timeout}s"
 }
 
+# Fail with a clear message if a hostname does not resolve.
+# Usage: require_host_resolvable <hostname>
+require_host_resolvable() {
+    local host="$1"
+    if ! getent ahosts "${host}" &>/dev/null; then
+        echo "ERROR: Cannot resolve hostname '${host}'." >&2
+        echo "Add it to /etc/hosts pointing at your cluster ingress IP." >&2
+        echo "  oc get routes -n <namespace> -o jsonpath='{range .items[*]}{.spec.host}{\"\\n\"}{end}'" >&2
+        exit 1
+    fi
+}
+
+# Require an OpenShift Route to exist and return its host.
+# Usage: get_route_host <namespace> <route-name>
+get_route_host() {
+    local namespace="$1" route_name="$2" host="" rc=0
+    host=$(oc get route "${route_name}" -n "${namespace}" -o jsonpath='{.spec.host}' 2>&1) || rc=$?
+    if (( rc != 0 )); then
+        echo "ERROR: failed to get route '${route_name}' in namespace '${namespace}':" >&2
+        echo "${host}" >&2
+        exit 1
+    fi
+    if [[ -z "${host}" ]]; then
+        echo "ERROR: Route '${route_name}' not found in namespace '${namespace}'." >&2
+        exit 1
+    fi
+    echo "${host}"
+}
+
 # Retry a command until it succeeds or times out.
 # All output (stdout/stderr) is preserved on every attempt.
 # Usage: retry_command <timeout_seconds> <interval_seconds> <command> [args...]
@@ -78,6 +107,10 @@ retry_command() {
         if (( rc == 0 )); then
             echo "  retry_command: succeeded on attempt ${attempt} after $(( SECONDS - start ))s"
             return 0
+        fi
+        if (( rc == 127 )); then
+            echo "  retry_command: command not found — install it and ensure it is on PATH" >&2
+            return 127
         fi
         if (( SECONDS - start >= timeout )); then
             echo "  retry_command: FAILED after ${attempt} attempts, $(( SECONDS - start ))s elapsed (exit code ${rc})"

--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -15,6 +15,10 @@ fi
 
 echo "Creating AAP API token for OSAC operator (namespace: ${INSTALLER_NAMESPACE})..."
 
+AAP_ROUTE_HOST=$(get_route_host "${INSTALLER_NAMESPACE}" osac-aap)
+require_host_resolvable "${AAP_ROUTE_HOST}"
+AAP_URL="https://${AAP_ROUTE_HOST}"
+
 SECRET_B64=""
 rc=0
 SECRET_B64=$(oc get secret osac-aap-admin-password -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.password}' 2>&1) || rc=$?

--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -13,12 +13,21 @@ if [[ -z "${INSTALLER_NAMESPACE:-}" ]]; then
     [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: INSTALLER_NAMESPACE not set and could not determine from overlay" && exit 1
 fi
 
-# Get the AAP gateway route URL
-AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
-AAP_URL="https://${AAP_ROUTE_HOST}"
+echo "Creating AAP API token for OSAC operator (namespace: ${INSTALLER_NAMESPACE})..."
 
-# Get the AAP admin password
-AAP_ADMIN_PASSWORD=$(oc get secret osac-aap-admin-password -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.password}' | base64 -d)
+SECRET_B64=""
+rc=0
+SECRET_B64=$(oc get secret osac-aap-admin-password -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.password}' 2>&1) || rc=$?
+if (( rc != 0 )); then
+    echo "ERROR: failed to get secret osac-aap-admin-password in ${INSTALLER_NAMESPACE}:" >&2
+    echo "${SECRET_B64}" >&2
+    exit 1
+fi
+AAP_ADMIN_PASSWORD=$(printf '%s' "${SECRET_B64}" | base64 -d)
+[[ -n "${AAP_ADMIN_PASSWORD}" ]] || {
+    echo "ERROR: Secret osac-aap-admin-password is missing or empty in ${INSTALLER_NAMESPACE}" >&2
+    exit 1
+}
 
 AAP_TOKEN=$(http_json "Failed to create AAP API token (gateway may be rolling out)" 30 10 \
     '.token // empty' \
@@ -28,11 +37,10 @@ AAP_TOKEN=$(http_json "Failed to create AAP API token (gateway may be rolling ou
     "${AAP_URL}/api/gateway/v1/tokens/")
 
 if [[ -z "${AAP_TOKEN}" || "${AAP_TOKEN}" == "null" ]]; then
-    echo "ERROR: AAP API token was empty"
+    echo "ERROR: Failed to create AAP API token (empty or null token in response)" >&2
     exit 1
 fi
 
-# Store the token in a Kubernetes secret
 oc create secret generic osac-aap-api-token \
     --from-literal=token="${AAP_TOKEN}" \
     -n "${INSTALLER_NAMESPACE}" \

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -15,11 +15,24 @@ fi
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 INSTALLER_CLUSTER_TEMPLATE=${INSTALLER_CLUSTER_TEMPLATE:-}
 
+command -v osac &>/dev/null || {
+    echo "ERROR: 'osac' CLI not found on PATH." >&2
+    echo "Install from: https://github.com/osac-project/fulfillment-service/releases/latest/download/osac_Linux_x86_64" >&2
+    exit 1
+}
+
+echo "Registering hub with fulfillment service (namespace: ${INSTALLER_NAMESPACE})..."
+
 create_hub() {
     ./scripts/create-hub-access-kubeconfig.sh
 
-    local fulfillment_url
-    fulfillment_url=https://$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-internal-api -o jsonpath='{.status.ingress[0].host}')
+    # The private API (osac.private.v1.*) is only available via the internal listener
+    # (fulfillment-internal-api route, port 8001). The external listener
+    # (fulfillment-api route, port 8000) only routes public API methods.
+    local fulfillment_host fulfillment_url
+    fulfillment_host=$(get_route_host "${INSTALLER_NAMESPACE}" fulfillment-internal-api)
+    require_host_resolvable "${fulfillment_host}"
+    fulfillment_url="https://${fulfillment_host}"
     echo "Fulfillment internal API URL: ${fulfillment_url}"
 
     echo "Logging into fulfillment internal API..."
@@ -39,7 +52,8 @@ sync_aap_project() {
     local AAP_ROUTE_HOST AAP_URL AAP_TOKEN JT_ID PROJECT_ID
     local EXPECTED_BRANCH EXPECTED_URI
 
-    AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
+    AAP_ROUTE_HOST=$(get_route_host "${INSTALLER_NAMESPACE}" osac-aap)
+    require_host_resolvable "${AAP_ROUTE_HOST}"
     AAP_URL="https://${AAP_ROUTE_HOST}"
     AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
 
@@ -117,7 +131,8 @@ sync_aap_project() {
 publish_templates() {
     local AAP_ROUTE_HOST AAP_URL AAP_TOKEN JT_ID PROJECT_ID
 
-    AAP_ROUTE_HOST=$(oc get routes -n "${INSTALLER_NAMESPACE}" --no-headers osac-aap -o jsonpath='{.spec.host}')
+    AAP_ROUTE_HOST=$(get_route_host "${INSTALLER_NAMESPACE}" osac-aap)
+    require_host_resolvable "${AAP_ROUTE_HOST}"
     AAP_URL="https://${AAP_ROUTE_HOST}"
     AAP_TOKEN=$(oc get secret osac-aap-api-token -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.data.token}' | base64 -d)
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -421,13 +421,13 @@ wait_for_resource deployment/fulfillment-ingress-proxy condition=Available 300 $
 # Update project context
 oc project ${INSTALLER_NAMESPACE}
 
-# Create AAP API token for the OSAC operator
+echo "Creating AAP API token for the OSAC operator..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-aap.sh
 
-# Setup OSAC CLI, register hub
+echo "Setting up OSAC CLI and registering hub..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-fulfillment-service.sh
 
-# Prepare tenant
+echo "Preparing tenant..."
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" ./scripts/prepare-tenant.sh
 
 echo ""


### PR DESCRIPTION
Surface DNS resolution failures, missing routes, curl errors, and a missing osac CLI instead of exiting silently under errexit. Also, add step banners to setup.sh so progress is visible after long bootstrap waits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and messaging for missing CLI tools and unresolved hostnames.
  * Strengthened validation for required AAP secrets and API tokens, with clearer errors for empty/null values.

* **Chores**
  * Improved gateway and service URL construction by using consistent route host discovery and resolvability checks.
  * Added clearer setup progress output and an additional “Preparing tenant…” marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->