### PR TITLE
Add bare metal fulfillment components

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "base/osac-aap"]
 	path = base/osac-aap
 	url = https://github.com/osac-project/osac-aap.git
+[submodule "base/bare-metal-fulfillment-operator"]
+	path = base/bare-metal-fulfillment-operator
+	url = https://github.com/osac-project/bare-metal-fulfillment-operator.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Kustomize-based deployment system that assembles fulfillment-service, osac-operator, and osac-aap (Git submodules under `base/`) into OpenShift overlays.
+Kustomize-based deployment system that assembles fulfillment-service, osac-operator, osac-aap, and bare-metal-fulfillment-operator (Git submodules under `base/`) into OpenShift overlays.
 
 ## Common Commands
 
@@ -34,11 +34,12 @@ yamllint --strict .
 ### Kustomize Composition
 
 ```
-base/kustomization.yaml          # Composes all submodule components + hub-access
-  base/osac-fulfillment-service/   # Git submodule -> fulfillment-service repo
-  base/osac-operator/              # Git submodule -> osac-operator repo
-  base/osac-aap/                   # Git submodule -> osac-aap repo
-  base/hub-access/                 # Local: ServiceAccount + RBAC for hub cluster access
+base/kustomization.yaml                        # Composes all submodule components + hub-access
+  base/osac-fulfillment-service/                 # Git submodule -> fulfillment-service repo
+  base/osac-operator/                            # Git submodule -> osac-operator repo
+  base/osac-aap/                                 # Git submodule -> osac-aap repo
+  base/bare-metal-fulfillment-operator/          # Git submodule -> bare-metal-fulfillment-operator repo
+  base/hub-access/                               # Local: ServiceAccount + RBAC for hub cluster access
 
 overlays/<name>/kustomization.yaml  # Extends base with env-specific config
   - namespace, image pins, patches, secretGenerator
@@ -78,7 +79,7 @@ An overlay's `files/` directory must contain `quay-pull-secret.json` and `licens
 
 ## Submodules and Local Development
 
-Submodules under `base/` (osac-operator, osac-fulfillment-service, osac-aap) are pinned snapshots of the real working repos. They do not auto-sync -- to test local changes, synchronize modified files from the working repo into the submodule directory, without committing. During active development the submodule pointers are often dirty; this is expected.
+Submodules under `base/` (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator) are pinned snapshots of the real working repos. They do not auto-sync -- to test local changes, synchronize modified files from the working repo into the submodule directory, without committing. During active development the submodule pointers are often dirty; this is expected.
 
 Do not `cd` into submodule directories and run git commands there -- you will operate on the submodule repo, not the installer. Always run git commands from the installer root.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ The OSAC platform relies on four core components to deliver governed self-servic
    Leverages the **Red Hat Ansible Automation Platform** to store and execute the custom
    template logic required for provisioning.
 
+5. **Bare Metal Fulfillment Operator:**
+   Kubernetes operator for managing bare-metal host pools. It watches **BareMetalPool**
+   custom resources and reconciles them to their desired state by provisioning pools of
+   bare-metal hosts organized by host type (e.g., GPU nodes, worker nodes). Uses profile
+   templates to configure workflows and apply configuration parameters to selected hosts.
+   It also contains a Kubernetes controller that manages bare-metal hosts via OpenStack
+   Ironic. It watches **BareMetalInstance** CRs (defined by the Bare Metal Fulfillment Operator)
+   and reconciles power state with Ironic.
+
 ### Prerequisites & Setup
 
 > **System Requirements** This solution requires the following platforms to be installed
@@ -130,7 +139,8 @@ Use Kustomize to manage your environment-specific configurations.
 4. **Update Critical Configuration:**
    You **must** update these configuration values to match your environment:
 
