### PR TITLE
Skip components without published images in bump-submodules workflow

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -36,8 +36,8 @@ jobs:
               -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
               "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
             if [[ "${code}" != "200" ]]; then
-              echo "ERROR: ${repo} latest main commit ${sha:0:7} has no published image (tag ${tag})" >&2
-              return 1
+              echo "WARN: ${repo} latest main commit ${sha:0:7} has no published image (tag ${tag}), skipping" >&2
+              return 0
             fi
             echo "${sha}"
           }
@@ -45,6 +45,10 @@ jobs:
           OPERATOR=$(check_image osac-operator osac-operator)
           FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
           AAP=$(check_image osac-aap osac-aap)
+
+          if [[ -z "${OPERATOR}" && -z "${FULFILLMENT}" && -z "${AAP}" ]]; then
+            echo "No components have published images for latest main commits; nothing to bump"
+          fi
 
           echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
           echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
@@ -60,6 +64,11 @@ jobs:
             local path=$1
             local name=$2
             local target=$3
+            if [[ -z "${target}" ]]; then
+              echo "${name}: skipped (no published image for latest main commit)"
+              summary="${summary}- **${name}**: skipped (no published image for latest main commit)\n"
+              return
+            fi
             local current
             current=$(git -C "${path}" rev-parse HEAD)
             if [[ "${current}" == "${target}" ]]; then
@@ -118,6 +127,7 @@ jobs:
           $(cat /tmp/bump-summary.txt)
 
           Only bumps to commits that have a published container image in GHCR.
+          Components without a published image for the latest main commit are left unchanged.
           Runs every 3 hours via [bump-submodules workflow](../actions/workflows/bump-submodules.yaml).
           BODY_EOF
           )


### PR DESCRIPTION
## Summary
- When a component's latest main commit has no published GHCR image, the bump-submodules workflow now logs a warning and skips that component instead of failing the entire job
- Components with published images are still bumped; skipped components are noted in the automated PR summary
- If no components have images, the workflow exits cleanly with no PR

## Why
The scheduled bump job failed entirely when `fulfillment-service` latest main (`e9dbed7`)
had no published GHCR image yet. That blocked bumps for operator and aap even when their
images were available. Image publish can lag behind merges, so the workflow should tolerate
per-component gaps rather than fail all-or-nothing.

## Jira
N/A

## Test plan
- [x] `bash scripts/kustomize-build-all.sh`
- [ ] Trigger `bump-submodules` via workflow_dispatch and confirm partial bumps succeed when one image is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)