### PR TITLE
OSAC-1407: Whitelist committed overlays in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,24 @@ charts/*/Chart.lock
 
 # Implementation artifacts
 .artifacts/
+
+# Overlays: whitelist committed directories; personal overlays/<project-name> are ignored.
+# To add a new committed overlay, add !overlays/<name>/ and !overlays/<name>/** below.
+overlays/*
+!overlays/_shared/
+!overlays/_shared/**
+
+!overlays/caas-ci/
+!overlays/caas-ci/**
+
+!overlays/development/
+!overlays/development/**
+
+!overlays/hypershift2/
+!overlays/hypershift2/**
+
+!overlays/osac-integration/
+!overlays/osac-integration/**
+
+!overlays/vmaas-ci/
+!overlays/vmaas-ci/**

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Place the downloaded `license.zip` file in your values directory (e.g., `values/
 
 ### Pre-Installation Steps
 
+Personal overlays under `overlays/<project-name>` are gitignored by default and will
+not appear in `git status`. Only committed overlay directories whitelisted in the root
+`.gitignore` are tracked.
+
 #### 1. Initialize Submodules
 
 The OSAC installer uses Git submodules for version tracking:


### PR DESCRIPTION
## Summary

- Add overlay whitelist rules to the root `.gitignore` so only committed overlay directories (`_shared`, `development`, `caas-ci`, `vmaas-ci`, `osac-integration`, `hypershift2`) are tracked. Any other path under `overlays/` is ignored by default.
- Add a brief note to the root README that personal overlays (`overlays/<project-name>`) are gitignored and won't appear in `git status`.

Personal overlays use any directory not on the whitelist (e.g. `overlays/tohughes-dev`). To add a new committed overlay, update the whitelist entries in the root `.gitignore`.

## Jira

[OSAC-1407](https://redhat.atlassian.net/browse/OSAC-1407)

## Test plan

- [x] `git check-ignore` confirms unlisted paths (e.g. `overlays/<project-name>/`) are ignored
- [x] `git check-ignore` confirms whitelisted overlays (`development`, `_shared`) are not ignored
- [x] Tracked overlay files remain in `git ls-files overlays/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that personal overlay directories under `overlays/<project-name>` are gitignored by default, so they don’t appear in version control status.
  * Explained that only explicitly whitelisted overlay directories in the root `overlays/.gitignore` are tracked.
* **Chores**
  * Updated ignore rules to ignore all `overlays/*` by default, while re-including the committed shared overlay tree and selected named overlay directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->