-   - In `kustomization.yaml`: Update the `namespace` field to `<project-name>`
+   - In `kustomization.yaml`: Update the `namespace` field and other instances
+     of the default namespace throughout the overlay to `<project-name>`.
    - In `prefixTransformer.yaml`: Update the `prefix` field to `<project-name>-`
    - The `ca-bundle` Bundle is cluster-scoped and shared across overlays.
      **If using `setup.sh`**, it handles the Bundle automatically (creates it on
@@ -173,6 +183,66 @@ Use Kustomize to manage your environment-specific configurations.
      `oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'`.
      **If using `setup.sh`**, these values are discovered from the cluster
      and patched automatically.
+   - In `kustomization.yaml`: For bare metal fulfillment, copy each `.example` file in
+     `files/` to its real name, fill in the required values, and update the
+     corresponding `secretGenerator` entry to reference the real file.
+
+     **`files/clouds.yaml`** — OpenStack credentials for the bare metal provider:
+     ```yaml
+     clouds:
+       my-cloud:                        # cloud name — used as OS_CLOUD value below
+         auth:
+           auth_url: https://keystone.example.com:35357/
+           project_name: myproject
+           username: myuser
+           password: mypassword
+         region_name: RegionOne
+     ```
+
+     **`files/inventory.yaml`** — inventory source configuration:
+     ```yaml
+     name: my-inventory
+     type: openstack
+     options:
+       openstack:
+         cloud: my-cloud                # must match the cloud name in clouds.yaml
+     hostClass: openstack
+     networkClass: openstack
+     ```
+
+     **`files/management.yaml`** — management cloud configuration:
+     ```yaml
+     name: my-management
+     type: openstack
+     options:
+       openstack:
+         cloud: my-cloud                # must match the cloud name in clouds.yaml
+     ```
+
+     **`files/profile.yaml`** — one entry per bare metal host provisioning profile:
+     ```yaml
+     - name: agentProvisioning
+       hostSelector:
+         managedBy: baremetal
+         provisionState: available
+       labels:
+         profileName: agentProvisioning
+       persistentLabels:
+         managedBy: agent
+       hostTemplate: bm_host_agent_provisioning
+       expectedTemplateParameters:
+         - agentPrivateNetwork
+         - imageURL
+     ```
+
+     The cloud name key in `clouds.yaml` must also be set in the
+     `bare-metal-fulfillment-ig` secretGenerator literal so that the BMF operator and
+     the Ironic controller use the same OpenStack cloud:
+     ```yaml
+     - name: bare-metal-fulfillment-ig
+       literals:
+         - OS_CLOUD=my-cloud            # must match the cloud name in clouds.yaml
+     ```
 
    These changes ensure your installation uses a unique namespace and prevents resource
    name conflicts with other OSAC installations.
@@ -222,6 +292,7 @@ To test a specific revision of a component, you need to:
    | Fulfillment Service | `fulfillment-service` |
    | OSAC Operator | `osac-operator` |
    | OSAC AAP | `osac-aap` |
+   | Bare Metal Fulfillment Operator | `bare-metal-fulfillment-operator` |
 
 #### OSAC AAP Customization
 

--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - osac-operator/config/console-proxy-kube-system
   - osac-fulfillment-service/manifests/overlays/openshift
   - hub-access
+  - bare-metal-fulfillment-operator/config/default
 
 # Common labels for all OSAC components
 labels:
@@ -33,6 +34,8 @@ images:
   newTag: sha-1ada6eb
 - name: ghcr.io/osac-project/osac-operator
   newTag: sha-4771f5f
+- name: ghcr.io/osac-project/bare-metal-fulfillment-operator
+  newTag: sha-0a06955
 - name: envoy
   newName: ghcr.io/osac-project/envoy
   newTag: v1.33.0

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -21,3 +21,11 @@ dependencies:
     version: ">=0.0.0"
     repository: "file://../../base/osac-aap/charts/aap"
     alias: aap
+  - name: bare-metal-fulfillment-operator-crds
+    version: ">=0.0.0"
+    repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator-crds"
+    alias: bmfCrds
+  - name: bare-metal-fulfillment-operator
+    version: ">=0.0.0"
+    repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator"
+    alias: bmf

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -232,6 +232,109 @@
           "properties": {
             "name": { "type": "string", "default": "service" },
             "user": { "type": "string", "default": "service" }
+	  }
+	}
+      }
+    },
+    "bmfCrds": {
+      "type": "object",
+      "description": "Bare Metal Fulfillment Operator CRDs configuration"
+    },
+    "bmf": {
+      "type": "object",
+      "description": "Bare Metal Fulfillment Operator configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Operator container image repository",
+              "default": "ghcr.io/osac-project/bare-metal-fulfillment-operator"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Operator container image tag",
+              "default": "latest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Image pull policy",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "Always"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of operator replicas",
+          "minimum": 1,
+          "default": 1
+        },
+        "resources": {
+          "type": "object",
+          "description": "Container resource requests and limits",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean",
+              "description": "Create a ServiceAccount for the operator",
+              "default": true
+            },
+            "name": {
+              "type": "string",
+              "description": "Override the ServiceAccount name (uses fullname if empty)"
+            }
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "description": "Names of Secrets mounted into the operator pod",
+          "properties": {
+            "inventoryConfig": {
+              "type": "string",
+              "description": "Secret name for OSAC inventory configuration",
+              "default": "osac-inventory-config"
+            },
+            "managementConfig": {
+              "type": "string",
+              "description": "Secret name for OSAC management configuration",
+              "default": "osac-management-config"
+            },
+            "osClouds": {
+              "type": "string",
+              "description": "Secret name for OpenStack clouds.yaml",
+              "default": "osac-os-clouds"
+            }
+          }
+        },
+        "configMaps": {
+          "type": "object",
+          "description": "Names of ConfigMaps mounted into the operator pod",
+          "properties": {
+            "profiles": {
+              "type": "string",
+              "description": "ConfigMap name for OSAC profiles",
+              "default": "osac-profiles"
+            }
           }
         }
       }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -114,6 +114,33 @@ bundledPostgres:
     name: service
     user: service
 
