### PR TITLE
OSAC-420: Configure console-proxy token issuer, CORS, and cert SANs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,13 @@ Use Kustomize to manage your environment-specific configurations.
      ]'
      ```
      If this is not configured, all gRPC calls will fail with `Unauthenticated` errors.
-   - In `kustomization.yaml`: Replace `<cluster-name>.<base-domain>` in the `OSAC_AAP_URL`
-     value with your cluster's actual domain (e.g., `mgmt.example.devcluster.openshift.com`).
-     You can find it by running: `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`
+   - In `kustomization.yaml`: Replace `osac-devel` with your project name and
+     `<cluster-name>.<base-domain>` with your cluster's actual domain in the
+     `OSAC_AAP_URL`, token-issuer, CORS, and certificate patches.
+     You can find your cluster domain by running:
+     `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`.
+     **If using `setup.sh`**, these values are discovered from the cluster
+     and patched automatically.
 
    These changes ensure your installation uses a unique namespace and prevents resource
    name conflicts with other OSAC installations.

--- a/overlays/caas-ci/console-proxy-replacements.yaml
+++ b/overlays/caas-ci/console-proxy-replacements.yaml
@@ -43,3 +43,22 @@
       name: osac-console-proxy-auth-reader
     fieldPaths:
     - metadata.namespace
+# Propagates the fulfillment-api namespace into the ingress-proxy certificate
+# dnsNames so the cert covers the namespace-qualified FQDNs used by the
+# console-proxy JWKS fetch and by in-cluster clients.
+- source:
+    kind: Service
+    name: fulfillment-api
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: fulfillment-api
+    fieldPaths:
+    - spec.dnsNames.2
+    - spec.dnsNames.3
+    - spec.dnsNames.5
+    - spec.dnsNames.6
+    options:
+      delimiter: '.'
+      index: 1

--- a/overlays/development/console-proxy-replacements.yaml
+++ b/overlays/development/console-proxy-replacements.yaml
@@ -56,3 +56,22 @@
       name: osac-console-proxy-auth-reader
     fieldPaths:
     - metadata.namespace
+# Propagates the fulfillment-api namespace into the ingress-proxy certificate
+# dnsNames so the cert covers the namespace-qualified FQDNs used by the
+# console-proxy JWKS fetch and by in-cluster clients.
+- source:
+    kind: Service
+    name: fulfillment-api
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: fulfillment-api
+    fieldPaths:
+    - spec.dnsNames.2
+    - spec.dnsNames.3
+    - spec.dnsNames.5
+    - spec.dnsNames.6
+    options:
+      delimiter: '.'
+      index: 1

--- a/overlays/hypershift2/console-proxy-replacements.yaml
+++ b/overlays/hypershift2/console-proxy-replacements.yaml
@@ -43,3 +43,22 @@
       name: osac-console-proxy-auth-reader
     fieldPaths:
     - metadata.namespace
+# Propagates the fulfillment-api namespace into the ingress-proxy certificate
+# dnsNames so the cert covers the namespace-qualified FQDNs used by the
+# console-proxy JWKS fetch and by in-cluster clients.
+- source:
+    kind: Service
+    name: fulfillment-api
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: fulfillment-api
+    fieldPaths:
+    - spec.dnsNames.2
+    - spec.dnsNames.3
+    - spec.dnsNames.5
+    - spec.dnsNames.6
+    options:
+      delimiter: '.'
+      index: 1

--- a/overlays/osac-integration/console-proxy-replacements.yaml
+++ b/overlays/osac-integration/console-proxy-replacements.yaml
@@ -43,3 +43,22 @@
       name: osac-console-proxy-auth-reader
     fieldPaths:
     - metadata.namespace
+# Propagates the fulfillment-api namespace into the ingress-proxy certificate
+# dnsNames so the cert covers the namespace-qualified FQDNs used by the
+# console-proxy JWKS fetch and by in-cluster clients.
+- source:
+    kind: Service
+    name: fulfillment-api
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: fulfillment-api
+    fieldPaths:
+    - spec.dnsNames.2
+    - spec.dnsNames.3
+    - spec.dnsNames.5
+    - spec.dnsNames.6
+    options:
+      delimiter: '.'
+      index: 1

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -139,6 +139,40 @@ patches:
                 - --grpc-authn-external-address=authorino-authorino-authorization:50051
                 - --tenancy-logic=default
                 - --metrics-listener-address=0.0.0.0:8002
+                - --token-signer-crt=/etc/fulfillment-token-signer/tls.crt
+                - --token-signer-key=/etc/fulfillment-token-signer/tls.key
+                - --token-encryption-crt=/etc/fulfillment-token-encryption/tls.crt
+                - --token-issuer=https://fulfillment-api-osac-integration.apps.osac-integration.svc.massopen.cloud
+
+  # Override the console-proxy --token-issuer to use the external FQDN so it
+  # matches the iss claim stamped by the grpc-server.
+  - target:
+      kind: Deployment
+      name: fulfillment-console-proxy
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/command/5
+        value: --token-issuer=https://fulfillment-api-osac-integration.apps.osac-integration.svc.massopen.cloud
+
+  # Override the console-proxy --console-cors-allowed-origins to use the
+  # external FQDN so browser WebSocket Origin headers are accepted.
+  - target:
+      kind: Deployment
+      name: fulfillment-console-proxy
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/command/13
+        value: --console-cors-allowed-origins=https://fulfillment-api-osac-integration.apps.osac-integration.svc.massopen.cloud
+
+  # Add the external FQDN to the ingress-proxy certificate so TLS validation
+  # succeeds when the console-proxy fetches JWKS via the external hostname.
+  - target:
+      kind: Certificate
+      name: fulfillment-api
+    patch: |-
+      - op: add
+        path: /spec/dnsNames/-
+        value: fulfillment-api-osac-integration.apps.osac-integration.svc.massopen.cloud
 
   - target:
       kind: Deployment

--- a/overlays/vmaas-ci/console-proxy-replacements.yaml
+++ b/overlays/vmaas-ci/console-proxy-replacements.yaml
@@ -43,3 +43,22 @@
       name: osac-console-proxy-auth-reader
     fieldPaths:
     - metadata.namespace
+# Propagates the fulfillment-api namespace into the ingress-proxy certificate
+# dnsNames so the cert covers the namespace-qualified FQDNs used by the
+# console-proxy JWKS fetch and by in-cluster clients.
+- source:
+    kind: Service
+    name: fulfillment-api
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: fulfillment-api
+    fieldPaths:
+    - spec.dnsNames.2
+    - spec.dnsNames.3
+    - spec.dnsNames.5
+    - spec.dnsNames.6
+    options:
+      delimiter: '.'
+      index: 1

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -182,6 +182,36 @@ publish_templates() {
     fi
 }
 
+patch_token_config() {
+    local api_route_host issuer_url
+    # The route ingress host may take a moment to populate after apply.
+    retry_until 60 5 \
+        '[[ -n "$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-api -o jsonpath="{.status.ingress[0].host}" 2>/dev/null)" ]]' || {
+        echo "ERROR: fulfillment-api route has no ingress host after 60s"
+        exit 1
+    }
+    api_route_host=$(oc get route -n "${INSTALLER_NAMESPACE}" fulfillment-api -o jsonpath='{.status.ingress[0].host}')
+    issuer_url="https://${api_route_host}"
+
+    echo "Patching token-issuer and CORS to ${issuer_url}..."
+
+    # Patch grpc-server --token-issuer (command[19])
+    oc patch deployment/fulfillment-grpc-server -n "${INSTALLER_NAMESPACE}" --type=json \
+        -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command/19\",\"value\":\"--token-issuer=${issuer_url}\"}]"
+
+    # Patch console-proxy --token-issuer (command[5]) and CORS (command[13])
+    oc patch deployment/fulfillment-console-proxy -n "${INSTALLER_NAMESPACE}" --type=json \
+        -p "[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command/5\",\"value\":\"--token-issuer=${issuer_url}\"},{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command/13\",\"value\":\"--console-cors-allowed-origins=${issuer_url}\"}]"
+
+    # Add external FQDN to fulfillment-api certificate SANs (idempotent)
+    if ! oc get certificate/fulfillment-api -n "${INSTALLER_NAMESPACE}" -o jsonpath='{.spec.dnsNames}' | grep -qF "${api_route_host}"; then
+        oc patch certificate/fulfillment-api -n "${INSTALLER_NAMESPACE}" --type=json \
+            -p "[{\"op\":\"add\",\"path\":\"/spec/dnsNames/-\",\"value\":\"${api_route_host}\"}]"
+    fi
+}
+
+patch_token_config
+
 create_hub &
 pid_hub=$!
 sync_aap_project &


### PR DESCRIPTION
Align the fulfillment-service `console-proxy` auth and TLS hostnames with the actual FQDNs used by clients. This ensures the token `iss` claim, derived JWKS endpoint, CORS origin checks, and certificate SANs all point at hostnames that are actually reachable and covered by TLS.

Update the `fulfillment-api` certificate SANs across overlays to use the correct namespace-qualified service DNS names. For `osac-integration`, also add the external route hostname to the token issuer, CORS origin, and certificate SANs, and update `setup.sh` to auto-discover and apply the same route-based values at deploy time (covers development overlays as well).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration instructions with clearer guidance on cluster domain substitution and automatic configuration patching.

* **Bug Fixes**
  * Improved certificate DNS naming to automatically support namespace-qualified domain names across deployment environments.
  * Enhanced token configuration and CORS settings discovery to properly use external ingress hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->