### PR TITLE
OSAC-1083: OSAC-1397: Add schema validation and fix subchart version pinning

### DIFF
--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -6,18 +6,18 @@ version: 0.0.1
 
 dependencies:
   - name: osac-operator-crds
-    version: "0.0.0"
+    version: ">=0.0.0"
     repository: "file://../../base/osac-operator/charts/operator-crds"
     alias: operatorCrds
   - name: osac-operator
-    version: "0.0.0"
+    version: ">=0.0.0"
     repository: "file://../../base/osac-operator/charts/operator"
     alias: operator
   - name: fulfillment-service
-    version: "0.0.0"
+    version: ">=0.0.0"
     repository: "file://../../base/osac-fulfillment-service/charts/service"
     alias: service
   - name: osac-aap
-    version: "0.0.0"
+    version: ">=0.0.0"
     repository: "file://../../base/osac-aap/charts/aap"
     alias: aap

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -94,6 +94,7 @@
     "service": {
       "type": "object",
       "description": "Fulfillment Service configuration",
+      "required": ["auth", "certs"],
       "properties": {
         "variant": {
           "type": "string",
@@ -111,6 +112,66 @@
             "envoy": {
               "type": "string",
               "description": "Envoy proxy container image"
+            }
+          }
+        },
+        "certs": {
+          "type": "object",
+          "description": "TLS certificate configuration",
+          "required": ["issuerRef"],
+          "properties": {
+            "issuerRef": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "description": "Issuer kind (ClusterIssuer or Issuer)",
+                  "enum": ["ClusterIssuer", "Issuer"],
+                  "default": "ClusterIssuer"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the cert-manager ClusterIssuer or Issuer",
+                  "minLength": 1
+                }
+              }
+            },
+            "caBundle": {
+              "type": "object",
+              "properties": {
+                "configMap": {
+                  "type": "string",
+                  "description": "ConfigMap name containing the CA bundle"
+                }
+              }
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "description": "Authentication configuration",
+          "required": ["issuerUrl"],
+          "properties": {
+            "issuerUrl": {
+              "type": "string",
+              "description": "OIDC issuer URL (e.g. Keycloak realm URL)",
+              "minLength": 1,
+              "pattern": "^https?://"
+            },
+            "controllerCredentials": {
+              "type": "array",
+              "description": "Controller credential volume sources"
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "description": "Database configuration",
+          "properties": {
+            "connection": {
+              "type": "array",
+              "description": "Database connection volume sources (secret or configMap references)"
             }
           }
         }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -50,7 +50,7 @@ service:
     caBundle:
       configMap: ca-bundle
   auth:
-    issuerUrl: ""
+    issuerUrl: "https://REPLACE_ME"
     controllerCredentials: []
   idp:
     provider: keycloak


### PR DESCRIPTION
## Summary
- Use version range `">=0.0.0"` in `Chart.yaml` for `file://` dependencies so submodule bumps don't break `helm dependency build` when subcharts change their version (fixes #248)
- Update publish workflow to read each subchart's actual version from its own `Chart.yaml` using `yq` instead of assuming a single version for all
- Add required field validation in `values.schema.json` for `service.auth.issuerUrl` (URL pattern) and `service.certs.issuerRef.name`
- Set `issuerUrl` default to `https://REPLACE_ME` placeholder so `helm lint` / `ct lint` passes with schema enforcement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened Helm chart dependency version constraints for increased flexibility
  * Enhanced configuration requirements for service authentication and certificate management
  * Updated configuration schema with additional TLS and authentication setup options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->