### PR TITLE
NO-ISSUE: Pass OC_IMPERSONATE to osac login token-script

### DIFF
--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -21,7 +21,11 @@ create_hub() {
     echo "Fulfillment internal API URL: ${fulfillment_url}"
 
     echo "Logging into fulfillment internal API..."
-    retry_command 300 10 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin" --address "${fulfillment_url}"
+    # OC_IMPERSONATE wraps the oc bash function but osac spawns oc as a
+    # child process, so we pass --as directly in the token-script.
+    local _impersonate_flag=""
+    [[ -n "${OC_IMPERSONATE:-}" ]] && _impersonate_flag="--as $(printf '%q' "${OC_IMPERSONATE}")"
+    retry_command 300 10 osac login --insecure --private --token-script "oc create token -n ${INSTALLER_NAMESPACE} admin ${_impersonate_flag}" --address "${fulfillment_url}"
 
     echo "Deleting existing hub..."
     retry_command 300 10 osac delete hub hub


### PR DESCRIPTION
OC_IMPERSONATE defines a bash function wrapper around oc, but osac spawns oc as a child process that bypasses the wrapper. Forward the --as flag into the token-script string when OC_IMPERSONATE is set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Kubernetes/OpenShift authentication with conditional user impersonation support in login workflows. When enabled, the token generation process automatically applies specified user impersonation settings to authentication requests. Full backward compatibility is maintained, allowing standard deployments to continue operating with existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->