### PR TITLE
Add PublicIPPools/Get and /List to OPA allowed methods in all overlays

### DIFF
--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -372,6 +372,8 @@ patches:
                     "/osac.public.v1.PublicIPAttachments/Get",
                     "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPAttachments/Update",
+                    "/osac.public.v1.PublicIPPools/Get",
+                    "/osac.public.v1.PublicIPPools/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -390,6 +390,8 @@ patches:
                     "/osac.public.v1.PublicIPAttachments/Get",
                     "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPAttachments/Update",
+                    "/osac.public.v1.PublicIPPools/Get",
+                    "/osac.public.v1.PublicIPPools/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -478,6 +478,8 @@ patches:
                     "/osac.public.v1.PublicIPAttachments/Get",
                     "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPAttachments/Update",
+                    "/osac.public.v1.PublicIPPools/Get",
+                    "/osac.public.v1.PublicIPPools/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -360,6 +360,8 @@ patches:
                     "/osac.public.v1.PublicIPAttachments/Get",
                     "/osac.public.v1.PublicIPAttachments/List",
                     "/osac.public.v1.PublicIPAttachments/Update",
+                    "/osac.public.v1.PublicIPPools/Get",
+                    "/osac.public.v1.PublicIPPools/List",
                     "/osac.public.v1.PublicIPs/Create",
                     "/osac.public.v1.PublicIPs/Delete",
                     "/osac.public.v1.PublicIPs/Get",


### PR DESCRIPTION
The PublicIPPools service was added to osac-operator but the corresponding OPA policy entries were missing from the installer overlays, preventing clients from calling these endpoints.