### PR TITLE
OSAC-496: Pass shared tenant on hub create

### DIFF
--- a/OSAC-CLI-HOWTO.md
+++ b/OSAC-CLI-HOWTO.md
@@ -608,6 +608,9 @@ EOF
 ```
 
 **Step 2: Register the Hub**
+
+When registering as an admin (universal tenant access), specify `--tenant shared` or rely on the CLI default (`shared`).
+
 ```bash
 # Register hub with fulfillment service
 ./osac create hub \

--- a/scripts/prepare-fulfillment-service.sh
+++ b/scripts/prepare-fulfillment-service.sh
@@ -30,7 +30,7 @@ create_hub() {
     local _server_name
     _server_name=$(oc config view --minify --output jsonpath="{.clusters[*].cluster.server}")
     _server_name=${_server_name#*.}; _server_name=${_server_name%%.*}
-    retry_command 300 10 osac create hub --kubeconfig="/tmp/kubeconfig.hub-access.${_server_name}" --id hub --namespace "${INSTALLER_NAMESPACE}"
+    retry_command 300 10 osac create hub --kubeconfig="/tmp/kubeconfig.hub-access.${_server_name}" --id hub --namespace "${INSTALLER_NAMESPACE}" --tenant shared
 }
 
 sync_aap_project() {


### PR DESCRIPTION
## Summary

- Pass `--tenant shared` in `prepare-fulfillment-service.sh` when registering the hub (admin token has universal tenant access after [OSAC-496](https://redhat.atlassian.net/browse/OSAC-496))
- Document the `--tenant` flag in `OSAC-CLI-HOWTO.md` (CLI also defaults to `shared` when omitted)

## Jira

https://redhat.atlassian.net/browse/OSAC-496

## Related PRs

- https://github.com/osac-project/fulfillment-service/pull/704
- https://github.com/osac-project/osac-operator/pull/297

## Test plan

- [x] `bash scripts/kustomize-build-all.sh` — pass
- [ ] CI (if applicable)