### PR TITLE
OSAC-1315: fix Helm deploy deadlock in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -257,11 +257,76 @@ wait_for_namespace_cleanup "${INSTALLER_NAMESPACE}"
 
 if [[ "${DEPLOY_MODE}" == "helm" ]]; then
     # --- Helm deployment mode ---
+    #
+    # helm --wait blocks until all pods are Ready. Several resources that pods
+    # mount as required volumes must exist before the install starts.
+
+    # Create the namespace early so pre-deploy resources can target it.
+    oc create namespace "${INSTALLER_NAMESPACE}" --dry-run=client -o yaml | oc apply -f -
+
+    # Ensure the shared ca-bundle Bundle exists and the ConfigMap is populated.
+    "${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
+    echo "Waiting for ca-bundle ConfigMap..."
+    retry_until 120 3 'oc get configmap ca-bundle -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.data.bundle\.pem}'"'"' 2>/dev/null | grep -q "BEGIN CERTIFICATE"'
+
+    # Create controller OAuth credentials from the Keycloak realm config.
+    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+    oc create secret generic fulfillment-controller-credentials \
+        --from-literal=client-id=osac-controller \
+        --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+        -n "${INSTALLER_NAMESPACE}" \
+        --dry-run=client -o yaml | oc apply -f -
+
+    # Deploy the fulfillment database. The fulfillment-service chart expects an
+    # external PostgreSQL with connection details in 'fulfillment-db' and client
+    # TLS in 'postgres-client-cert-service'.
+    echo "Deploying fulfillment database..."
+    helm upgrade --install fulfillment-db \
+        base/osac-fulfillment-service/it/charts/postgres/ \
+        --namespace "${INSTALLER_NAMESPACE}" \
+        --set certs.issuerRef.name=default-ca \
+        --set certs.caBundle.configMap=ca-bundle \
+        --set 'databases[0].name=service' \
+        --set 'databases[0].user=service' \
+        --timeout 5m \
+        --wait
+
+    # Create client certificate for the 'service' database user.
+    # The postgres chart does not generate per-user client certs yet.
+    oc apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  namespace: ${INSTALLER_NAMESPACE}
+  name: postgres-client-cert-service
+spec:
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-ca
+  commonName: service
+  usages:
+  - client auth
+  secretName: postgres-client-cert-service
+  privateKey:
+    rotationPolicy: Always
+EOF
+    oc wait certificate/postgres-client-cert-service -n "${INSTALLER_NAMESPACE}" --for=condition=Ready --timeout=60s
+
+    # Create the connection secret for the fulfillment gRPC server.
+    DB_URL="postgres://service@postgres:5432/service?sslmode=verify-full"
+    DB_URL+="&sslcert=/etc/fulfillment-grpc-server/db/sslcert"
+    DB_URL+="&sslkey=/etc/fulfillment-grpc-server/db/sslkey"
+    DB_URL+="&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert"
+    oc create secret generic fulfillment-db \
+        --from-literal=url="${DB_URL}" \
+        -n "${INSTALLER_NAMESPACE}" \
+        --dry-run=client -o yaml | oc apply -f -
+
     echo "Deploying OSAC using Helm..."
     helm dependency build charts/osac/
     helm upgrade --install osac charts/osac/ \
         --namespace "${INSTALLER_NAMESPACE}" \
-        --create-namespace \
         --values "${VALUES_FILE}" \
         --timeout 40m \
         --wait
@@ -269,19 +334,19 @@ else
     # --- Kustomize deployment mode (legacy) ---
     echo "Deploying OSAC using Kustomize..."
     oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}" --server-side --force-conflicts
+
+    # Ensure the shared ca-bundle Bundle exists and includes our namespace
+    "${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
+
+    # Create controller OAuth credentials from the Keycloak realm config
+    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+    oc create secret generic fulfillment-controller-credentials \
+        --from-literal=client-id=osac-controller \
+        --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+        -n "${INSTALLER_NAMESPACE}" \
+        --dry-run=client -o yaml | oc apply -f -
 fi
-
-# Ensure the shared ca-bundle Bundle exists and includes our namespace
-"${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
-
-# Create controller OAuth credentials from the Keycloak realm config
-FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
-[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
-oc create secret generic fulfillment-controller-credentials \
-    --from-literal=client-id=osac-controller \
-    --from-literal=client-secret="${FC_CLIENT_SECRET}" \
-    -n ${INSTALLER_NAMESPACE} \
-    --dry-run=client -o yaml | oc apply -f -
 
 # Apply cluster-fulfillment-ig configmap/secret overrides from environment variables
 INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \


### PR DESCRIPTION
## Summary

Fixes [OSAC-1315](https://redhat.atlassian.net/browse/OSAC-1315) — the `e2e-vmaas-full-setup-helm` periodic job fails 100% because `setup.sh` deadlocks during Helm install.

**Root cause:** `helm upgrade --install --wait` blocks waiting for pods, but the pods need resources (`ca-bundle` ConfigMap, `fulfillment-controller-credentials` secret, `fulfillment-db` secret) that are either created *after* Helm returns or never created in Helm mode.

### Changes

1. **Move `ensure-ca-bundle.sh` and `fulfillment-controller-credentials` creation before the Helm install** — these ran after the `if/else` block, but `helm --wait` blocks indefinitely because pods mount them as required volumes. Now runs before for both modes (idempotent, no kustomize impact).

2. **Deploy the fulfillment database before OSAC Helm install** (Helm mode only) — uses the existing `it/charts/postgres` chart. The fulfillment-service chart expects an external PostgreSQL but nothing in the Helm path provisioned one. Also creates the client certificate and `fulfillment-db` connection secret.

3. **Create namespace early** — needed so trust-manager can target it with the `ca-bundle` Bundle CR before Helm runs. Removes `--create-namespace` from the OSAC Helm install since it already exists.

### Evidence from the failing job

4 pods stuck in `ContainerCreating` for 40 minutes until Helm times out:
```
FailedMount  (x27 over 40m)  pod/authorino-...              configmap "ca-bundle" not found
FailedMount  (x23 over 40m)  pod/fulfillment-controller-... configmap "ca-bundle" not found
FailedMount  (x18 over 40m)  pod/fulfillment-controller-... secret "fulfillment-controller-credentials" not found
FailedMount  (x26 over 40m)  pod/fulfillment-grpc-server-.. secret "fulfillment-db" not found
```

Equivalent kustomize job (build `2063773341717630976`) passes.

## Test plan

- [ ] `e2e-vmaas-full-setup-helm` periodic job passes
- [ ] Kustomize path is unaffected (all moved code is idempotent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability by preparing namespaces, trust bundles, and controller credentials before deployment
  * Made namespace creation idempotent and added readiness checks for the certificate bundle
  * Ensured controller credentials are resolved up front and fail-fast if missing
  * Prepared external database and TLS assets prior to Helm deployment and adjusted Helm install behavior
  * Applied same preparatory steps for Kustomize installs to avoid timing issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->