### PR TITLE
NO-ISSUE: Fix Keycloak issuer URL for gRPC server in vmaas-ci

### DIFF
--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -90,6 +90,13 @@ patches:
         value: "--idp-url=https://keycloak.keycloak.svc.cluster.local"
   - target:
       kind: Deployment
+      name: fulfillment-grpc-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/command/11
+        value: "--grpc-authn-trusted-token-issuers=https://keycloak.keycloak.svc.cluster.local/realms/osac"
+  - target:
+      kind: Deployment
       name: osac-operator-controller-manager
     patch: |-
       - op: add


### PR DESCRIPTION
## Summary

- The vmaas-ci overlay patches `--auth-issuer-url` on the `fulfillment-controller` to
  remove the `:8000` port, but the `--grpc-authn-trusted-token-issuers` flag on the
  `fulfillment-grpc-server` deployment was left at the base default which still includes
  `:8000`. This adds a matching patch for the gRPC server.
- This wasn't causing authentication failures because currently Authorino validates tokens,
  but once [fulfillment-service#685](https://github.com/osac-project/fulfillment-service/pull/685)
  lands and moves token validation into the gRPC server, the `iss` claim mismatch will
  break authentication. It was also likely causing issues with the CLI, as the server was
  directing it to the wrong Keycloak URL for token acquisition.

## Test plan

- [x] `kustomize-build-all.sh` passes
- [ ] Verify the `fulfillment-grpc-server` deployment on vmaas-ci uses the correct
  `--grpc-authn-trusted-token-issuers` URL without `:8000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gRPC server authentication configuration to use Keycloak for token validation within the cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->