### PR TITLE
OSAC-1406: Rename Keycloak Service to osac-keycloak and align auth URLs

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -14,7 +14,7 @@ operator:
 service:
   variant: openshift
   auth:
-    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials
@@ -23,7 +23,7 @@ service:
           param: client-id
   idp:
     provider: keycloak
-    url: https://keycloak.keycloak.svc.cluster.local
+    url: https://osac-keycloak.keycloak.svc.cluster.local
     credentials:
     - secret:
         name: fulfillment-controller-credentials

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -619,8 +619,8 @@ Key settings to review in your values file:
 | Setting | Description | Where to Find |
 |---------|-------------|---------------|
 | `operator.aap.url` | AAP controller API URL | Set post-install by `prepare-aap.sh` |
-| `service.auth.issuerUrl` | Keycloak realm URL | `https://keycloak.keycloak.svc.cluster.local/realms/osac` (default works) |
-| `service.idp.url` | Keycloak base URL | `https://keycloak.keycloak.svc.cluster.local` (default works) |
+| `service.auth.issuerUrl` | Keycloak realm URL | `https://osac-keycloak.keycloak.svc.cluster.local/realms/osac` (default works) |
+| `service.idp.url` | Keycloak base URL | `https://osac-keycloak.keycloak.svc.cluster.local` (default works) |
 | `service.database.connection` | PostgreSQL connection | Referenced from `fulfillment-db` secret |
 | `aap.aap.instance.enabled` | Create AAP instance CR | `true` (chart manages AAP instance) |
 | `aap.bootstrap.enabled` | Run bootstrap job | `true` (configures AAP with job templates) |

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -271,7 +271,9 @@ oc wait deployment/authorino-operator -n openshift-operators \
 ### 1.8 Keycloak
 
 Keycloak provides identity management (OAuth/OIDC) for OSAC. It includes its