+# --- Bare Metal Fulfillment Operator CRDs ---
+bmfCrds: {}
+
+# --- Bare Metal Fulfillment Operator ---
+bmf:
+  image:
+    repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  serviceAccount:
+    create: true
+    name: ""
+  secrets:
+    inventoryConfig: "osac-inventory-config"
+    managementConfig: "osac-management-config"
+    osClouds: "osac-os-clouds"
+  configMaps:
+    profiles: "osac-profiles"
+
 # --- Hub Access ---
 hubAccess:
   enabled: true

--- a/overlays/caas-ci/kustomization.yaml
+++ b/overlays/caas-ci/kustomization.yaml
@@ -79,6 +79,59 @@ images:
     newTag: "4.20.0"
 
 patches:
+  # kustomize nameReference tracking breaks when osac-operator and bmf-operator both contribute a
+  # ServiceAccount originally named "controller-manager", causing the prefix transformer to reset
+  # CRB subjects to the unresolved original. Pin them explicitly to work around the collision.
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-admin-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
   - patch: |
       apiVersion: apps/v1
       kind: Deployment

--- a/overlays/development/files/clouds.yaml.example
+++ b/overlays/development/files/clouds.yaml.example
@@ -1,0 +1,8 @@
+clouds:
+  openstack:
+    auth:
+      auth_url: http://192.168.122.10:35357/
+      project_name: demo
+      username: demo
+      password: 0penstack
+    region_name: RegionOne

--- a/overlays/development/files/inventory.yaml.example
+++ b/overlays/development/files/inventory.yaml.example
@@ -1,0 +1,7 @@
+name: my-inventory
+type: openstack
+options:
+  openstack:
+    cloud: openstack
+hostClass: openstack
+networkClass: openstack

--- a/overlays/development/files/management.yaml.example
+++ b/overlays/development/files/management.yaml.example
@@ -1,0 +1,5 @@
+name: my-management
+type: openstack
+options:
+  openstack:
+    cloud: openstack

--- a/overlays/development/files/profile.yaml.example
+++ b/overlays/development/files/profile.yaml.example
@@ -1,0 +1,34 @@
+- name: agentProvisioning
+  hostSelector:
+    managedBy: baremetal
+    provisionState: available
+  labels:
+    profileName: agentProvisioning
+  persistentLabels:
+    managedBy: agent
+  hostTemplate: bm_host_agent_provisioning
+  expectedTemplateParameters:
+    - agentPrivateNetwork
+    - imageURL
+
+- name: agentDeprovisioning
+  hostSelector:
+    managedBy: agent
+    provisionState: active
+  labels:
+    profileName: agentDeprovisioning
+  persistentLabels:
+    managedBy: baremetal
+  hostTemplate: bm_host_agent_deprovisioning
+
+- name: agentCaaS
+  hostSelector:
+    managedBy: agent
+    provisionState: active
+  labels:
+    profileName: agentCaaS
+  bareMetalPoolTemplate: bm_private_network
+  hostTemplate: bm_host_private_network
+  expectedTemplateParameters:
+    - privateNetwork
+    - networkAfterDelete

--- a/overlays/development/kustomization.yaml
+++ b/overlays/development/kustomization.yaml
@@ -59,6 +59,42 @@ secretGenerator:
     labels:
       osac.openshift.io/project: osac-aap
 
