### PR TITLE
OSAC-1526: Replace bitnami/kubectl with origin-cli in validation hook

### DIFF
--- a/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -30,7 +30,7 @@ spec:
 
           # Check that cert-manager CRDs exist
           echo "Checking for cert-manager CRDs..."
-          if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
+          if oc get crd certificates.cert-manager.io >/dev/null 2>&1; then
             echo "  cert-manager CRDs found."
           else
             echo "ERROR: cert-manager CRDs not found."
@@ -40,7 +40,7 @@ spec:
 
           # Check that a default StorageClass exists
           echo "Checking for default StorageClass..."
-          DEFAULT_SC=$(kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null)
+          DEFAULT_SC=$(oc get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}' 2>/dev/null)
           if [ -n "$DEFAULT_SC" ]; then
             echo "  Default StorageClass found: $DEFAULT_SC"
           else

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -291,7 +291,7 @@ validation:
   # Run pre-install checks (cert-manager CRDs, default StorageClass).
   # Catches missing prerequisites before deployment starts.
   enabled: true
-  image: bitnami/kubectl:latest
+  image: quay.io/openshift/origin-cli:4.20.0
 
 # ---------------------
 # Database Migration

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -127,7 +127,7 @@ publishTemplates:
 # --- Validation hooks ---
 validation:
   enabled: true
-  image: bitnami/kubectl:latest
+  image: quay.io/openshift/origin-cli:4.20.0
 
 # --- Database migration hook ---
 # NOTE: Disabled until the 'migrate' subcommand is released in the


### PR DESCRIPTION
## Summary

- Replace `bitnami/kubectl:latest` (Docker Hub) with `quay.io/openshift/origin-cli:4.20.0` in the pre-install validation hook, eliminating Docker Hub rate limit / disconnected cluster failures
- Replace `kubectl` with `oc` in the validation script (two calls: `get crd` and `get sc`)
- Aligns the validation hook with the bootstrap job, which already uses `origin-cli`

## Test plan

- [ ] `helm lint charts/osac/` passes
- [ ] All CI values template successfully
- [ ] Rendered template shows `quay.io/openshift/origin-cli:4.20.0` and no `bitnami` references
- [ ] Deploy on an OpenShift cluster and verify the pre-install validation hook succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart pre-install validation hooks to use OpenShift-native command-line tools, enhancing compatibility and reliability for cluster dependency verification, cert-manager availability checks, and dynamic storage class discovery
  * Updated and standardized container image references across installation, bootstrap, and configuration tooling components to use current OpenShift-compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->