-own PostgreSQL database.
+own PostgreSQL database. The in-cluster Service and Route are named
+`osac-keycloak` (see [keycloak-service-rename.md](keycloak-service-rename.md)
+for upgrading environments that still have the old `keycloak` Service/Route).
 
 ```bash
 oc apply -k prerequisites/keycloak/

--- a/docs/keycloak-service-rename.md
+++ b/docs/keycloak-service-rename.md
@@ -1,0 +1,160 @@
+# Keycloak Service Rename Migration
+
+The in-cluster Keycloak `Service` and `Route` were renamed from `keycloak` to
+`osac-keycloak` to avoid clashing with generic `keycloak` service names on shared
+clusters.
+
+This guide covers upgrading existing environments. Greenfield installs can ignore
+it — `oc apply -k prerequisites/keycloak/` already creates `osac-keycloak`.
+
+## What changed
+
+| Resource | Before | After |
+|----------|--------|-------|
+| Service | `keycloak` | `osac-keycloak` |
+| Route | `keycloak` | `osac-keycloak` |
+| In-cluster DNS | `keycloak.keycloak.svc.cluster.local` | `osac-keycloak.keycloak.svc.cluster.local` |
+| TLS cert SANs | `keycloak`, `keycloak.keycloak.svc.cluster.local` | `osac-keycloak`, `osac-keycloak.keycloak.svc.cluster.local` |
+| `KC_HOSTNAME` | `keycloak.keycloak.svc.cluster.local` | `osac-keycloak.keycloak.svc.cluster.local` |
+
+**Unchanged:** the `keycloak` namespace, `keycloak-service` Deployment, database,
+and realm ConfigMap names.
+
+## Who is affected
+
+Apply this migration if your environment uses any of:
+
+- Fulfillment auth URLs pointing at `keycloak.keycloak.svc.cluster.local`
+- `scripts/refresh-after-snapshot.sh` (looks up the Keycloak Route by name)
+- An overlay with hardcoded external route hostnames derived from the old Route
+  name (for example `keycloak-keycloak.apps.<cluster>`)
+
+Installer overlays updated in the rename PR: `development`, `caas-ci`,
+`vmaas-ci`, `osac-integration`.
+
+**Not updated (separate follow-up if needed):**
+
+- `base/osac-fulfillment-service` submodule defaults (`:8000` hostname, used by
+  kind/local dev and overlays that do not patch auth URLs, such as `hypershift2`)
+- Personal or fork-specific overlays (for example `tohughes-dev`)
+
+## Upgrade procedure
+
+Run these steps in order. Expect a brief auth outage while JWT issuer URLs change.
+
+### 1. Apply updated Keycloak prerequisites
+
+```bash
+oc apply -k prerequisites/keycloak/
+```
+
+Wait for the deployment and certificate:
+
+```bash
+oc wait deployment/keycloak-service -n keycloak --for=condition=Available --timeout=600s
+oc wait --for=condition=Ready certificate/keycloak-tls -n keycloak --timeout=300s
+```
+
+Kustomize creates the new `osac-keycloak` Service and Route but does **not**
+remove the old `keycloak` Service/Route. Both may point at the same pods until
+you clean up in step 4.
+
+### 2. Verify Keycloak on the new service
+
+From a pod in the `keycloak` namespace:
+
+```bash
+curl -k -s -o /dev/null -w '%{http_code}\n' https://osac-keycloak:443/realms/osac
+```
+
+Expect `200`. The password-setup job uses this short name.
+
+For external access, confirm the new Route hostname:
+
+```bash
+oc get route osac-keycloak -n keycloak -o jsonpath='{.spec.host}{"\n"}'
+```
+
+OpenShift route hostnames follow `<route-name>-<namespace>.apps.<domain>`. After
+the rename, external URLs change from `keycloak-keycloak.apps...` to
+`osac-keycloak-keycloak.apps...`.
+
+### 3. Apply the fulfillment overlay
+
+Re-apply your installer overlay so fulfillment auth issuer/idp URLs match the
+new hostname. For example:
+
+```bash
+oc apply -k overlays/development/
+# or overlays/caas-ci/, overlays/vmaas-ci/, overlays/osac-integration/, etc.
+```
+
+Wait for fulfillment deployments to roll out:
+
+```bash
+oc rollout status deployment/fulfillment-controller -n <namespace> --timeout=300s
+oc rollout status deployment/fulfillment-grpc-server -n <namespace> --timeout=300s
+```
+
+### 4. Delete orphaned resources
+
+After fulfillment auth works against `osac-keycloak`, remove the old Service and
+Route:
+
+```bash
+oc delete route keycloak -n keycloak --ignore-not-found
+oc delete service keycloak -n keycloak --ignore-not-found
+```
+
+### 5. Re-authenticate clients
+
+`KC_HOSTNAME` and issuer URLs change with the rename. Existing JWTs issued under
+the old hostname are rejected until clients obtain new tokens.
+
+## Environment-specific notes
+
+### CI overlays (`caas-ci`, `vmaas-ci`, `development`)
+
+Auth URLs use in-cluster DNS on port 443 (via the Service port mapping):
+
+```
+https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
+```
+
+### `osac-integration`
+
+This overlay uses the external Route hostname, not in-cluster DNS. After
+redeploying prerequisites, update auth URLs to match the new route host (or
+re-apply the overlay from a branch that includes the rename).
+
+### Helm deployments
+
+Set values explicitly:
+
+```yaml
+service:
+  auth:
+    issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
+  idp:
+    url: https://osac-keycloak.keycloak.svc.cluster.local
+```
+
+See `values/development.yaml` and `charts/osac/ci/full-values.yaml` for examples.
+
+## Rollback
+
+If you need to revert before deleting the old resources:
+
+1. Re-apply the previous installer/overlay revision with old auth URLs.
+2. Re-apply previous `prerequisites/keycloak/` manifests (old Service/Route names).
+3. Delete `osac-keycloak` Service and Route if they were created.
+
+Rollback is only straightforward if step 4 cleanup has not run yet.
+
+## Verification checklist
+
+- [ ] `https://osac-keycloak:443/realms/osac` returns 200 from inside the `keycloak` namespace
+- [ ] Fulfillment controller and gRPC server pods are running
+- [ ] `osac login` (or equivalent API call with a fresh token) succeeds
+- [ ] `scripts/refresh-after-snapshot.sh` keycloak sync completes (uses `route/osac-keycloak`)
+- [ ] Old `service/keycloak` and `route/keycloak` are deleted

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -96,10 +96,10 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/command/7
-        value: "--auth-issuer-url=https://keycloak.keycloak.svc.cluster.local/realms/osac"
+        value: "--auth-issuer-url=https://osac-keycloak.keycloak.svc.cluster.local/realms/osac"
       - op: replace
         path: /spec/template/spec/containers/0/command/11
