### PR TITLE
OSAC-757: Update keycloak deployment manifests to match fulfillment-service changes

### DIFF
--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -430,7 +430,8 @@
           "containerId": "23cad6d9-db0b-43b2-9d20-63e90b1b571e",
           "attributes": {}
         }
-      ]
+      ],
+      "osac-admin": []
     }
   },
   "groups": [
@@ -739,6 +740,24 @@
       },
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "id": "c3e4f5a6-b7c8-4d9e-0f1a-2b3c4d5e6f7a",
+      "username": "service-account-osac-admin",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "osac-admin",
+      "createdTimestamp": 1757683950000,
+      "credentials": [],
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-my realm"
+      ],
+      "clientRoles": {},
+      "notBefore": 0,
+      "groups": []
     }
   ],
   "scopeMappings": [
@@ -1028,7 +1047,65 @@
       "consentRequired": false,
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1757684016",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "a1c2d3e4-f5a6-4b7c-8d9e-0f1a2b3c4d5e",
+      "clientId": "osac-admin",
+      "name": "OSAC administrator",
+      "description": "Service account for the OSAC administrator",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "kP9xRmNvQw3hYjL8sT5uA2dF7gB0cE4i",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "/*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": true,
       "publicClient": false,
       "frontchannelLogout": true,

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -15,7 +15,7 @@ INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 KEYCLOAK_NS="keycloak"
 REALM_JSON="prerequisites/keycloak/service/files/realm.json"
-FC_CLIENT="osac-controller"
+FC_CLIENT=${FC_CLIENT:-"osac-controller"}
 
 echo "=== Refreshing OSAC after snapshot boot ==="
 echo "Namespace: ${INSTALLER_NAMESPACE}"

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -144,15 +144,14 @@ keycloak_sync() {
 
 create_fulfillment_credentials() {
     echo "[2/9] Recreating fulfillment controller credentials..."
-    FC_CLIENT_ID=$(jq -er '.clients[] | select(.serviceAccountsEnabled == true) | .clientId' "${REALM_JSON}")
-    FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${REALM_JSON}")
-    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
+    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' "${REALM_JSON}")
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
     oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
     oc create secret generic fulfillment-controller-credentials \
-        --from-literal=client-id="${FC_CLIENT_ID}" \
+        --from-literal=client-id=osac-controller \
         --from-literal=client-secret="${FC_CLIENT_SECRET}" \
         -n "${INSTALLER_NAMESPACE}"
-    echo "[2/9] Credentials created for client: ${FC_CLIENT_ID}"
+    echo "[2/9] Credentials created for client: osac-controller"
 }
 
 keycloak_sync &

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -15,6 +15,7 @@ INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
 CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 KEYCLOAK_NS="keycloak"
 REALM_JSON="prerequisites/keycloak/service/files/realm.json"
+FC_CLIENT="osac-controller"
 
 echo "=== Refreshing OSAC after snapshot boot ==="
 echo "Namespace: ${INSTALLER_NAMESPACE}"
@@ -144,14 +145,15 @@ keycloak_sync() {
 
 create_fulfillment_credentials() {
     echo "[2/9] Recreating fulfillment controller credentials..."
-    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' "${REALM_JSON}")
-    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+    FC_CLIENT_ID=${FC_CLIENT:-$(jq -er 'first(.clients[] | select(.serviceAccountsEnabled==true)) | .clientId' "${REALM_JSON}")}
+    FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${REALM_JSON}")
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
     oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
     oc create secret generic fulfillment-controller-credentials \
-        --from-literal=client-id=osac-controller \
+        --from-literal=client-id="${FC_CLIENT_ID}" \
         --from-literal=client-secret="${FC_CLIENT_SECRET}" \
         -n "${INSTALLER_NAMESPACE}"
-    echo "[2/9] Credentials created for client: osac-controller"
+    echo "[2/9] Credentials created for client: ${FC_CLIENT_ID}"
 }
 
 keycloak_sync &


### PR DESCRIPTION
## Summary

Aligns the `osac-installer` Keycloak realm configuration and supporting scripts with the service-account changes introduced in [fulfillment-service PR #462](https://github.com/osac-project/fulfillment-service/pull/462).

- **Add `osac-admin` client & service-account user to `realm.json`** — mirrors the new admin service-account client created in the fulfillment-service IT Helm chart. Also sets `directAccessGrantsEnabled: false` on `osac-controller` to match the client-credentials-only pattern.
- **Fix `refresh-after-snapshot.sh`** — the old `select(.serviceAccountsEnabled == true)` now returns multiple clients; switched to explicit `select(.clientId == "osac-controller")` so the credential secret is always resolved unambiguously.
- **Fix `sync-authconfig-rego.py` & resync overlay AuthConfig policies** — the base Rego now lists `controller` after `admin` in `emergency_service_accounts`, so the injection-point pattern was updated from `admin` → `controller`. Re-ran `--fix` to bring all four overlays in sync (adds `controller` SA, corrects comments, updates API endpoint names).

## Changed files

| File | Change |
|------|--------|
| `prerequisites/keycloak/service/files/realm.json` | Add `osac-admin` client, `service-account-osac-admin` user, `roles.client` entry; set `directAccessGrantsEnabled: false` on `osac-controller` |
| `scripts/refresh-after-snapshot.sh` | Hardcode `osac-controller` lookup instead of generic `serviceAccountsEnabled` query |
| `scripts/sync-authconfig-rego.py` | Update Rego injection point pattern from `admin` to `controller` |
| `overlays/{caas-ci,development,osac-integration,vmaas-ci}/kustomization.yaml` | Resync overlay Rego with base (emergency SA, API endpoints, comments) |

## Test plan

- [ ] `python scripts/sync-authconfig-rego.py` exits 0 (no drift)
- [ ] `jq . prerequisites/keycloak/service/files/realm.json > /dev/null` passes (valid JSON)
- [ ] Deploy to a dev cluster and verify both `osac-admin` and `osac-controller` clients appear in the Keycloak admin console
- [ ] Verify `refresh-after-snapshot.sh` correctly recreates the `fulfillment-controller-credentials` secret after a snapshot boot
- [ ] Verify the fulfillment-service controller can authenticate using the `osac-controller` client credentials

Resolves: [OSAC-757](https://redhat.atlassian.net/browse/OSAC-757)
Related: [fulfillment-service PR #462](https://github.com/osac-project/fulfillment-service/pull/462)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak realm configuration for `osac` by refining admin roles and service-account setup, and disabling direct access grants for the controller while keeping service accounts enabled.
  * Improved the fulfillment-controller credential refresh script to select and regenerate fulfillment credentials for a specific Keycloak client via a new environment variable, using the corresponding client secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->