+- name: bare-metal-fulfillment-ig
+  literals:
+    - OS_CLOUD=openstack
+
+# Configures the inventory source used for bare metal host discovery.
+# Copy files/inventory.yaml.example to files/inventory.yaml and set:
+#   name: a display name for this inventory
+#   type: the provider type (e.g. openstack)
+#   options.openstack.cloud: the cloud name from clouds.yaml to use for host discovery
+#   hostClass: the host class identifier
+#   networkClass: the network class identifier
+# Then update this generator entry to use files/inventory.yaml
+- name: osac-inventory-config
+  files:
+  - files/inventory.yaml.example
+
+# Standard OpenStack clouds.yaml with credentials for the bare metal provider.
+# Copy files/clouds.yaml.example to files/clouds.yaml and set:
+#   clouds.<name>.auth.auth_url: Keystone endpoint
+#   clouds.<name>.auth.project_name, username, password: OpenStack credentials
+#   clouds.<name>.region_name: OpenStack region
+# Then update this generator entry to use files/clouds.yaml
+- name: osac-os-clouds
+  files:
+    - files/clouds.yaml.example
+
+# Configures the management cloud connection used by the fulfillment service.
+# Copy files/management.yaml.example to files/management.yaml and set:
+#   name: a display name for this management provider
+#   type: the provider type (e.g. openstack)
+#   options.openstack.cloud: the cloud name from clouds.yaml to use for management operations
+# Then update this generator entry to use files/management.yaml
+- name: osac-management-config
+  files:
+  - files/management.yaml.example
+
 # Base defaults for the cluster-fulfillment-ig ConfigMap.
 # scripts/aap-configuration.sh may override these with values
 # from files/osac-aap-configuration.env after oc apply -k.
@@ -90,6 +126,19 @@ configMapGenerator:
     - NETRIS_SITE_ID=5
     - NETRIS_TENANT_ID=1
     - NETRIS_TENANT_NAME=Admin
+# Configures bare metal host provisioning profiles.
+# Copy files/profile.yaml.example to files/profile.yaml and define one entry per profile:
+#   name: unique profile identifier
+#   hostSelector: label selectors to match eligible bare metal hosts (e.g. managedBy, provisionState)
+#   labels: labels applied to the host while this profile is active
+#   persistentLabels: labels that remain on the host after the profile completes
+#   hostTemplate: AAP job template to run for host-level provisioning
+#   bareMetalPoolTemplate: AAP job template for pool-level operations (optional)
+#   expectedTemplateParameters: list of required input parameters for the host template (optional)
+# Then update this generator entry to use files/profile.yaml
+- name: osac-profiles
+  files:
+    - files/profile.yaml.example
 
 images:
   - name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -161,6 +210,79 @@ patches:
         value:
           name: OSAC_FULFILLMENT_TOKEN_FILE
           value: /var/run/secrets/kubernetes.io/serviceaccount/token
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Always
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-devel
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-devel
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+  - target:
+      kind: Deployment
+      name: bmf-operator-controller-manager
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_TEMPLATE_PREFIX
+          value: osac
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_URL
+          value: "https://osac-aap.osac-devel.apps.<cluster-name>.<base-domain>/api/controller"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: osac-aap-api-token
+              key: token
+              optional: true
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OSAC_AAP_INSECURE_SKIP_VERIFY
+          value: "true"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OS_CLOUD
+          valueFrom:
+            secretKeyRef:
+              name: bare-metal-fulfillment-ig
+              key: OS_CLOUD
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: os-clouds
+          secret:
+            secretName: osac-os-clouds
       - op: replace
         path: /spec/template/spec/containers/0/imagePullPolicy
         value: Always

--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -79,6 +79,59 @@ images:
     newTag: "4.20.0"
 
 patches:
+  # kustomize nameReference tracking breaks when osac-operator and bmf-operator both contribute a
+  # ServiceAccount originally named "controller-manager", causing the prefix transformer to reset
+  # CRB subjects to the unresolved original. Pin them explicitly to work around the collision.
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-integration
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-admin-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-integration
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-integration
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-integration
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-integration
   - patch: |
       apiVersion: apps/v1
       kind: Deployment

--- a/overlays/vmaas-ci/kustomization.yaml
+++ b/overlays/vmaas-ci/kustomization.yaml
@@ -67,6 +67,59 @@ images:
     newTag: "4.20.0"
 
 patches:
+  # kustomize nameReference tracking breaks when osac-operator and bmf-operator both contribute a
+  # ServiceAccount originally named "controller-manager", causing the prefix transformer to reset
+  # CRB subjects to the unresolved original. Pin them explicitly to work around the collision.
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-manager-admin-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: osac-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: osac-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-manager-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
+  - target:
+      kind: ClusterRoleBinding
+      name: bmf-operator-metrics-auth-rolebinding
+    patch: |-
+      - op: replace
+        path: /subjects/0/name
+        value: bmf-operator-controller-manager
+      - op: replace
+        path: /subjects/0/namespace
+        value: osac-e2e-ci
   - patch: |
       apiVersion: apps/v1
       kind: Deployment

