### PR TITLE
OSAC-757: Enabling Keycloak Organizations and granting osac-controller admin roles

### DIFF
--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -94,6 +94,24 @@
         "clientRole": false,
         "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
         "attributes": {}
+      },
+      {
+        "id": "b2c3d4e5-6789-0123-4567-890123456789",
+        "name": "tenant-user-manager",
+        "description": "Tenant user manager with user management permissions",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+        "attributes": {}
+      },
+      {
+        "id": "a1b2c3d4-e5f6-7890-abcd-900000000004",
+        "name": "tenant-idp-manager",
+        "description": "Tenant IdP manager with IdP configuration and role assignment permissions",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "01e6c34f-6906-4907-9cbd-2dec7a6a0e1d",
+        "attributes": {}
       }
     ],
     "client": {
@@ -694,6 +712,31 @@
         "/tenant1",
         "/tenant2"
       ]
+    },
+    {
+      "id": "b6c7d8e9-f0a1-2345-6789-abcdef012345",
+      "username": "service-account-osac-controller",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "osac-controller",
+      "createdTimestamp": 1757683950000,
+      "credentials": [],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-my realm"
+      ],
+      "clientRoles": {
+        "realm-management": [
+          "manage-realm",
+          "manage-users",
+          "view-realm",
+          "view-users"
+        ]
+      },
+      "notBefore": 0,
+      "groups": []
     }
   ],
   "scopeMappings": [
@@ -953,6 +996,7 @@
         "groups",
         "basic",
         "username",
+        "organization",
         "roles"
       ],
       "optionalClientScopes": []
@@ -2908,7 +2952,7 @@
   },
   "keycloakVersion": "26.3.5",
   "userManagedAccessAllowed": false,
-  "organizationsEnabled": false,
+  "organizationsEnabled": true,
   "verifiableCredentialsEnabled": false,
   "adminPermissionsEnabled": false,
   "clientProfiles": {


### PR DESCRIPTION
## Summary
- Enable Keycloak Organizations feature (`organizationsEnabled: true`) so the Admin REST API accepts organization management calls
- Add `service-account-osac-controller` user with `realm-admin` role to grant the controller permissions to call the Admin API
- Add missing `tenant-idp-manager` realm role that the controller assigns to break-glass users during organization creation
- Add `organization` scope to `osac-cli` defaultClientScopes so user JWTs include org membership claims


## Problem
The fulfillment-controller was failing with `HTTP 403 Forbidden` when calling `POST /admin/realms/osac/organizations` to create tenant organizations. The error cascaded for all tenants (tenant1, tenant2).


## Root Cause
Three issues in the Keycloak realm configuration:
1. `organizationsEnabled` was `false` — Keycloak returns 403 on the organizations endpoint when disabled
2. No service account user or role mappings existed for `osac-controller` 
3. The `tenant-idp-manager` realm role didn't exist 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization functionality is now enabled, providing structured tenant management capabilities
  * New administrative roles introduced for tenant user management and identity provider configuration

* **Chores**
  * Updated service account configurations and default client scopes for improved system administration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->