### PR TITLE
NO-ISSUE: Override Keycloak realm on every startup

### DIFF
--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -90,9 +90,13 @@ spec:
           value: keycloak
         - name: KC_DB_PASSWORD
           value: ""
-        args:
-        - start
-        - --import-realm
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          /opt/keycloak/bin/kc.sh import --dir /opt/keycloak/data/import --override true
+          exec /opt/keycloak/bin/kc.sh start
         ports:
         - name: https
           containerPort: 8001


### PR DESCRIPTION
## Summary

- Use `kc.sh import --override true` before starting the server so that the realm
  configuration is always re-imported, even if the realm already exists in the database.
- The `--import-realm` startup flag skips existing realms by design, which means tests
  would run with the stale realm from the VM snapshot rather than the current one.

## Test plan

- [ ] Deploy Keycloak and verify the realm is imported on first startup.
- [ ] Restart the pod and verify the realm is re-imported (check logs for import activity).
- [ ] Modify `realm.json`, restart, and confirm the changes are picked up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak service deployment startup sequence to explicitly run realm import first, then start the service. This ensures realm configuration from the import directory is applied reliably on every restart, with a clearer separation between import and normal startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->