### PR TITLE
OWNERS: restrict /override to wg-infra only

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,22 +1,24 @@
-approvers:
-- jhernand
-- adriengentil
-- tzvatot
-- larsks
-- tzumainn
-- akshaynadkarni
-- trewest
-- danmanor
-- omer-vishlitzky
-- eranco74
-reviewers:
-- jhernand
-- adriengentil
-- tzvatot
-- larsks
-- tzumainn
-- akshaynadkarni
-- trewest
-- danmanor
-- omer-vishlitzky
-- eranco74
+filters:
+  "[^.]":
+    approvers:
+    - jhernand
+    - adriengentil
+    - tzvatot
+    - larsks
+    - tzumainn
+    - akshaynadkarni
+    - trewest
+    - danmanor
+    - omer-vishlitzky
+    - eranco74
+    reviewers:
+    - jhernand
+    - adriengentil
+    - tzvatot
+    - larsks
+    - tzumainn
+    - akshaynadkarni
+    - trewest
+    - danmanor
+    - omer-vishlitzky
+    - eranco74


### PR DESCRIPTION
## Summary

- Restructure OWNERS to use `filters: "[^.]":` pattern so that `TopLevelApprovers()` returns empty, restricting `/override` to `wg-infra` team members only.

## Related

- [OSAC-1322](https://redhat.atlassian.net/browse/OSAC-1322)
- Prow config PR: https://github.com/openshift/release/pull/80291