### PR TITLE
Updating OSAC Helm Chart for AAP Version

### DIFF
--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -18,6 +18,6 @@ dependencies:
     repository: "file://../../base/osac-fulfillment-service/charts/service"
     alias: service
   - name: osac-aap
-    version: "0.0.0"
+    version: "0.1.0"
     repository: "file://../../base/osac-aap/charts/aap"
     alias: aap


### PR DESCRIPTION
Helm version of the dependent [AAP chart](https://github.com/osac-project/osac-aap/blob/main/charts/aap/Chart.yaml) is at 0.1.0, but the OSAC chart still points to 0.0.0. Helm install currently fails with
```
Error: can't get a valid version for 1 subchart(s): "osac-aap" (repository "file://../../base/osac-aap/charts/aap", version "0.0.0"). Make sure a matching chart version exists in the repo, or change the version constraint in Chart.yaml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `osac-aap` dependency to version `0.1.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->