-        value: "--idp-url=https://keycloak.keycloak.svc.cluster.local"
+        value: "--idp-url=https://osac-keycloak.keycloak.svc.cluster.local"
   - target:
       kind: Deployment
       name: osac-operator-controller-manager
@@ -172,7 +172,7 @@ patches:
         authentication:
           keycloak-jwt:
             jwt:
-              issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+              issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
         authorization:
           default:
             opa:

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -114,10 +114,10 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/command/7
-        value: "--auth-issuer-url=https://keycloak.keycloak.svc.cluster.local/realms/osac"
+        value: "--auth-issuer-url=https://osac-keycloak.keycloak.svc.cluster.local/realms/osac"
       - op: replace
         path: /spec/template/spec/containers/0/command/11
-        value: "--idp-url=https://keycloak.keycloak.svc.cluster.local"
+        value: "--idp-url=https://osac-keycloak.keycloak.svc.cluster.local"
   - target:
       kind: Deployment
       name: osac-operator-controller-manager
@@ -190,7 +190,7 @@ patches:
         authentication:
           keycloak-jwt:
             jwt:
-              issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+              issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
         authorization:
           default:
             opa:

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -98,11 +98,11 @@ patches:
                 - --log-headers=false
                 - --log-bodies=true
                 - --ca-file=/etc/fulfillment-controller/tls/cas
-                - --auth-issuer-url=https://keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
+                - --auth-issuer-url=https://osac-keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
                 - --auth-client-id-file=/etc/fulfillment-controller/credentials/client-id
                 - --auth-client-secret-file=/etc/fulfillment-controller/credentials/client-secret
                 - --idp-provider=keycloak
-                - --idp-url=https://keycloak-keycloak.apps.osac-integration.svc.massopen.cloud
+                - --idp-url=https://osac-keycloak-keycloak.apps.osac-integration.svc.massopen.cloud
                 - --idp-client-id-file=/etc/fulfillment-controller/idp/client-id
                 - --idp-client-secret-file=/etc/fulfillment-controller/idp/client-secret
                 - --grpc-server-address=fulfillment-internal-api:8001
@@ -134,7 +134,7 @@ patches:
                 - --grpc-listener-address=0.0.0.0:8000
                 - --grpc-listener-tls-crt=/etc/fulfillment-grpc-server/tls/tls.crt
                 - --grpc-listener-tls-key=/etc/fulfillment-grpc-server/tls/tls.key
-                - --grpc-authn-trusted-token-issuers=https://keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
+                - --grpc-authn-trusted-token-issuers=https://osac-keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
                 - --grpc-authn-type=external
                 - --grpc-authn-external-address=authorino-authorino-authorization:50051
                 - --tenancy-logic=default
@@ -237,7 +237,7 @@ patches:
             priority: 0
           keycloak-jwt:
             jwt:
-              issuerUrl: https://keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
+              issuerUrl: https://osac-keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
             metrics: false
             overrides:
               authnMethod:

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -84,10 +84,10 @@ patches:
     patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/command/7
-        value: "--auth-issuer-url=https://keycloak.keycloak.svc.cluster.local/realms/osac"
+        value: "--auth-issuer-url=https://osac-keycloak.keycloak.svc.cluster.local/realms/osac"
       - op: replace
         path: /spec/template/spec/containers/0/command/11
-        value: "--idp-url=https://keycloak.keycloak.svc.cluster.local"
+        value: "--idp-url=https://osac-keycloak.keycloak.svc.cluster.local"
   - target:
       kind: Deployment
       name: osac-operator-controller-manager
@@ -160,7 +160,7 @@ patches:
         authentication:
           keycloak-jwt:
             jwt:
-              issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+              issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
         authorization:
           default:
             opa:

--- a/prerequisites/keycloak/service/certificate.yaml
+++ b/prerequisites/keycloak/service/certificate.yaml
@@ -20,8 +20,8 @@ spec:
     kind: ClusterIssuer
     name: default-ca
   dnsNames:
