### PR TITLE
OSAC-1402: add fulfillment instance group config to Helm chart

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -54,3 +54,33 @@ dbMigrate:
   enabled: true
   image: ghcr.io/osac-project/fulfillment-service:latest
   dbUrlFile: "/etc/fulfillment-service/db/url"
+
+clusterFulfillment:
+  enabled: true
+  config:
+    NETWORK_CLASS: "netris"
+    NETWORK_STEPS_COLLECTION: "netris.steps"
+    NETRIS_CONTROLLER_URL: "https://test-ctl.netris.io"
+    NETRIS_USERNAME: "testuser"
+    NETRIS_SITE_ID: "1"
+    NETRIS_TENANT_ID: "1"
+    NETRIS_TENANT_NAME: "Admin"
+    EXTERNAL_ACCESS_BASE_DOMAIN: "test.example.com"
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "test.example.com"
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "hypershift"
+    HOSTED_CLUSTER_BASE_DOMAIN: "test.example.com"
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "SingleReplica"
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "SingleReplica"
+  secret:
+    NETRIS_PASSWORD: "test-password"
+
+networkFulfillment:
+  enabled: true
+  config:
+    NETRIS_CONTROLLER_URL: "https://test-ctl.netris.io"
+    NETRIS_USERNAME: "testuser"
+    NETRIS_SITE_ID: "1"
+    NETRIS_TENANT_ID: "1"
+    NETRIS_TENANT_NAME: "Admin"
+  secret:
+    NETRIS_PASSWORD: "test-password"

