### PR TITLE
OSAC-1564: Create AAP config-as-code secrets in Helm mode

### DIFF
--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -242,8 +242,9 @@ aap:
       hostname: ""
 
   configAsCode:
-    # Secret names for AAP config-as-code. These are created by
-    # scripts/aap-configuration.sh during post-install setup.
+    # Secret names for AAP config-as-code. These must exist before the
+    # bootstrap job runs. scripts/setup.sh creates them automatically in
+    # Helm mode; see docs/helm-deployment-guide.md for manual creation.
     manifestSecret: "config-as-code-manifest-ig"
     secret: "config-as-code-ig"
 

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -464,8 +464,14 @@ The AAP bootstrap job requires a subscription manifest (license.zip). Obtain
 it from the [Red Hat Customer Portal](https://access.redhat.com/) under
 **Subscriptions > Subscription Allocations > Export Manifest**.
 
+> **Note:** `scripts/setup.sh` creates this secret automatically when
+> `DEPLOY_MODE=helm`. Place `license.zip` in
+> `overlays/<overlay>/files/license.zip` or set the `AAP_LICENSE_FILE`
+> environment variable to its path. The manual command below is only needed
+> if you are not using `setup.sh`.
+
 ```bash
-# Create the license secret
+# Create the license secret (manual method)
 oc create secret generic config-as-code-manifest-ig \
   --from-file=license.zip=/path/to/your/license.zip \
   -n ${NAMESPACE}
@@ -476,7 +482,13 @@ oc create secret generic config-as-code-manifest-ig \
 This tells the AAP bootstrap job which execution environment image and git
 repository to use for configuration playbooks.
 
+> **Note:** `scripts/setup.sh` creates this secret automatically when
+> `DEPLOY_MODE=helm`, using sensible defaults. Override via `AAP_EE_IMAGE`,
+> `AAP_PROJECT_GIT_URI`, and `AAP_PROJECT_GIT_BRANCH` environment variables.
+> The manual command below is only needed if you are not using `setup.sh`.
+
 ```bash
+# Create the config-as-code secret (manual method)
 oc create secret generic config-as-code-ig \
   --from-literal=AAP_EE_IMAGE=ghcr.io/osac-project/osac-aap:latest \
   --from-literal=AAP_PROJECT_GIT_URI=https://github.com/osac-project/osac-aap \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -323,6 +323,40 @@ EOF
         -n "${INSTALLER_NAMESPACE}" \
         --dry-run=client -o yaml | oc apply -f -
 
+    # Create AAP license secret (required by the bootstrap job).
+    # In kustomize mode this is handled by secretGenerator; in Helm mode we
+    # must create it explicitly. The license.zip can be provided via:
+    #   1. AAP_LICENSE_FILE env var (absolute path)
+    #   2. overlays/<overlay>/files/license.zip (default convention)
+    AAP_LICENSE_FILE=${AAP_LICENSE_FILE:-"overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/license.zip"}
+    if [[ -f "${AAP_LICENSE_FILE}" ]]; then
+        echo "Creating config-as-code-manifest-ig secret from ${AAP_LICENSE_FILE}..."
+        oc create secret generic config-as-code-manifest-ig \
+            --from-file=license.zip="${AAP_LICENSE_FILE}" \
+            -n "${INSTALLER_NAMESPACE}" \
+            --dry-run=client -o yaml | oc apply -f -
+        oc label secret config-as-code-manifest-ig \
+            osac.openshift.io/project=osac-aap \
+            -n "${INSTALLER_NAMESPACE}" --overwrite
+    else
+        echo "WARNING: AAP license file not found at ${AAP_LICENSE_FILE}"
+        echo "The AAP bootstrap job will fail without it."
+        echo "Set AAP_LICENSE_FILE or place license.zip in overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/files/"
+    fi
+
+    # Create AAP config-as-code secret (EE image, git URI, git branch).
+    # Values can be overridden via environment variables.
+    AAP_EE_IMAGE=${AAP_EE_IMAGE:-"ghcr.io/osac-project/osac-aap:latest"}
+    AAP_PROJECT_GIT_URI=${AAP_PROJECT_GIT_URI:-"https://github.com/osac-project/osac-aap"}
+    AAP_PROJECT_GIT_BRANCH=${AAP_PROJECT_GIT_BRANCH:-"main"}
+    echo "Creating config-as-code-ig secret..."
+    oc create secret generic config-as-code-ig \
+        --from-literal=AAP_EE_IMAGE="${AAP_EE_IMAGE}" \
+        --from-literal=AAP_PROJECT_GIT_URI="${AAP_PROJECT_GIT_URI}" \
+        --from-literal=AAP_PROJECT_GIT_BRANCH="${AAP_PROJECT_GIT_BRANCH}" \
+        -n "${INSTALLER_NAMESPACE}" \
+        --dry-run=client -o yaml | oc apply -f -
+
     echo "Deploying OSAC using Helm..."
     helm dependency build charts/osac/
     helm upgrade --install osac charts/osac/ \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -358,7 +358,7 @@ EOF
         --dry-run=client -o yaml | oc apply -f -
 
     echo "Deploying OSAC using Helm..."
-    helm dependency build charts/osac/
+    helm dependency update charts/osac/
     helm upgrade --install osac charts/osac/ \
         --namespace "${INSTALLER_NAMESPACE}" \
         --values "${VALUES_FILE}" \


### PR DESCRIPTION
## Summary
- `setup.sh` in Helm mode (`DEPLOY_MODE=helm`) did not create the `config-as-code-manifest-ig` and `config-as-code-ig` secrets, causing the AAP bootstrap job to fail
- These secrets were only created by kustomize `secretGenerator` in the legacy path
- Add explicit `oc create secret` commands to the Helm block in `setup.sh`, before `helm upgrade --install`, matching the manual steps documented in the Helm deployment guide (sections 2.4-2.5)

## Changes
- **`scripts/setup.sh`** — Add license secret (`config-as-code-manifest-ig`) and config-as-code secret (`config-as-code-ig`) creation in Helm mode, with env var overrides (`AAP_LICENSE_FILE`, `AAP_EE_IMAGE`, `AAP_PROJECT_GIT_URI`, `AAP_PROJECT_GIT_BRANCH`) and idempotent apply
- **`docs/helm-deployment-guide.md`** — Note that `setup.sh` now handles these secrets automatically; manual commands kept for reference
- **`charts/osac/values-example.yaml`** — Fix inaccurate comment (previously said `aap-configuration.sh` created these secrets, which it does not)

## Test plan
- [ ] Run `setup.sh` with `DEPLOY_MODE=helm` and a valid `license.zip` — verify both secrets are created in the namespace before Helm install
- [ ] Run `setup.sh` with `DEPLOY_MODE=helm` without `license.zip` — verify warning is emitted and script continues
- [ ] Verify AAP bootstrap job completes successfully with the fix
- [ ] Verify `DEPLOY_MODE=kustomize` still works (no regression)
- [ ] Verify env var overrides (`AAP_LICENSE_FILE`, `AAP_EE_IMAGE`) work

Fixes: https://redhat.atlassian.net/browse/OSAC-1564

Generated by agent-teams skill

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm deployment guide with clarification on AAP license and Config-as-Code secret provisioning in Helm mode.
  * Updated configuration examples with notes on secret requirements and automatic setup.

* **New Features**
  * Helm deployment mode now automatically provisions required AAP secrets during setup.
  * Added support for environment variable overrides for license file, container image, and Git repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->