### PR TITLE
OSAC-1534: Replace docker.io/envoyproxy/envoy with ghcr.io mirror

### DIFF
--- a/.github/workflows/mirror-envoy.yaml
+++ b/.github/workflows/mirror-envoy.yaml
@@ -1,0 +1,53 @@
+name: Mirror Envoy Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Envoy version to mirror (e.g. v1.33.0)'
+        required: true
+  # Weekly re-push of DEFAULT_VERSION to keep the GHCR copy fresh.
+  # To mirror a new version, use workflow_dispatch with the version input.
+  schedule:
+    - cron: '0 6 * * 1'  # Monday 6am UTC
+
+env:
+  SOURCE: docker.io/envoyproxy/envoy
+  TARGET: ghcr.io/osac-project/envoy
+  DEFAULT_VERSION: v1.33.0
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - name: Log in to GHCR
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Install skopeo
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq skopeo
+
+    - name: Mirror image (all architectures)
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        VERSION="${INPUT_VERSION:-${DEFAULT_VERSION}}"
+        echo "Mirroring ${SOURCE}:${VERSION} -> ${TARGET}:${VERSION}"
+        skopeo copy --all \
+          "docker://${SOURCE}:${VERSION}" \
+          "docker://${TARGET}:${VERSION}"
+
+    - name: Verify mirrored image
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        VERSION="${INPUT_VERSION:-${DEFAULT_VERSION}}"
+        skopeo inspect "docker://${TARGET}:${VERSION}" > /dev/null
+        echo "Verified ${TARGET}:${VERSION} is pullable"

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -34,7 +34,7 @@ images:
 - name: ghcr.io/osac-project/osac-operator
   newTag: sha-acb50ad
 - name: envoy
-  newName: docker.io/envoyproxy/envoy
+  newName: ghcr.io/osac-project/envoy
   newTag: v1.33.0
 - name: openshift-cli
   newName: image-registry.openshift-image-registry.svc:5000/openshift/cli

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -105,7 +105,7 @@ service:
     # Production: pin to a specific SHA tag.
     # Development: use "latest".
     service: ghcr.io/osac-project/fulfillment-service:latest
-    envoy: docker.io/envoyproxy/envoy:v1.33.0
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
 
   # TLS certificate configuration. All service components use cert-manager
   # to generate certificates signed by this issuer.

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -42,7 +42,7 @@ service:
   variant: openshift
   images:
     service: ghcr.io/osac-project/fulfillment-service:latest
-    envoy: docker.io/envoyproxy/envoy:v1.33.0
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
       kind: ClusterIssuer

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -24,7 +24,7 @@ service:
   variant: openshift
   images:
     service: ghcr.io/osac-project/fulfillment-service:sha-79daf20
-    envoy: docker.io/envoyproxy/envoy:v1.33.0
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
       kind: ClusterIssuer

--- a/values/development.yaml
+++ b/values/development.yaml
@@ -28,7 +28,7 @@ service:
   variant: openshift
   images:
     service: ghcr.io/osac-project/fulfillment-service:latest
-    envoy: docker.io/envoyproxy/envoy:v1.33.0
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
       kind: ClusterIssuer

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -24,7 +24,7 @@ service:
   variant: openshift
   images:
     service: ghcr.io/osac-project/fulfillment-service:sha-79daf20
-    envoy: docker.io/envoyproxy/envoy:v1.33.0
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
       kind: ClusterIssuer


### PR DESCRIPTION
## Summary

- Replace all `docker.io/envoyproxy/envoy` image references with `ghcr.io/osac-project/envoy` to avoid Docker Hub rate limits and `ImagePullBackOff` on disconnected clusters
- Add a GitHub Actions workflow (`.github/workflows/mirror-envoy.yaml`) to mirror the envoy image from Docker Hub to GHCR, triggered manually or on a weekly schedule

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/mirror-envoy.yaml` | New — image mirroring workflow |
| `base/kustomization.yaml` | Update envoy `newName` |
| `charts/osac/values.yaml` | Update envoy image |
| `charts/osac/values-example.yaml` | Update envoy image |
| `values/development.yaml` | Update envoy image |
| `values/vmaas-ci.yaml` | Update envoy image |
| `values/caas-ci.yaml` | Update envoy image |

## Pre-requisites

1. **Mirror the image**: After merging, run the `Mirror Envoy Image` workflow manually with `v1.33.0` to push the image to GHCR. Otherwise deployed clusters will get `ImagePullNotFound`.
2. **Set package visibility to public**: The `ghcr.io/osac-project/envoy` package will be created as **private** by default. It must be changed to public in the [osac-project org package settings](https://github.com/orgs/osac-project/packages) after the first push, otherwise clusters without GHCR auth will still get `ImagePullBackOff`.

## Test plan

- [ ] Run mirror-envoy workflow manually with `v1.33.0` and verify `ghcr.io/osac-project/envoy:v1.33.0` exists
- [ ] Set `ghcr.io/osac-project/envoy` package visibility to public
- [ ] `helm lint charts/osac/` passes
- [ ] `helm template` with all CI values files succeeds and shows `ghcr.io/osac-project/envoy:v1.33.0`
- [ ] No `docker.io/envoyproxy` references remain outside submodules and the mirror workflow SOURCE
- [ ] `kustomize build base/` produces no `docker.io/envoyproxy` references