### PR TITLE
NO-ISSUE: Add `aud` claim to tokens issued by Keycloak

### DIFF
--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -997,7 +997,8 @@
         "basic",
         "username",
         "organization",
-        "roles"
+        "roles",
+        "osac-api"
       ],
       "optionalClientScopes": []
     },
@@ -1049,7 +1050,8 @@
         "profile",
         "roles",
         "basic",
-        "email"
+        "email",
+        "osac-api"
       ],
       "optionalClientScopes": [
         "address",
@@ -1173,6 +1175,35 @@
     }
   ],
   "clientScopes": [
+    {
+      "id": "8899e9f6-9ba9-48c6-8abd-c281dfd067c5",
+      "name": "osac-api",
+      "description": "OSAC API",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": "",
+        "include.in.openid.provider.metadata": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "9c44741f-8a3a-4468-8911-6b2ea6611b52",
+          "name": "osac-api-aud",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "included.custom.audience": "osac-api"
+          }
+        }
+      ]
+    },
     {
       "id": "2d4feb76-fd87-46d5-9eca-b7471da62403",
       "name": "service_account",


### PR DESCRIPTION
## Summary

- Adds an `osac-api` client scope with an `oidc-audience-mapper` so that
  Keycloak includes `osac-api` as the `aud` claim in access tokens.
- Assigns the scope as a default client scope for the `osac-cli` and
  `osac-controller` clients, ensuring all tokens carry the expected audience.
- Required because the fulfillment service will reject tokens without this
  claim once https://github.com/osac-project/fulfillment-service/pull/690 is
  enforced.

## Test plan

- [x] Verify `kustomize build` still succeeds for all overlays.
- [x] Deploy Keycloak with the updated realm and confirm tokens include the
  `aud: osac-api` claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a new OpenID Connect client scope for the `osac-api` audience to emit the audience claim in access tokens and token introspection results.
  * Applied the scope as a default client scope for both the CLI and controller to standardize API access.
  * Ensures clients receive consistent audience information when validating tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->