### PR TITLE
Fully qualify bare metal templates in example bare metal profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Use Kustomize to manage your environment-specific configurations.
          profileName: agentProvisioning
        persistentLabels:
          managedBy: agent
-       hostTemplate: bm_host_agent_provisioning
+       hostTemplate: osac.templates.bm_host_agent_provisioning
        expectedTemplateParameters:
          - agentPrivateNetwork
          - imageURL

--- a/overlays/development/files/profile.yaml.example
+++ b/overlays/development/files/profile.yaml.example
@@ -6,7 +6,7 @@
     profileName: agentProvisioning
   persistentLabels:
     managedBy: agent
-  hostTemplate: bm_host_agent_provisioning
+  hostTemplate: osac.templates.bm_host_agent_provisioning
   expectedTemplateParameters:
     - agentPrivateNetwork
     - imageURL
@@ -19,7 +19,7 @@
     profileName: agentDeprovisioning
   persistentLabels:
     managedBy: baremetal
-  hostTemplate: bm_host_agent_deprovisioning
+  hostTemplate: osac.templates.bm_host_agent_deprovisioning
 
 - name: agentCaaS
   hostSelector:
@@ -27,8 +27,8 @@
     provisionState: active
   labels:
     profileName: agentCaaS
-  bareMetalPoolTemplate: bm_private_network
-  hostTemplate: bm_host_private_network
+  bareMetalPoolTemplate: osac.templates.bm_private_network
+  hostTemplate: osac.templates.bm_host_private_network
   expectedTemplateParameters:
     - privateNetwork
     - networkAfterDelete


### PR DESCRIPTION
The bare metal AAP playbooks now expect a fully qualified bare metal template names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated template identifiers in configuration profiles to use fully qualified namespace paths for agent provisioning, deprovisioning, and network templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->