### PR TITLE
NO-ISSUE: Add Copilot instructions referencing AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read and follow the project's AGENTS.md for build commands, architecture, conventions, and coding standards.


### PR DESCRIPTION
## Summary
- Add `.github/copilot-instructions.md` pointing to AGENTS.md for GitHub Copilot support

Part of workspace-wide AI-readiness improvements (osac-workspace#60).

Assisted-by: Claude Code <noreply@anthropic.com>