### PR TITLE
NO-ISSUE: Document AAP bootstrap EE image wiring and fix setup.sh overlay grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,19 +285,26 @@ To test a specific revision of a component, you need to:
        newTag: <your-tag>
    ```
 
-   The component image names used in the base are:
+   Overlays include `../../base`, which already applies image transforms. Use the
+   **resolved** image name from base in overlay `images:` entries (not the
+   placeholder in component manifests), or the override is ignored:
 
-   | Component | Image name |
-   |-----------|-----------|
-   | Fulfillment Service | `fulfillment-service` |
-   | OSAC Operator | `osac-operator` |
-   | OSAC AAP | `osac-aap` |
-   | Bare Metal Fulfillment Operator | `bare-metal-fulfillment-operator` |
+   | Component | Overlay `images.name` |
+   |-----------|----------------------|
+   | Fulfillment Service | `ghcr.io/osac-project/fulfillment-service` |
+   | OSAC Operator | `ghcr.io/osac-project/osac-operator` |
+   | OSAC AAP | `ghcr.io/osac-project/osac-aap` |
+   | Bare Metal Fulfillment Operator | `ghcr.io/osac-project/bare-metal-fulfillment-operator` |
 
 #### OSAC AAP Customization
 
-For osac-aap, in addition to the image override, you must also update the AAP
-configuration secrets in your overlay's `kustomization.yaml`:
+The `aap-bootstrap` Job pulls its container image from overlay `images:` while
+`AAP_EE_IMAGE` registers the EE inside AAP — both must stay aligned. See
+[AAP Configuration](docs/aap-configuration.md#bootstrap-job-image-vs-aap_ee_image)
+for details.
+
+In addition to the image override, update the AAP configuration secrets in your
+overlay's `kustomization.yaml`:
 
 ```yaml
 secretGenerator:

--- a/docs/aap-configuration.md
+++ b/docs/aap-configuration.md
@@ -33,6 +33,32 @@ INSTALLER_NAMESPACE=<project-name> ./scripts/aap-configuration.sh
 Shell environment variables override values from the env files, which is useful
 for CI pipelines.
 
+## Bootstrap job image vs `AAP_EE_IMAGE`
+
+The `aap-bootstrap` Job uses two independent mechanisms to reference the OSAC
+execution environment (EE) image. Overlays must keep both aligned when pinning a
+custom registry or tag.
+
+| Mechanism | Where to set | What it controls |
+|-----------|--------------|------------------|
+| Kustomize `images:` | Overlay `kustomization.yaml` — transform placeholder `osac-aap` | Container image for the `aap-bootstrap` pod (runs `ansible-playbook`) |
+| `AAP_EE_IMAGE` | `config-as-code-ig` secret literal (or Helm equivalent) | EE image registered **inside AAP** by `osac.config_as_code.configure` |
+
+Base `kustomization.yaml` maps placeholder `osac-aap` to `ghcr.io/osac-project/osac-aap:<tag>`.
+Overlays that only set `AAP_EE_IMAGE` in `config-as-code-ig` do not change the bootstrap
+pod image — the Job will still pull from `ghcr.io` unless the overlay also adds an
+`images:` entry. Match the **resolved** image name from base (not the placeholder):
+
+```yaml
+images:
+  - name: ghcr.io/osac-project/osac-aap
+    newName: quay.io/<your-registry>/osac-aap
+    newTag: sha-<commit>
+```
+
+Use the same registry and tag for `AAP_EE_IMAGE` so bootstrap, AAP EE registration, and
+subsequent job pods stay consistent.
+
 ## ConfigMap Variables (`osac-aap-configuration.env`)
 
 | Variable | Default | Description |

--- a/docs/aap-configuration.md
+++ b/docs/aap-configuration.md
@@ -41,7 +41,7 @@ custom registry or tag.
 
 | Mechanism | Where to set | What it controls |
 |-----------|--------------|------------------|
-| Kustomize `images:` | Overlay `kustomization.yaml` — transform placeholder `osac-aap` | Container image for the `aap-bootstrap` pod (runs `ansible-playbook`) |
+| Kustomize `images:` | Overlay `kustomization.yaml` — match resolved name `ghcr.io/osac-project/osac-aap` | Container image for the `aap-bootstrap` pod (runs `ansible-playbook`) |
 | `AAP_EE_IMAGE` | `config-as-code-ig` secret literal (or Helm equivalent) | EE image registered **inside AAP** by `osac.config_as_code.configure` |
 
 Base `kustomization.yaml` maps placeholder `osac-aap` to `ghcr.io/osac-project/osac-aap:<tag>`.

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -127,5 +127,15 @@ http_json() {
     return 1
 }
 
