### PR TITLE
Initializing externalHostname and internalHostname vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ helm upgrade --install osac charts/osac/ \
   --namespace <project-name> \
   --create-namespace \
   --values values/<project-name>.yaml \
+  --set service.externalHostname=${EXTERNAL_HOSTNAME} \
+  --set service.internalHostname=${INTERNAL_HOSTNAME} \
   --timeout 40m \
   --wait
 ```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -22,6 +22,10 @@ if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
     [[ -z "${INSTALLER_NAMESPACE}" ]] && echo "ERROR: Could not determine namespace from overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" && exit 1
 else
     INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-"osac"}
+    INGRESS_FQDN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
+    [[ -z "${INGRESS_FQDN}" ]] && echo "ERROR: Could not determine the ingress FQDN" && exit 1
+    EXTERNAL_HOSTNAME=fulfillment-api-${INSTALLER_NAMESPACE}.${INGRESS_FQDN}
+    INTERNAL_HOSTNAME=fulfillment-internal-api-${INSTALLER_NAMESPACE}.${INGRESS_FQDN}
 fi
 
 INSTALLER_VM_TEMPLATE=${INSTALLER_VM_TEMPLATE:-}
@@ -366,6 +370,8 @@ EOF
     helm upgrade --install osac charts/osac/ \
         --namespace "${INSTALLER_NAMESPACE}" \
         --values "${VALUES_FILE}" \
+        --set service.externalHostname=${EXTERNAL_HOSTNAME} \
+        --set service.internalHostname=${INTERNAL_HOSTNAME} \
         --timeout 40m \
         --wait
 else


### PR DESCRIPTION
These varaibles are required for helm deploy method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the manual Helm installation guide to set service external/internal hostnames using environment-derived values.

* **Chores**
  * Enhanced Helm deployment setup to auto-detect the cluster ingress domain, derive external and internal hostname values, and apply them during install/upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->