--- a/charts/osac/templates/cluster-fulfillment-ig.yaml
+++ b/charts/osac/templates/cluster-fulfillment-ig.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.clusterFulfillment.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-fulfillment-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+data:
+  {{- range $key, $val := .Values.clusterFulfillment.config }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-fulfillment-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+type: Opaque
+data:
+  {{- range $key, $val := .Values.clusterFulfillment.secret }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/osac/templates/network-fulfillment-ig.yaml
+++ b/charts/osac/templates/network-fulfillment-ig.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.networkFulfillment.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network-fulfillment-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+data:
+  {{- range $key, $val := .Values.networkFulfillment.config }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: network-fulfillment-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+type: Opaque
+data:
+  {{- range $key, $val := .Values.networkFulfillment.secret }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -137,3 +137,52 @@ dbMigrate:
   image: ghcr.io/osac-project/fulfillment-service:latest
   dbUrl: ""
   dbUrlFile: ""
+
+# --- Cluster Fulfillment Instance Group ---
+# ConfigMap and Secret for the AAP cluster-fulfillment instance group.
+# Carries network backend selection, Netris credentials, SSH config,
+# external-access domains, and hosted-cluster defaults.
+clusterFulfillment:
+  enabled: false
+  config:
+    NETWORK_CLASS: ""
+    NETWORK_STEPS_COLLECTION: ""
+    NETRIS_CONTROLLER_URL: ""
+    NETRIS_USERNAME: ""
+    NETRIS_SITE_ID: ""
+    NETRIS_TENANT_ID: ""
+    NETRIS_TENANT_NAME: ""
+    NETRIS_MGMT_VPC_ID: ""
+    NETRIS_MGMT_VPC_NAME: ""
+    NETRIS_RESOURCE_CLASS_MAP: ""
+    SERVER_SSH_BASTION_HOST: ""
+    SERVER_SSH_BASTION_USER: ""
+    SERVER_SSH_USER: ""
+    SERVER_MGMT_ROUTE_DESTINATION: ""
+    SERVER_MGMT_ROUTE_GATEWAY: ""
+    EXTERNAL_ACCESS_BASE_DOMAIN: ""
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: ""
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: ""
+    HOSTED_CLUSTER_BASE_DOMAIN: ""
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: ""
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: ""
+  secret:
+    NETRIS_PASSWORD: ""
+    AWS_ACCESS_KEY_ID: ""
+    AWS_SECRET_ACCESS_KEY: ""
+    SERVER_SSH_KEY: ""
+    SERVER_SSH_BASTION_KEY: ""
+
+# --- Network Fulfillment Instance Group ---
+# ConfigMap and Secret for the AAP networking-operations instance group.
+# Carries Netris controller credentials for network resource lifecycle.
+networkFulfillment:
+  enabled: false
+  config:
+    NETRIS_CONTROLLER_URL: ""
+    NETRIS_USERNAME: ""
+    NETRIS_SITE_ID: ""
+    NETRIS_TENANT_ID: ""
+    NETRIS_TENANT_NAME: ""
+  secret:
+    NETRIS_PASSWORD: ""

--- a/docs/network-backend.md
+++ b/docs/network-backend.md
@@ -66,3 +66,88 @@ Values must be plaintext — the script base64-encodes them automatically.
 Each key is a resource class name. `server_cluster_template_id` is the Netris server
 cluster template ID, `mgmt_interface` is the management NIC name, and `vpc_interfaces`
 lists the data-plane NIC names.
+
+## Helm Chart Configuration
+
+When deploying with Helm, Netris configuration is provided via values instead of
+env files. Two values sections control the fulfillment instance groups:
+
+### Enabling the Instance Groups
+
+In your environment values file (e.g., `values/development.yaml`):
+
+```yaml
+clusterFulfillment:
+  enabled: true
+  config:
+    NETWORK_CLASS: "netris"
+    NETWORK_STEPS_COLLECTION: "netris.steps"
+    NETRIS_CONTROLLER_URL: "https://redhat-ctl.netris.io"
+    NETRIS_USERNAME: "netris"
+    NETRIS_SITE_ID: "5"
+    NETRIS_TENANT_ID: "1"
+    NETRIS_TENANT_NAME: "Admin"
+    NETRIS_MGMT_VPC_ID: "4"
+    NETRIS_MGMT_VPC_NAME: "RH-Infra"
+    NETRIS_RESOURCE_CLASS_MAP: '{"fc430": {"server_cluster_template_id": 89, "mgmt_interface": "ens4", "vpc_interfaces": ["ens13"]}}'
+    SERVER_SSH_BASTION_HOST: "redhat-ctl.netris.io"
+    SERVER_SSH_BASTION_USER: "ubuntu"
+    SERVER_SSH_USER: "core"
+    SERVER_MGMT_ROUTE_DESTINATION: "10.8.0.0/30"
+    SERVER_MGMT_ROUTE_GATEWAY: "192.168.16.1"
+    EXTERNAL_ACCESS_BASE_DOMAIN: "box.massopen.cloud"
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "box.massopen.cloud"
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "hypershift"
+    HOSTED_CLUSTER_BASE_DOMAIN: "box.massopen.cloud"
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "HighlyAvailable"
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "HighlyAvailable"
+
+networkFulfillment:
+  enabled: true
+  config:
+    NETRIS_CONTROLLER_URL: "https://redhat-ctl.netris.io"
+    NETRIS_USERNAME: "netris"
+    NETRIS_SITE_ID: "5"
+    NETRIS_TENANT_ID: "1"
+    NETRIS_TENANT_NAME: "Admin"
+```
+
+Only non-empty values are rendered into the ConfigMap. Keys left as `""` are
+omitted, so you only need to set the variables relevant to your network backend.
+
+### Setting Secret Values
+
+Create a separate secrets values file that is **not committed to git**
+(`.local.yaml` files are already gitignored):
+
+```yaml
+# values/development-secrets.local.yaml
+clusterFulfillment:
+  secret:
+    NETRIS_PASSWORD: "my-netris-password"
+    AWS_ACCESS_KEY_ID: "AKIA..."
+    AWS_SECRET_ACCESS_KEY: "..."
+    SERVER_SSH_KEY: "<contents of ~/.ssh/id_rsa>"
+    SERVER_SSH_BASTION_KEY: "<contents of ~/.ssh/id_ed25519>"
+
+networkFulfillment:
+  secret:
+    NETRIS_PASSWORD: "my-netris-password"
+```
+
+Pass both files when deploying — Helm deep-merges them:
+
+```bash
+helm install osac charts/osac \
+  -f values/development.yaml \
+  -f values/development-secrets.local.yaml \
+  -n <namespace>
+```
+
+Alternatively, pass secrets directly on the command line:
+
+```bash
+helm install osac charts/osac -f values/development.yaml \
+  --set clusterFulfillment.secret.NETRIS_PASSWORD=mypass \
+  --set networkFulfillment.secret.NETRIS_PASSWORD=mypass
+```

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -94,3 +94,13 @@ validation:
 dbMigrate:
   enabled: false
   image: ghcr.io/osac-project/fulfillment-service:sha-79daf20
+
+clusterFulfillment:
+  enabled: true
+  config:
+    NETWORK_STEPS_COLLECTION: "ci.steps"
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "SingleReplica"
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "SingleReplica"
+
+networkFulfillment:
+  enabled: true

--- a/values/development.yaml
+++ b/values/development.yaml
@@ -95,3 +95,24 @@ validation:
 dbMigrate:
   enabled: false
   image: ghcr.io/osac-project/fulfillment-service:latest
+
+clusterFulfillment:
+  enabled: true
+  config:
+    NETWORK_CLASS: "esi"
+    NETWORK_STEPS_COLLECTION: "osac.steps"
+    EXTERNAL_ACCESS_BASE_DOMAIN: "box.massopen.cloud"
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: "box.massopen.cloud"
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: "hypershift"
+    HOSTED_CLUSTER_BASE_DOMAIN: "box.massopen.cloud"
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "HighlyAvailable"
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "HighlyAvailable"
+
+networkFulfillment:
+  enabled: true
+  config:
+    NETRIS_CONTROLLER_URL: "https://redhat-ctl.netris.io"
+    NETRIS_USERNAME: "netris"
+    NETRIS_SITE_ID: "5"
+    NETRIS_TENANT_ID: "1"
+    NETRIS_TENANT_NAME: "Admin"


### PR DESCRIPTION
## Summary

- Add `cluster-fulfillment-ig` and `network-fulfillment-ig` ConfigMap/Secret Helm templates so Netris network backend configuration works when deploying via Helm (parity with the Kustomize flow)
- New `clusterFulfillment` and `networkFulfillment` values sections, disabled by default — operators opt in and populate credentials for their environment
- Update CI (`full-values.yaml`), CaaS CI (`caas-ci.yaml`), and development (`development.yaml`) values files
- Document Helm-based Netris configuration and secret management in `docs/network-backend.md`

## Test plan

- [x] `helm template charts/osac -f values/development.yaml` renders `cluster-fulfillment-ig` and `network-fulfillment-ig` ConfigMap + Secret
- [x] `helm template charts/osac -f charts/osac/ci/full-values.yaml` renders all four resources with correct keys
- [x] Empty values are omitted from rendered ConfigMaps/Secrets
- [x] `helm template` passes with all values files (`default-values`, `full-values`, `no-aap-values`, `caas-ci`, `development`, `vmaas-ci`)
- [x] Existing Kustomize overlays unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new `clusterFulfillment` and `networkFulfillment` Helm values to control automated cluster and network provisioning.
  * When enabled, the chart now creates fulfillment ConfigMaps and Secrets, including only non-empty entries.
  * Updated CI and development value sets to enable and prefill the required fulfillment parameters (including NETRIS connectivity and related policy settings).
* **Documentation**
  * Expanded `NETWORK_CLASS=netris` documentation with configuration examples, including how to supply secret values via additional values files or `--set`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->