### PR TITLE
OSAC-1628: Add required externalHostname and internalHostname to umbrella chart

### DIFF
--- a/.github/workflows/helm-integration.yaml
+++ b/.github/workflows/helm-integration.yaml
@@ -44,7 +44,11 @@ jobs:
       run: helm lint charts/osac/
 
     - name: Template chart (dry-run validation)
-      run: helm template osac charts/osac/ --values values/development.yaml > /dev/null
+      run: |
+        helm template osac charts/osac/ --values values/development.yaml \
+          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
+          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local \
+          > /dev/null
 
     - name: Deploy umbrella chart
       continue-on-error: true
@@ -53,6 +57,8 @@ jobs:
           --namespace osac \
           --create-namespace \
           --values values/development.yaml \
+          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
+          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local \
           --set validation.enabled=false \
           --set aap.bootstrap.enabled=false \
           --set aap.aap.instance.enabled=false \
@@ -78,6 +84,8 @@ jobs:
         helm upgrade osac charts/osac/ \
           --namespace osac \
           --values values/development.yaml \
+          --set service.externalHostname=fulfillment-api.osac.svc.cluster.local \
+          --set service.internalHostname=fulfillment-internal-api.osac.svc.cluster.local \
           --set validation.enabled=false \
           --set aap.bootstrap.enabled=false \
           --set aap.aap.instance.enabled=false \

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -45,7 +45,10 @@ jobs:
         set -euo pipefail
         for f in values/*.yaml; do
           echo "--- helm template with $(basename "$f") ---"
-          helm template osac charts/osac/ --values "$f" > /dev/null
+          helm template osac charts/osac/ --values "$f" \
+            --set service.externalHostname=fulfillment-api.example.com \
+            --set service.internalHostname=fulfillment-internal-api.example.com \
+            > /dev/null
         done
 
     - name: Validate values schema

--- a/charts/osac/ci/bundled-postgres-values.yaml
+++ b/charts/osac/ci/bundled-postgres-values.yaml
@@ -6,6 +6,8 @@ bundledPostgres:
     user: service
 
 service:
+  externalHostname: fulfillment-api.example.com
+  internalHostname: fulfillment-internal-api.example.com
   auth:
     issuerUrl: https://keycloak.example.com/realms/osac
     controllerCredentials:

--- a/charts/osac/ci/default-values.yaml
+++ b/charts/osac/ci/default-values.yaml
@@ -2,6 +2,8 @@
 # Only sets values that subcharts mark as required.
 
 service:
+  externalHostname: fulfillment-api.example.com
+  internalHostname: fulfillment-internal-api.example.com
   auth:
     issuerUrl: https://keycloak.example.com/realms/osac
     controllerCredentials:

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -13,6 +13,8 @@ operator:
 
 service:
   variant: openshift
+  externalHostname: fulfillment-api.example.com
+  internalHostname: fulfillment-internal-api.example.com
   auth:
     issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
     controllerCredentials:

--- a/charts/osac/ci/no-aap-values.yaml
+++ b/charts/osac/ci/no-aap-values.yaml
@@ -2,6 +2,8 @@
 # Exercises the disabled-AAP template branches.
 
 service:
+  externalHostname: fulfillment-api.example.com
+  internalHostname: fulfillment-internal-api.example.com
   auth:
     issuerUrl: https://keycloak.example.com/realms/osac
     controllerCredentials:

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -101,6 +101,18 @@ service:
   # Deployment variant: "openshift" for OCP clusters, "kind" for local dev.
   variant: openshift
 
+  # [REQUIRED] Hostname used to access the public API from outside the cluster.
+  # This is the hostname for the OpenShift Route or Ingress that exposes the
+  # fulfillment API externally.
+  # Example: fulfillment-api-osac.apps.mycluster.example.com
+  externalHostname: ""
+
+  # [REQUIRED] Hostname used to access both the public and private APIs
+  # internally. This Route/Ingress is typically not exposed to the internet
+  # and is used by other OSAC components (operator, AAP) within the cluster.
+  # Example: fulfillment-internal-api-osac.apps.mycluster.example.com
+  internalHostname: ""
+
   images:
     # Production: pin to a specific SHA tag.
     # Development: use "latest".

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -94,8 +94,18 @@
     "service": {
       "type": "object",
       "description": "Fulfillment Service configuration",
-      "required": ["auth", "certs"],
+      "required": ["externalHostname", "internalHostname", "auth", "certs"],
       "properties": {
+        "externalHostname": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Hostname for the external API Route"
+        },
+        "internalHostname": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Hostname for the internal API Route"
+        },
         "variant": {
           "type": "string",
           "description": "Deployment variant",

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -40,6 +40,10 @@ operator:
 # --- Fulfillment Service ---
 service:
   variant: openshift
+  # [REQUIRED] Hostname for the external API Route (e.g. fulfillment-api-osac.apps.mycluster.example.com)
+  externalHostname: ""
+  # [REQUIRED] Hostname for the internal API Route (e.g. fulfillment-internal-api-osac.apps.mycluster.example.com)
+  internalHostname: ""
   images:
     service: ghcr.io/osac-project/fulfillment-service:latest
     envoy: ghcr.io/osac-project/envoy:v1.33.0

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -640,6 +640,8 @@ Key settings to review in your values file:
 
 | Setting | Description | Where to Find |
 |---------|-------------|---------------|
+| `service.externalHostname` | **Required.** Hostname for the external API Route | `fulfillment-api-${NAMESPACE}.apps.<cluster>.<domain>` |
+| `service.internalHostname` | **Required.** Hostname for the internal API Route | `fulfillment-internal-api-${NAMESPACE}.apps.<cluster>.<domain>` |
 | `operator.aap.url` | AAP controller API URL | Set post-install by `prepare-aap.sh` |
 | `service.auth.issuerUrl` | Keycloak realm URL | `https://keycloak.keycloak.svc.cluster.local/realms/osac` (default works) |
 | `service.idp.url` | Keycloak base URL | `https://keycloak.keycloak.svc.cluster.local` (default works) |
@@ -648,6 +650,20 @@ Key settings to review in your values file:
 | `aap.bootstrap.enabled` | Run bootstrap job | `true` (configures AAP with job templates) |
 | `hubAccess.enabled` | Create hub-access SA and RBAC | `true` (required for hub registration) |
 | `publishTemplates.enabled` | Create publish-templates-ig ConfigMap | `true` (template publishing config) |
+
+#### Determine API Hostnames
+
+The fulfillment service requires explicit hostnames for the external and internal API
+Routes. These are used in TLS certificate generation and cannot be auto-detected. On
+OpenShift, determine your cluster's ingress domain and set the hostnames accordingly:
+
+```bash
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+export EXTERNAL_HOSTNAME="fulfillment-api-${NAMESPACE}.${DOMAIN}"
+export INTERNAL_HOSTNAME="fulfillment-internal-api-${NAMESPACE}.${DOMAIN}"
+```
+
+Set these in your values file or pass them via `--set` at install time.
 
 ### 3.3 Validate
 
@@ -661,7 +677,10 @@ helm lint charts/osac/
 # Dry-run render
 helm template osac charts/osac/ \
   --namespace ${NAMESPACE} \
-  --values values/development.yaml > /dev/null
+  --values values/development.yaml \
+  --set service.externalHostname=${EXTERNAL_HOSTNAME} \
+  --set service.internalHostname=${INTERNAL_HOSTNAME} \
+  > /dev/null
 ```
 
 ### 3.4 Deploy
@@ -671,6 +690,8 @@ helm upgrade --install osac charts/osac/ \
   --namespace ${NAMESPACE} \
   --create-namespace \
   --values values/development.yaml \
+  --set service.externalHostname=${EXTERNAL_HOSTNAME} \
+  --set service.internalHostname=${INTERNAL_HOSTNAME} \
   --timeout 40m \
   --wait
 ```
@@ -807,6 +828,7 @@ Keycloak, AAP.
 
 ```bash
 export NAMESPACE=osac
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 # Phase 1: Install LVMS (if needed), CNV, cert-manager, trust-manager,
 #           CA issuer, Authorino, Keycloak, AAP operator
 # Phase 2: Create secrets (license, config-as-code, credentials)
@@ -814,6 +836,8 @@ export NAMESPACE=osac
 helm upgrade --install osac charts/osac/ \
   --namespace ${NAMESPACE} --create-namespace \
   --values values/vmaas-ci.yaml \
+  --set service.externalHostname=fulfillment-api-${NAMESPACE}.${DOMAIN} \
+  --set service.internalHostname=fulfillment-internal-api-${NAMESPACE}.${DOMAIN} \
   --timeout 40m --wait
 # Phase 4: Post-install scripts
 ```
@@ -825,6 +849,7 @@ Keycloak, AAP.
 
 ```bash
 export NAMESPACE=osac
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 # Phase 1: Install LVMS (if needed), MCE, cert-manager, trust-manager,
 #           CA issuer, Authorino, Keycloak, AAP operator
 # Phase 2: Create secrets (license, config-as-code, credentials)
@@ -832,6 +857,8 @@ export NAMESPACE=osac
 helm upgrade --install osac charts/osac/ \
   --namespace ${NAMESPACE} --create-namespace \
   --values values/caas-ci.yaml \
+  --set service.externalHostname=fulfillment-api-${NAMESPACE}.${DOMAIN} \
+  --set service.internalHostname=fulfillment-internal-api-${NAMESPACE}.${DOMAIN} \
   --timeout 40m --wait
 # Phase 4: Post-install scripts
 ```
@@ -843,12 +870,15 @@ Authorino, Keycloak, AAP).
 
 ```bash
 export NAMESPACE=osac
+DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
 # Phase 1: Install all prerequisites
 # Phase 2: Create secrets
 # Phase 3: Deploy
 helm upgrade --install osac charts/osac/ \
   --namespace ${NAMESPACE} --create-namespace \
   --values values/development.yaml \
+  --set service.externalHostname=fulfillment-api-${NAMESPACE}.${DOMAIN} \
+  --set service.internalHostname=fulfillment-internal-api-${NAMESPACE}.${DOMAIN} \
   --timeout 40m --wait
 # Phase 4: Post-install scripts
 ```

--- a/values/caas-ci.yaml
+++ b/values/caas-ci.yaml
@@ -22,6 +22,8 @@ operator:
 # --- Fulfillment Service ---
 service:
   variant: openshift
+  externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
+  internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   images:
     service: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
     envoy: ghcr.io/osac-project/envoy:v1.33.0

--- a/values/development.yaml
+++ b/values/development.yaml
@@ -26,6 +26,8 @@ operator:
 # --- Fulfillment Service ---
 service:
   variant: openshift
+  externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
+  internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   images:
     service: ghcr.io/osac-project/fulfillment-service:latest
     envoy: ghcr.io/osac-project/envoy:v1.33.0

--- a/values/vmaas-ci.yaml
+++ b/values/vmaas-ci.yaml
@@ -22,6 +22,8 @@ operator:
 # --- Fulfillment Service ---
 service:
   variant: openshift
+  externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
+  internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   images:
     service: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
     envoy: ghcr.io/osac-project/envoy:v1.33.0


### PR DESCRIPTION
## Summary

- Add `externalHostname` and `internalHostname` as required parameters in the umbrella chart's
  values, schema, and CI values files. These are needed because the fulfillment-service subchart
  is making them mandatory (see osac-project/fulfillment-service#727) since TLS certificates
  must include the correct hostnames.
- Update the helm-lint and helm-integration CI workflows to supply the hostnames when templating
  with environment values files.
- Update the deployment guide with instructions on how to determine and set these parameters.

## Test plan

- Verify `helm template` passes with the updated CI values files.
- Verify the JSON schema is valid.
- Verify the deployment guide renders correctly.

Related: https://redhat.atlassian.net/browse/OSAC-1628
Ref: https://github.com/osac-project/fulfillment-service/pull/727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required `externalHostname` and `internalHostname` configuration fields for API service endpoints.

* **Documentation**
  * Updated Helm deployment guide with instructions for determining and configuring API hostnames using cluster ingress domains.

* **Chores**
  * Updated CI/CD workflows to pass hostname configuration during Helm templating and deployment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->