### PR TITLE
OSAC-1625: add DNS backend configuration to Helm values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ kubeconfig.hub-access
 # Helm build artifacts
 charts/*/charts/*.tgz
 charts/*/Chart.lock
+
+# Implementation artifacts
+.artifacts/

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -62,6 +62,8 @@ clusterFulfillment:
   config:
     NETWORK_CLASS: "netris"
     NETWORK_STEPS_COLLECTION: "netris.steps"
+    DNS_CLASS: "dns.route53.dns"
+    DNS_ZONE: "test.example.com"
     NETRIS_CONTROLLER_URL: "https://test-ctl.netris.io"
     NETRIS_USERNAME: "testuser"
     NETRIS_SITE_ID: "1"

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -298,6 +298,83 @@ publishTemplates:
   fulfillmentServiceUri: "https://fulfillment-internal-api:8001"
 
 # ---------------------
+# Cluster Fulfillment Instance Group
+# ---------------------
+# ConfigMap and Secret for the AAP cluster-fulfillment instance group.
+# Carries network backend selection, Netris credentials, SSH config,
+# external-access domains, hosted-cluster defaults, and DNS backend config.
+#
+# The config keys become environment variables in the AAP instance group.
+# See osac-aap/group_vars/all/configuration.yaml for how they are consumed.
+clusterFulfillment:
+  enabled: false
+  config:
+    # --- Network Backend ---
+    # Network implementation class (e.g., "netris", "esi").
+    NETWORK_CLASS: ""
+    # Ansible collection providing network-class-specific steps.
+    NETWORK_STEPS_COLLECTION: ""
+
+    # --- DNS Backend ---
+    # Fully-qualified Ansible role name of the DNS driver to use.
+    # Examples: "dns.route53.dns", "dns.cloudflare.dns"
+    # Default (when empty): "dns.route53.dns"
+    DNS_CLASS: ""
+    # DNS zone to operate in (e.g., "example.com").
+    # Default (when empty): value of EXTERNAL_ACCESS_BASE_DOMAIN.
+    DNS_ZONE: ""
+
+    # --- Netris Controller ---
+    NETRIS_CONTROLLER_URL: ""
+    NETRIS_USERNAME: ""
+    NETRIS_SITE_ID: ""
+    NETRIS_TENANT_ID: ""
+    NETRIS_TENANT_NAME: ""
+    NETRIS_MGMT_VPC_ID: ""
+    NETRIS_MGMT_VPC_NAME: ""
+    NETRIS_RESOURCE_CLASS_MAP: ""
+
+    # --- SSH Access ---
+    SERVER_SSH_BASTION_HOST: ""
+    SERVER_SSH_BASTION_USER: ""
+    SERVER_SSH_USER: ""
+    SERVER_MGMT_ROUTE_DESTINATION: ""
+    SERVER_MGMT_ROUTE_GATEWAY: ""
+
+    # --- External Access ---
+    EXTERNAL_ACCESS_BASE_DOMAIN: ""
+    EXTERNAL_ACCESS_SUPPORTED_BASE_DOMAINS: ""
+    EXTERNAL_ACCESS_API_INTERNAL_NETWORK: ""
+
+    # --- Hosted Cluster ---
+    HOSTED_CLUSTER_BASE_DOMAIN: ""
+    HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: ""
+    HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: ""
+  secret:
+    NETRIS_PASSWORD: ""
+    # AWS credentials (used by the Route 53 DNS backend).
+    AWS_ACCESS_KEY_ID: ""
+    AWS_SECRET_ACCESS_KEY: ""
+    SERVER_SSH_KEY: ""
+    SERVER_SSH_BASTION_KEY: ""
+
+# ---------------------
+# Network Fulfillment Instance Group
+# ---------------------
+# ConfigMap and Secret for the AAP networking-operations instance group.
+# Carries Netris controller credentials for network resource lifecycle.
+networkFulfillment:
+  enabled: false
+  config:
+    NETRIS_CONTROLLER_URL: ""
+    NETRIS_USERNAME: ""
+    NETRIS_SITE_ID: ""
+    NETRIS_TENANT_ID: ""
+    NETRIS_TENANT_NAME: ""
+  secret:
+    NETRIS_PASSWORD: ""
+
+# ---------------------
 # Pre-install Validation
 # ---------------------
 validation:

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -184,12 +184,14 @@ dbMigrate:
 # --- Cluster Fulfillment Instance Group ---
 # ConfigMap and Secret for the AAP cluster-fulfillment instance group.
 # Carries network backend selection, Netris credentials, SSH config,
-# external-access domains, and hosted-cluster defaults.
+# external-access domains, hosted-cluster defaults, and DNS backend config.
 clusterFulfillment:
   enabled: false
   config:
     NETWORK_CLASS: ""
     NETWORK_STEPS_COLLECTION: ""
+    DNS_CLASS: ""
+    DNS_ZONE: ""
     NETRIS_CONTROLLER_URL: ""
     NETRIS_USERNAME: ""
     NETRIS_SITE_ID: ""


### PR DESCRIPTION
## [OSAC-1625](https://redhat.atlassian.net/browse/OSAC-1625): Add DNS backend configuration to Helm values

**Jira:** https://redhat.atlassian.net/browse/OSAC-1625

### Summary

Adds DNS backend configuration support to the osac-installer Helm chart. This enables platform operators to configure the DNS provider (Route 53, Cloudflare, etc.) and DNS zone through Helm values, following the same pattern used for Netris network backend configuration ([OSAC-1402](https://redhat.atlassian.net/browse/OSAC-1402)).

### Changes

- **`charts/osac/values.yaml`** — Added `DNS_CLASS` and `DNS_ZONE` to `clusterFulfillment.config`
- **`charts/osac/values-example.yaml`** — Added fully documented `clusterFulfillment` and `networkFulfillment` sections with inline comments for all config/secret keys, including DNS backend documentation
- **`charts/osac/ci/full-values.yaml`** — Added `DNS_CLASS: "dns.route53.dns"` and `DNS_ZONE: "test.example.com"` to exercise template branches in CI

### Testing

- **Helm lint:** passes
- **YAML lint:** passes
- **Unit/integration tests:** N/A — values-only change, no new template logic. The existing `cluster-fulfillment-ig.yaml` template iterates all config keys generically.

### How it works

The DNS config keys become environment variables in the AAP cluster-fulfillment instance group. AAP's `group_vars/all/configuration.yaml` reads them:
- `DNS_CLASS` → `dns_class` (fully-qualified Ansible role name, default: `dns.route53.dns`)
- `DNS_ZONE` → `dns_zone` (DNS zone, defaults to `external_access_base_domain`)

### Acceptance Criteria

- [x] Helm templates create DNS provider ConfigMap (via existing generic template)
- [x] Values schema documents DNS configuration knobs
- [x] Templates are conditionally rendered (gated by `clusterFulfillment.enabled`)
- [x] CI values file demonstrates DNS configuration
- [x] `helm lint` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build artifact exclusion patterns.
  * Added DNS backend configuration options to cluster fulfillment settings.
  * Expanded configuration templates with new network and cluster fulfillment examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->