### PR TITLE
Ensure helm is installed.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,6 +9,10 @@ source "${SCRIPT_DIR}/lib.sh"
 
 # Deploy mode: "helm" (default) or "kustomize" (legacy)
 DEPLOY_MODE=${DEPLOY_MODE:-"helm"}
+if [[ "${DEPLOY_MODE}" == "helm" ]]; then
+    # Ensure helm is installed
+    command -v helm &>/dev/null || { echo "Error: helm not found in PATH" >&2; exit 1; }
+fi
 
 INSTALLER_KUSTOMIZE_OVERLAY=${INSTALLER_KUSTOMIZE_OVERLAY:-"development"}
 VALUES_FILE=${VALUES_FILE:-"values/development.yaml"}


### PR DESCRIPTION
Without this check the setup.sh script silently exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the setup process for Helm deployments by checking that the `helm` command is available and showing a clear error message (with exit code `1`) when it isn’t.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->