### PR TITLE
NO-ISSUE: Fix CaaS boot failures caused by dirty database migrations

### DIFF
--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -164,7 +164,6 @@ failed=0
 wait ${pid_creds} || failed=1
 if (( failed )); then echo "ERROR: Failed to create fulfillment credentials"; exit 1; fi
 
-oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=0 2>/dev/null || true
 echo "[3/9] Applying kustomize overlay..."
 oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 # Exclude only the bootstrap job — it's redundant on snapshot boot and races
@@ -173,8 +172,14 @@ oc delete job -n "${INSTALLER_NAMESPACE}" --all --ignore-not-found
 # operator triggers into one reconciliation instead of a separate oc patch.
 sed '/job\.yaml/d' base/osac-aap/config/base/kustomization.yaml > base/osac-aap/config/base/kustomization.yaml.tmp \
     && mv base/osac-aap/config/base/kustomization.yaml.tmp base/osac-aap/config/base/kustomization.yaml
+# Deploy with fulfillment pods scaled to zero. The apply changes the database
+# StatefulSet image ref (tag → digest), triggering a pod recreation. If the
+# grpc-server were running, it could be mid-migration when the database is
+# killed, leaving golang-migrate's schema dirty. Deploying at zero replicas
+# eliminates the race entirely — pods are brought back at step [5/9] after
+# the database rollout completes.
+( cd "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}" && kustomize edit set replicas fulfillment-controller=0 fulfillment-grpc-server=0 )
 oc apply -k "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}"
-oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=0 2>/dev/null || true
 
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 PULL_SECRET="${REPO_ROOT}/overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/quay-pull-secret.json"
@@ -306,12 +311,20 @@ for cert in "${fs_certs[@]}"; do
         -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
 done
+failed=0
+for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
+if (( failed )); then echo "ERROR: TLS certificates not ready"; exit 1; fi
+# Wait for the database StatefulSet rollout before scaling up pods that run
+# migrations. The kustomize apply changed the image ref, triggering a
+# recreation — the database must be accepting connections before grpc-server
+# starts.
+oc rollout status statefulset/fulfillment-database -n "${INSTALLER_NAMESPACE}" --timeout=300s
+oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=1
+oc scale deploy/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}" --replicas=1
 # Envoy never re-reads its config after startup. Restart ingress-proxy before
 # the rollout wait so that pods depending on new routes (e.g. JWKS) can start.
 oc rollout restart deploy/fulfillment-ingress-proxy -n "${INSTALLER_NAMESPACE}"
-# Kustomize apply may have changed deployment images, triggering new rollouts
-# that run DB migrations. Wait for those to finish before restarting pods —
-# otherwise the restart kills pods mid-migration and leaves the DB dirty.
+pids=()
 for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout status "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}" --timeout=300s &
     pids+=($!)
@@ -319,9 +332,8 @@ done
 failed=0
 for pid in "${pids[@]}"; do wait "${pid}" || failed=1; done
 wait ${pid_cdi} || failed=1
-if (( failed )); then echo "ERROR: TLS certificates or fulfillment rollouts not ready"; exit 1; fi
+if (( failed )); then echo "ERROR: Fulfillment rollouts not ready"; exit 1; fi
 echo "[5/9] TLS certificates ready, restarting pods..."
-oc scale deploy/fulfillment-controller -n "${INSTALLER_NAMESPACE}" --replicas=1
 for deploy in "${FULFILLMENT_DEPLOYS[@]}"; do
     oc rollout restart "deploy/${deploy}" -n "${INSTALLER_NAMESPACE}"
 done


### PR DESCRIPTION
## Summary

- Scale down `fulfillment-grpc-server` to 0 before applying the kustomize overlay in the refresh script, preventing database migrations from running while the database pod is being recycled
- Remove `2>/dev/null || true` from scale-down commands — on snapshot boot the deployments always exist, and silent failures here mask real problems

## Root Cause

The kustomize overlay changes the `fulfillment-database` StatefulSet image reference from a `:latest` tag to a `@sha256:` digest. This spec change triggers a StatefulSet pod recreation, killing the database server. If `fulfillment-grpc-server` is running database migrations at that moment, `golang-migrate` leaves the `schema_migrations` table dirty (`dirty=true`), and all subsequent grpc-server starts crash with `Dirty database version N. Fix and force version.`

This was the root cause of intermittent CaaS boot failures in [openshift/release#79512](https://github.com/openshift/release/pull/79512) — the failure rate depended on whether migrations finished before the database pod was killed (a race condition).

## Evidence

Differential analysis across 5 CaaS rehearsal jobs from the same batch:
- **Failing** (osac-operator): DB pod age 7m53s (recreated), grpc-server `dirty=true` at v39
- **Passing** (osac-aap): DB pod age 30m (also recreated, but migrations had already completed)
- **Passing** (others): DB pod ages 27-29m, migrations completed before recreation

## Test plan

- [ ] Retest CaaS rehearsals in openshift/release#79512 — boot failures should no longer occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment refresh now uses declarative configuration for scaling during snapshot restoration.
  * Streamlined restart sequence for certificate and service refresh to improve reliability and reduce downtime.
  * Removed redundant runtime scaling steps and clarified operator guidance for preparing fulfillment services prior to refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->