-  - keycloak
-  - keycloak.keycloak.svc.cluster.local
+  - osac-keycloak
+  - osac-keycloak.keycloak.svc.cluster.local
   secretName: keycloak-tls-cert
   privateKey:
     rotationPolicy: Always

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: KC_HTTPS_CERTIFICATE_KEY_FILE
           value: "/secrets/tls/tls.key"
         - name: KC_HOSTNAME
-          value: "keycloak.keycloak.svc.cluster.local"
+          value: "osac-keycloak.keycloak.svc.cluster.local"
         - name: KC_DB
           value: "postgres"
         - name: KC_DB_URL

--- a/prerequisites/keycloak/service/password-setup-job.yaml
+++ b/prerequisites/keycloak/service/password-setup-job.yaml
@@ -21,7 +21,7 @@ data:
     set -e
 
     echo "Waiting for Keycloak to be ready..."
-    until curl -k -s https://keycloak:443/realms/osac > /dev/null 2>&1; do
+    until curl -k -s https://osac-keycloak:443/realms/osac > /dev/null 2>&1; do
       sleep 5
     done
     echo "Keycloak is ready!"
@@ -32,7 +32,7 @@ data:
       local password=$2
 
       # Get admin token
-      TOKEN=$(curl -k -s -X POST https://keycloak:443/realms/master/protocol/openid-connect/token \
+      TOKEN=$(curl -k -s -X POST https://osac-keycloak:443/realms/master/protocol/openid-connect/token \
         -H 'Content-Type: application/x-www-form-urlencoded' \
         -d 'grant_type=password' \
         -d 'client_id=admin-cli' \
@@ -45,7 +45,7 @@ data:
       fi
 
       # Get user ID
-      USER_ID=$(curl -k -s -X GET "https://keycloak:443/admin/realms/osac/users?username=$username" \
+      USER_ID=$(curl -k -s -X GET "https://osac-keycloak:443/admin/realms/osac/users?username=$username" \
         -H "Authorization: Bearer $TOKEN" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
 
       if [ -z "$USER_ID" ]; then
@@ -54,7 +54,7 @@ data:
       fi
 
       # Set password
-      curl -k -s -X PUT "https://keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
+      curl -k -s -X PUT "https://osac-keycloak:443/admin/realms/osac/users/$USER_ID/reset-password" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
         -d "{\"type\":\"password\",\"value\":\"$password\",\"temporary\":false}" 2>/dev/null

--- a/prerequisites/keycloak/service/route.yaml
+++ b/prerequisites/keycloak/service/route.yaml
@@ -14,11 +14,11 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: keycloak
+  name: osac-keycloak
 spec:
   to:
     kind: Service
-    name: keycloak
+    name: osac-keycloak
   port:
     targetPort: https
   tls:

--- a/prerequisites/keycloak/service/service.yaml
+++ b/prerequisites/keycloak/service/service.yaml
@@ -14,7 +14,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: keycloak
+  name: osac-keycloak
   labels:
     app: keycloak-service
 spec:

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -94,7 +94,7 @@ keycloak_sync() {
         echo "  ConfigMap unchanged, skipping Keycloak restart"
     fi
 
-    KC_URL="https://$(oc get route keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
+    KC_URL="https://$(oc get route osac-keycloak -n "${KEYCLOAK_NS}" -o jsonpath='{.spec.host}')"
     retry_until 300 5 '[[ "$(curl -sk -o /dev/null -w %{http_code} '"${KC_URL}"'/realms/osac)" == "200" ]]' || {
         echo "Timed out waiting for Keycloak"
         exit 1

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -32,7 +32,7 @@ service:
     caBundle:
       configMap: ca-bundle
   auth:
-    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials
@@ -43,7 +43,7 @@ service:
           param: client-secret
   idp:
     provider: keycloak
-    url: https://keycloak.keycloak.svc.cluster.local
+    url: https://osac-keycloak.keycloak.svc.cluster.local
     credentials:
     - secret:
         name: fulfillment-controller-credentials

--- a/values/development.yaml
+++ b/values/development.yaml
@@ -36,7 +36,7 @@ service:
     caBundle:
       configMap: ca-bundle
   auth:
-    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials
@@ -47,7 +47,7 @@ service:
           param: client-secret
   idp:
     provider: keycloak
-    url: https://keycloak.keycloak.svc.cluster.local
+    url: https://osac-keycloak.keycloak.svc.cluster.local
     credentials:
     - secret:
         name: fulfillment-controller-credentials

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -32,7 +32,7 @@ service:
     caBundle:
       configMap: ca-bundle
   auth:
-    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    issuerUrl: https://osac-keycloak.keycloak.svc.cluster.local/realms/osac
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials
@@ -43,7 +43,7 @@ service:
           param: client-secret
   idp:
     provider: keycloak
-    url: https://keycloak.keycloak.svc.cluster.local
+    url: https://osac-keycloak.keycloak.svc.cluster.local
     credentials:
     - secret:
         name: fulfillment-controller-credentials


### PR DESCRIPTION
## Motivation

The in-cluster Keycloak `Service` and `Route` are currently named `keycloak`. That generic name can clash with other Keycloak instances or create ambiguity on shared clusters. This PR renames them to `osac-keycloak` and aligns all in-cluster auth URLs that depend on the service DNS name.

**This is a breaking change for in-place upgrades.** Prerequisites and fulfillment overlays must be rolled out together. See [docs/keycloak-service-rename.md](docs/keycloak-service-rename.md) for the full migration guide.

## Changes

### Prerequisites (`prerequisites/keycloak/service/`)

- Rename `Service` and `Route`: `keycloak` → `osac-keycloak`
- Update TLS certificate SANs and `KC_HOSTNAME` to `osac-keycloak.keycloak.svc.cluster.local`
- Update password-setup job to call `https://osac-keycloak:443/...` (in-namespace short name)

### Fulfillment auth alignment

Update issuer/idp URLs to `https://osac-keycloak.keycloak.svc.cluster.local` in:

- Overlays: `development`, `caas-ci`, `vmaas-ci`, `osac-integration`
- Helm values: `values/{development,caas-ci,vmaas-ci}.yaml`, `charts/osac/ci/full-values.yaml`
- Docs: `docs/helm-deployment-guide.md`

### Follow-up fixes in this branch

- `scripts/refresh-after-snapshot.sh` — look up `route/osac-keycloak`
- `overlays/osac-integration` — external route hostname `osac-keycloak-keycloak.apps...`
- `docs/keycloak-service-rename.md` — upgrade procedure and cleanup steps

### Unchanged (intentionally)

- Keycloak **namespace** (`keycloak`) and **deployment** name (`keycloak-service`) — `setup.sh` wait logic unaffected
- Helm umbrella defaults (`charts/osac/values.yaml`) — `issuerUrl`/`url` remain empty; consumers set explicitly
- `base/osac-fulfillment-service` submodule defaults — separate cross-repo change if needed (`hypershift2` and kind/local dev)

## Known remaining gaps

| Gap | Status |
|-----|--------|
| `base/osac-fulfillment-service` submodule defaults | Deferred — cross-repo, different port/consumers |
| `hypershift2` overlay auth URLs | Deferred — confirm whether it uses prerequisites Keycloak |

## Upgrade / rollout order

1. Apply `prerequisites/keycloak/`
2. Wait for cert reissue and Keycloak rollout
3. Apply fulfillment overlay
4. Delete orphaned `Service/keycloak` and `Route/keycloak`
5. Re-authenticate clients (JWT issuer URL changes)

Details: [docs/keycloak-service-rename.md](docs/keycloak-service-rename.md)

## Jira

[OSAC-1406](https://redhat.atlassian.net/browse/OSAC-1406) (relates to [OSAC-1394](https://redhat.atlassian.net/browse/OSAC-1394))

## Test plan

- [x] `bash scripts/kustomize-build-all.sh`
- [ ] Deploy prerequisites Keycloak and verify password-setup job reaches `https://osac-keycloak:443/realms/osac`
- [ ] Deploy a CI overlay (`caas-ci` or `vmaas-ci`) and confirm fulfillment auth against the renamed service
- [ ] Verify `refresh-after-snapshot.sh` keycloak sync path
- [ ] Confirm no orphaned `keycloak` Service/Route causes dual-DNS confusion post-upgrade