--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -33,12 +33,17 @@ fi
 # Store the token in a Kubernetes secret
 oc create secret generic osac-aap-api-token \
     --from-literal=token="${AAP_TOKEN}" \
-    -n ${INSTALLER_NAMESPACE} \
+    -n "${INSTALLER_NAMESPACE}" \
     --dry-run=client -o yaml | oc apply -f -
 
 # Set the correct AAP URL on the operator deployment (triggers rollout)
 oc set env deployment/osac-operator-controller-manager \
-    -n ${INSTALLER_NAMESPACE} \
+    -n "${INSTALLER_NAMESPACE}" \
+    OSAC_AAP_URL="${AAP_URL}/api/controller"
+
+# Set the correct AAP URL on the bare metal fulfillment operator deployment (triggers rollout)
+oc set env deployment/bmf-operator-controller-manager \
+    -n "${INSTALLER_NAMESPACE}" \
     OSAC_AAP_URL="${AAP_URL}/api/controller"
 
 echo "AAP API token created and stored in secret osac-aap-api-token"

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -13,11 +13,12 @@ declare -A IMAGE_NAME=(
   [osac-operator]="ghcr.io/osac-project/osac-operator"
   [osac-fulfillment-service]="ghcr.io/osac-project/fulfillment-service"
   [osac-aap]="osac-aap"
+  [bare-metal-fulfillment-operator]="ghcr.io/osac-project/bare-metal-fulfillment-operator"
 )
 
 errors=0
 
-for submodule in osac-operator osac-fulfillment-service osac-aap; do
+for submodule in osac-operator osac-fulfillment-service osac-aap bare-metal-fulfillment-operator; do
   commit=$(git -C "${REPO_ROOT}" submodule status "base/${submodule}" | awk '{print $1}' | tr -d ' +-')
   short="${commit:0:7}"
   tag="sha-${short}"
@@ -74,6 +75,7 @@ done
 operator_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-operator | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 fulfillment_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-fulfillment-service | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 aap_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-aap | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
+bmf_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/bare-metal-fulfillment-operator | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 
 for values_file in "${REPO_ROOT}"/values/*.yaml; do
   [[ ! -f "${values_file}" ]] && continue
@@ -83,7 +85,8 @@ for values_file in "${REPO_ROOT}"/values/*.yaml; do
   for pair in \
     "osac-operator:tag ${operator_tag}" \
     "fulfillment-service:inline ${fulfillment_tag}" \
-    "osac-aap:inline ${aap_tag}"; do
+    "osac-aap:inline ${aap_tag}" \
+    "bare-metal-fulfillment-operator:tag ${bmf_tag}"; do
     component="${pair%%:*}"
     rest="${pair#*:}"
     mode="${rest%% *}"

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -104,3 +104,10 @@ clusterFulfillment:
 
 networkFulfillment:
   enabled: true
+
+# --- Bare Metal Fulfillment Operator ---
+bmf:
+  image:
+    repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
+    tag: sha-0a06955
+    pullPolicy: Always

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -94,3 +94,10 @@ validation:
 dbMigrate:
   enabled: false
   image: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
+
+# --- Bare Metal Fulfillment Operator ---
+bmf:
+  image:
+    repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
+    tag: sha-0a06955
+    pullPolicy: Always


### PR DESCRIPTION
Integrate bare-metal-fulfillment-operator as a git submodule to enable bare metal host pool management and OpenStack Ironic integration for physical infrastructure provisioning.

Changes:

* Add bare-metal-fulfillment-operator submodule
* Update base/kustomization.yaml with component resources and image tags
* Document new components in README.md OSAC Components section
* Update AGENTS.md architecture documentation with new submodules
* Extend scripts/sync-image-tags.sh to track bare metal component images

The Bare Metal Fulfillment Operator manages BareMetalPool CRs and uses profile templates for host provisioning workflows, and watches HostLease CRs to reconcile power state with Ironic.

Closes https://github.com/osac-project/issues/issues/401

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Bare Metal Fulfillment Operator component for managing bare-metal hosts and OpenStack integration.
  * Introduced Helm chart support with new `bmf` and `bmfCrds` configuration, including default operator image settings.
* **Documentation**
  * Expanded installation/customization instructions for bare-metal fulfillment, including OpenStack cloud alignment and copy/fill steps.
  * Added development example files for `clouds`, `inventory`, `management`, and `profile` configuration.
* **Chores**
  * Updated deployment/kustomize and image tag synchronization to use the latest pinned operator version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->