### PR TITLE
NO-ISSUE: Fix ingress-proxy stale config deadlock in refresh-after-sn…

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -306,6 +306,9 @@ for cert in "${fs_certs[@]}"; do
         -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
+# Envoy never re-reads its config after startup. Restart ingress-proxy before
+# the rollout wait so that pods depending on new routes (e.g. JWKS) can start.
+oc rollout restart deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}"
 # Kustomize apply may have changed deployment images, triggering new rollouts
 # that run DB migrations. Wait for those to finish before restarting pods —
 # otherwise the restart kills pods mid-migration and leaves the DB dirty.


### PR DESCRIPTION
…apshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a deployment timing issue where the ingress-proxy service could continue running with outdated configuration, preventing downstream services from using newly configured routes and settings. The service now restarts at the proper point during deployment to ensure all configuration changes take effect immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->