### PR TITLE
Create namespace pull secret in helm refresh for CI image pulls

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -453,6 +453,14 @@ def create_secrets(config: RefreshConfig) -> None:
     oc_apply_secret("config-as-code-manifest-ig", config.namespace,
                     f"--from-file=license.zip={license_path}")
 
+    pull_secret_path = Path(config.values_dir) / "pull-secret.json"
+    if pull_secret_path.exists():
+        oc_apply_secret("quay-pull-secret", config.namespace,
+                        f"--from-file=.dockerconfigjson={pull_secret_path}",
+                        "--type=kubernetes.io/dockerconfigjson")
+        oc("secrets", "link", "osac-sa", "quay-pull-secret", "--for=pull",
+           "-n", config.namespace)
+
     print("  Secrets created")
 
 


### PR DESCRIPTION
## Summary
- Creates `quay-pull-secret` in the OSAC namespace during `refresh-after-snapshot.py` when `pull-secret.json` is present in the values directory
- Links the secret to the `osac-sa` service account for AAP job pod image pulls
- Fixes intermittent `ErrImagePull` in CI when AAP automation jobs try to pull CI-built EE images before MCO propagates the global pull secret to CRI-O

## Context
The old kustomize flow created this secret via `secretGenerator` in the overlay. The helm migration dropped it, causing AAP job pods to fail pulling CI registry images (`registry.buildXX.ci.openshift.org`) in the osac-aap rehearsal path.

Depends on https://github.com/openshift/release/pull/80807 (mounts `/root/pull-secret` into the installer container at the values directory)

## Test plan
- [ ] Verify osac-aap e2e-vmaas rehearsal passes consistently (no ErrImagePull on automation jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instance groups configuration support
  * Introduced conditional enabling of Bare Metal Fulfillment Operator
  * Added cluster refresh workflow for snapshot-based deployments
  * Added emergency admin access configuration for fulfillment service
  * Enhanced RBAC permissions for OSAC operator

* **Improvements**
  * Updated gRPC probe configuration for improved reliability
  * Improved base domain detection for hosted clusters

* **Documentation**
  * Updated deployment guides with revised values file paths
  * Updated setup instructions and examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->