### PR TITLE
OSAC-1347: Add baremetalinstances RBAC to hub-access role

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -160,6 +160,24 @@ rules:
       - publicipattachments/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - baremetalinstances
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - baremetalinstances/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/osac/templates/hub-access.yaml
+++ b/charts/osac/templates/hub-access.yaml
@@ -183,6 +183,24 @@ rules:
       - publicipattachments/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - baremetalinstances
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - baremetalinstances/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
The fulfillment-service BareMetalInstance reconciler needs to create, patch, and delete BareMetalInstance CRs in hub clusters. Add the required permissions to the hub-access Role in both the kustomize base and the Helm chart.

Assisted-by: Claude Code <noreply@anthropic.com>