+# Shared dev clusters use overlays/_shared/console-proxy-shared-dev so console-proxy
+# runs in the fixed "osac" namespace (cluster-scoped APIService). Dedicated overlays
+# deploy console-proxy in INSTALLER_NAMESPACE and may mention the shared component
+# only in comments — match the components list entry, not arbitrary text.
+overlay_uses_shared_console_proxy() {
+    local overlay="${1:?overlay name required}"
+    grep -Eq '^[[:space:]]*- \.\./_shared/console-proxy-shared-dev[[:space:]]*$' \
+        "overlays/${overlay}/kustomization.yaml" 2>/dev/null
+}
+
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_LIB_DIR}/oc.sh"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -133,7 +133,7 @@ http_json() {
 # only in comments — match the components list entry, not arbitrary text.
 overlay_uses_shared_console_proxy() {
     local overlay="${1:?overlay name required}"
-    grep -Eq '^[[:space:]]*- \.\./_shared/console-proxy-shared-dev[[:space:]]*$' \
+    grep -Eq '^[[:space:]]*-[[:space:]]+"?\.\./_shared/console-proxy-shared-dev"?([[:space:]]+#.*)?[[:space:]]*$' \
         "overlays/${overlay}/kustomization.yaml" 2>/dev/null
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -431,8 +431,7 @@ INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
 if [[ "${DEPLOY_MODE}" == "helm" ]]; then
   CONSOLE_PROXY_NS="${INSTALLER_NAMESPACE}"
   CONSOLE_PROXY_DEPLOY="fulfillment-console-proxy"
-elif grep -Eq '^[[:space:]]*- \.\./_shared/console-proxy-shared-dev[[:space:]]*$' \
-    "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" 2>/dev/null; then
+elif overlay_uses_shared_console_proxy "${INSTALLER_KUSTOMIZE_OVERLAY}"; then
   CONSOLE_PROXY_NS="osac"
   CONSOLE_PROXY_DEPLOY="osac-console-proxy"
 else

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -431,7 +431,7 @@ INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
 if [[ "${DEPLOY_MODE}" == "helm" ]]; then
   CONSOLE_PROXY_NS="${INSTALLER_NAMESPACE}"
   CONSOLE_PROXY_DEPLOY="fulfillment-console-proxy"
-elif grep -q 'console-proxy-shared-dev' \
+elif grep -Eq '^[[:space:]]*- \.\./_shared/console-proxy-shared-dev[[:space:]]*$' \
     "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" 2>/dev/null; then
   CONSOLE_PROXY_NS="osac"
   CONSOLE_PROXY_DEPLOY="osac-console-proxy"


### PR DESCRIPTION
## Problem

### 1. Dual image wiring for `aap-bootstrap`

The bootstrap Job pulls its container image from kustomize `images:` (placeholder `osac-aap` → `ghcr.io/osac-project/osac-aap` in base), but registers the execution environment inside AAP from `AAP_EE_IMAGE` in the `config-as-code-ig` secret. Overlays that only override `AAP_EE_IMAGE` still run the bootstrap pod from `ghcr.io`, which breaks custom-registry dev overlays.

### 2. `setup.sh` console-proxy namespace false positive

`osac-console-proxy` registers a cluster-scoped APIService, so only one instance can exist per cluster. Overlays handle this two ways:

| Pattern | Overlay config | Where `osac-console-proxy` runs |
|---------|----------------|----------------------------------|
| **Shared** (e.g. `development`) | Includes `components: - ../_shared/console-proxy-shared-dev` | Fixed namespace `osac` (even when `INSTALLER_NAMESPACE` is e.g. `osac-devel`) |
| **Dedicated** (typical personal overlay) | Does **not** include that component; patches `osac-console-proxy` ServiceAccount with `deployment-namespace: <project>` | `INSTALLER_NAMESPACE` |

After deploy, `setup.sh` must wait for the Deployment in the correct namespace.

The old check used `grep -q 'console-proxy-shared-dev'`, which matches **comments** as well as the real component line. A dedicated overlay can document the shared pattern in a comment without including the component:

```yaml
  # Dedicated-namespace console-proxy (see overlays/_shared/console-proxy-shared-dev for shared clusters).
```

That false positive made setup wait for `deployment/osac-console-proxy` in `osac` while the Deployment actually lived in the overlay namespace → timeouts.

## Changes

- **`docs/aap-configuration.md`** — Document bootstrap `images:` vs `AAP_EE_IMAGE`; overlays must target the **resolved** image name (`ghcr.io/osac-project/osac-aap`, not the `osac-aap` placeholder).
- **`scripts/lib.sh`** — `overlay_uses_shared_console_proxy()` matches only the component list entry.
- **`scripts/setup.sh`** — Use that helper to set `CONSOLE_PROXY_NS`.

## Impact

| Overlay type | Before | After |
|--------------|--------|-------|
| Includes `../_shared/console-proxy-shared-dev` (e.g. `development`) | `CONSOLE_PROXY_NS=osac` | unchanged |
| Dedicated console-proxy (component not included; may mention it in comments) | `CONSOLE_PROXY_NS=osac` ❌ | `CONSOLE_PROXY_NS=$INSTALLER_NAMESPACE` ✅ |
| No shared console-proxy | `CONSOLE_PROXY_NS=$INSTALLER_NAMESPACE` | unchanged |

## Test plan

- [x] `bash scripts/kustomize-build-all.sh`
- [x] Grep behavior: component line → shared; comment-only mention → dedicated
- [x] `./scripts/setup.sh` with `INSTALLER_KUSTOMIZE_OVERLAY=development` — waits in `osac`
- [x] `./scripts/setup.sh` with a dedicated-namespace personal overlay — waits in `$INSTALLER_NAMESPACE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how the bootstrap job container image relates to `AAP_EE_IMAGE`, including when Kustomize image overrides are required for the bootstrap pod image to change.
  * Updated guidance for custom component versions and AAP customization, including what to set in overlay configuration secrets.

* **Bug Fixes**
  * Improved console-proxy namespace selection when an overlay uses the shared console-proxy.

* **Chores**
  * Reworked installer script logic to use a more reliable overlay detection helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->