### PR TITLE
OSAC-1624: remove eda

### DIFF
--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -217,7 +217,7 @@ aap:
       enabled: true
       # Name of the AAP instance CR. Used to derive route/service names.
       name: "osac-aap"
-      # AAP components to enable. Only controller and EDA are needed for OSAC.
+      # AAP components to enable. Only controller is needed for OSAC.
       controller:
         disabled: false
       eda:
@@ -248,8 +248,6 @@ aap:
     # Hostnames for AAP component routes. Leave empty to auto-detect
     # from the AAP instance CR status.
     gateway:
-      hostname: ""
-    eda:
       hostname: ""
     controller:
       hostname: ""

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -83,7 +83,7 @@ aap:
       controller:
         disabled: false
       eda:
-        disabled: false
+        disabled: true
       hub:
         disabled: true
       lightspeed:
@@ -98,8 +98,6 @@ aap:
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
     gateway:
-      hostname: ""
-    eda:
       hostname: ""
     controller:
       hostname: ""

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -263,7 +263,7 @@ oc wait deployment/keycloak-service -n keycloak --for=condition=Available --time
 
 ### 1.8 AAP Operator
 
-This installs the AAP operator only. The AAP instance itself (controller, EDA,
+This installs the AAP operator only. The AAP instance itself (controller,
 gateway) is created by the Helm chart.
 
 > **Note:** Depending on the AAP version, the operator may install into the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to reflect that only the AAP controller is needed for OSAC.
  * Revised example configuration to remove the EDA hostname from bootstrap settings.

* **Bug Fixes**
  * Adjusted default Helm values so EDA is disabled by default and no longer included in bootstrap hostname settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->