### PR TITLE
OSAC-1693: expose ConfigMap inventory backend configuration in helm chart

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -58,14 +58,7 @@ dbMigrate:
   dbUrlFile: "/etc/fulfillment-service/db/url"
 
 importAgents:
-  enabled: true
-  servers:
-    - name: test-server-001
-      bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/test-uuid"
-      bmc_secret: "test-server-001-bmc-secret"
-      boot_mac: "AA:BB:CC:DD:EE:01"
-      netris_server_name: "server-01"
-      resource_class: "fc430"
+  enabled: false
 
 clusterFulfillment:
   enabled: true

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -57,6 +57,16 @@ dbMigrate:
   image: ghcr.io/osac-project/fulfillment-service:latest
   dbUrlFile: "/etc/fulfillment-service/db/url"
 
+importAgents:
+  enabled: true
+  servers:
+    - name: test-server-001
+      bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/test-uuid"
+      bmc_secret: "test-server-001-bmc-secret"
+      boot_mac: "AA:BB:CC:DD:EE:01"
+      netris_server_name: "server-01"
+      resource_class: "fc430"
+
 clusterFulfillment:
   enabled: true
   config:
@@ -75,6 +85,10 @@ clusterFulfillment:
     HOSTED_CLUSTER_BASE_DOMAIN: "test.example.com"
     HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: "SingleReplica"
     HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: "SingleReplica"
+    IMPORT_AGENTS_NAMESPACE: "hardware-inventory"
+    IMPORT_AGENTS_INFRAENV_NAME: "infraenv"
+    IMPORT_AGENTS_PULL_SECRET_NAME: "pull-secret"
+    IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: "true"
   secret:
     NETRIS_PASSWORD: "test-password"
 

--- a/charts/osac/templates/config-as-code-ig.yaml
+++ b/charts/osac/templates/config-as-code-ig.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.aap.configAsCode.secret }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+type: Opaque
+stringData:
+  OSAC_IMPORT_AGENTS_ENABLED: {{ .Values.importAgents.enabled | toString | quote }}
+  {{- with .Values.aap.configAsCode.eeImage }}
+  AAP_EE_IMAGE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.aap.configAsCode.projectGitUri }}
+  AAP_PROJECT_GIT_URI: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.aap.configAsCode.projectGitBranch }}
+  AAP_PROJECT_GIT_BRANCH: {{ . | quote }}
+  {{- end }}

--- a/charts/osac/templates/config-as-code-ig.yaml
+++ b/charts/osac/templates/config-as-code-ig.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.importAgents.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,3 +19,4 @@ stringData:
   {{- with .Values.aap.configAsCode.projectGitBranch }}
   AAP_PROJECT_GIT_BRANCH: {{ . | quote }}
   {{- end }}
+{{- end }}

--- a/charts/osac/templates/import-agents-inventory.yaml
+++ b/charts/osac/templates/import-agents-inventory.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.importAgents.enabled .Values.importAgents.servers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: import-agents-inventory
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+data:
+  servers.yml: |
+    servers:
+    {{- .Values.importAgents.servers | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -350,6 +350,18 @@ clusterFulfillment:
     HOSTED_CLUSTER_BASE_DOMAIN: ""
     HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: ""
     HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: ""
+
+    # --- Import Agents ---
+    # Playbook variables for ConfigMap-based agent import.
+    # These override the playbook defaults when non-empty.
+    # Effective default: "hardware-inventory"
+    IMPORT_AGENTS_NAMESPACE: ""
+    # Effective default: "infraenv"
+    IMPORT_AGENTS_INFRAENV_NAME: ""
+    # Effective default: "pull-secret"
+    IMPORT_AGENTS_PULL_SECRET_NAME: ""
+    # Effective default: "true"
+    IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: ""
   secret:
     NETRIS_PASSWORD: ""
     # AWS credentials (used by the Route 53 DNS backend).
@@ -357,6 +369,35 @@ clusterFulfillment:
     AWS_SECRET_ACCESS_KEY: ""
     SERVER_SSH_KEY: ""
     SERVER_SSH_BASTION_KEY: ""
+
+# ---------------------
+# Import Agents (ConfigMap inventory backend)
+# ---------------------
+# Enables the ConfigMap-based bare metal agent import feature.
+# When enabled:
+#   - Sets OSAC_IMPORT_AGENTS_ENABLED=true in the config-as-code-ig Secret
+#   - Creates the import-agents-inventory ConfigMap from the servers list
+# See osac-aap/docs/import-agents.md for the server inventory format.
+importAgents:
+  enabled: false
+  # Server inventory for bare metal agent import.
+  # Each entry provisions a BareMetalHost CR via the import-agents playbook.
+  servers: []
+  # Example:
+  # servers:
+  #   - name: node001
+  #     bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
+  #     bmc_secret: "node001-bmc-secret"
+  #     boot_mac: "AA:BB:CC:DD:EE:01"
+  #     netris_server_name: "server-01"
+  #     resource_class: "fc430"
+  #   - name: node002
+  #     bmc_url: "redfish-virtualmedia+https://192.168.1.22:8000/redfish/v1/Systems/<uuid>"
+  #     bmc_secret: "node002-bmc-secret"
+  #     boot_mac: "AA:BB:CC:DD:EE:02"
+  #     netris_server_name: "server-02"
+  #     resource_class: "fc430"
+  #     disable_bmc_cert_verification: false
 
 # ---------------------
 # Network Fulfillment Instance Group

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -850,6 +850,22 @@
               "type": "string",
               "description": "Availability policy for hosted cluster infrastructure",
               "enum": ["", "HighlyAvailable", "SingleReplica"]
+            },
+            "IMPORT_AGENTS_NAMESPACE": {
+              "type": "string",
+              "description": "Namespace for BareMetalHost, Agent, and InfraEnv CRs (effective default: hardware-inventory)"
+            },
+            "IMPORT_AGENTS_INFRAENV_NAME": {
+              "type": "string",
+              "description": "InfraEnv CR name for agent discovery (effective default: infraenv)"
+            },
+            "IMPORT_AGENTS_PULL_SECRET_NAME": {
+              "type": "string",
+              "description": "Pull secret name for InfraEnv discovery ISO (effective default: pull-secret)"
+            },
+            "IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION": {
+              "type": "string",
+              "description": "Default BMC TLS certificate verification skip (effective default: true)"
             }
           }
         },
@@ -876,6 +892,55 @@
             "SERVER_SSH_BASTION_KEY": {
               "type": "string",
               "description": "SSH private key for bastion access"
+            }
+          }
+        }
+      }
+    },
+    "importAgents": {
+      "type": "object",
+      "description": "ConfigMap-based bare metal agent import configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ConfigMap-based bare metal agent import (sets OSAC_IMPORT_AGENTS_ENABLED in config-as-code-ig Secret)",
+          "default": false
+        },
+        "servers": {
+          "type": "array",
+          "description": "Server inventory for bare metal agent import. Each entry provisions a BareMetalHost CR.",
+          "items": {
+            "type": "object",
+            "required": ["name", "bmc_url", "bmc_secret", "boot_mac", "netris_server_name", "resource_class"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Server hostname, used as the BareMetalHost CR name"
+              },
+              "bmc_url": {
+                "type": "string",
+                "description": "Redfish BMC address for virtual media boot"
+              },
+              "bmc_secret": {
+                "type": "string",
+                "description": "Name of the Kubernetes Secret with BMC credentials"
+              },
+              "boot_mac": {
+                "type": "string",
+                "description": "Boot NIC MAC address"
+              },
+              "netris_server_name": {
+                "type": "string",
+                "description": "Netris server name label for the Agent"
+              },
+              "resource_class": {
+                "type": "string",
+                "description": "Hardware type label for the Agent"
+              },
+              "disable_bmc_cert_verification": {
+                "type": "boolean",
+                "description": "Per-server override for BMC TLS certificate verification"
+              }
             }
           }
         }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -222,9 +222,6 @@ clusterFulfillment:
     SERVER_SSH_KEY: ""
     SERVER_SSH_BASTION_KEY: ""
 
-# --- Network Fulfillment Instance Group ---
-# ConfigMap and Secret for the AAP networking-operations instance group.
-# Carries Netris controller credentials for network resource lifecycle.
 # --- Import Agents (ConfigMap inventory backend) ---
 # Enables the ConfigMap-based bare metal agent import feature.
 # When enabled, creates the import-agents-inventory ConfigMap and sets
@@ -233,6 +230,9 @@ importAgents:
   enabled: false
   servers: []
 
+# --- Network Fulfillment Instance Group ---
+# ConfigMap and Secret for the AAP networking-operations instance group.
+# Carries Netris controller credentials for network resource lifecycle.
 networkFulfillment:
   enabled: false
   config:

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -211,6 +211,10 @@ clusterFulfillment:
     HOSTED_CLUSTER_BASE_DOMAIN: ""
     HOSTED_CLUSTER_CONTROLLER_AVAILABILITY_POLICY: ""
     HOSTED_CLUSTER_INFRASTRUCTURE_AVAILABILITY_POLICY: ""
+    IMPORT_AGENTS_NAMESPACE: ""
+    IMPORT_AGENTS_INFRAENV_NAME: ""
+    IMPORT_AGENTS_PULL_SECRET_NAME: ""
+    IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: ""
   secret:
     NETRIS_PASSWORD: ""
     AWS_ACCESS_KEY_ID: ""
@@ -221,6 +225,14 @@ clusterFulfillment:
 # --- Network Fulfillment Instance Group ---
 # ConfigMap and Secret for the AAP networking-operations instance group.
 # Carries Netris controller credentials for network resource lifecycle.
+# --- Import Agents (ConfigMap inventory backend) ---
+# Enables the ConfigMap-based bare metal agent import feature.
+# When enabled, creates the import-agents-inventory ConfigMap and sets
+# OSAC_IMPORT_AGENTS_ENABLED=true in the config-as-code-ig Secret.
+importAgents:
+  enabled: false
+  servers: []
+
 networkFulfillment:
   enabled: false
   config:


### PR DESCRIPTION
## [OSAC-1693](https://redhat.atlassian.net/browse/OSAC-1693): Expose ConfigMap inventory backend configuration in helm chart

**Jira:** https://redhat.atlassian.net/browse/OSAC-1693
**Story type:** Task

### Summary

Exposes the ConfigMap-based bare metal agent import configuration through the installer helm chart so the Enclave UI can present configuration options to admins. Adds a new `importAgents` values section controlling the enable flag and server inventory, `IMPORT_AGENTS_*` playbook variables in the cluster-fulfillment-ig ConfigMap, and a helm-managed `config-as-code-ig` Secret with the `OSAC_IMPORT_AGENTS_ENABLED` feature flag.

### Changes

- **values.yaml / values-example.yaml:**
  - New `importAgents` section (`enabled: false`, `servers: []`)
  - `IMPORT_AGENTS_NAMESPACE`, `IMPORT_AGENTS_INFRAENV_NAME`, `IMPORT_AGENTS_PULL_SECRET_NAME`, `IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION` added to `clusterFulfillment.config`

- **New template: `config-as-code-ig.yaml`**
  - Renders the `config-as-code-ig` Secret with `OSAC_IMPORT_AGENTS_ENABLED` derived from `importAgents.enabled`
  - Conditionally includes `AAP_EE_IMAGE`, `AAP_PROJECT_GIT_URI`, `AAP_PROJECT_GIT_BRANCH` when set

- **New template: `import-agents-inventory.yaml`**
  - Creates `import-agents-inventory` ConfigMap with `servers.yml` when `importAgents.enabled` and `servers` is non-empty

- **values.schema.json:**
  - `importAgents` object schema (enabled boolean, servers array with per-server property definitions)
  - `IMPORT_AGENTS_*` property schemas under `clusterFulfillment.config`

- **CI values (`ci/full-values.yaml`):**
  - Exercises all new template branches with sample data

### Testing

- **Unit tests:** N/A (helm chart — no Go/Python code)
- **Integration tests:** N/A
- **Coverage:** All behavioral paths verified via `helm template` with CI and environment values files:
  - Feature disabled (default): no ConfigMap, Secret has `OSAC_IMPORT_AGENTS_ENABLED: "false"`
  - Feature enabled with servers: ConfigMap + Secret rendered correctly
  - Feature enabled without servers: no ConfigMap (guard on non-empty list)
  - All 4 CI values files and 3 environment values files render successfully

### Acceptance Criteria

- [x] `helm template` produces correct ConfigMap and Secret resources when configmap inventory is enabled
- [x] Schema validates correctly (`helm lint` passes)
- [x] Default values disable the feature (opt-in)
- [x] Existing CI values files continue to pass

### Notes

- The `IMPORT_AGENTS_*` env vars are not yet read by the import-agents playbook (it uses `group_vars` defaults). A follow-up osac-aap PR will wire up the `lookup('env', ...)` calls.
- The `config-as-code-ig` Secret is now helm-managed. Deployments previously creating this Secret via `setup.sh` should migrate the values to helm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Import Agents” capability for bare-metal environments, including an enable/disable toggle and configurable server inventory inputs.
  * When enabled, the chart now generates the required config for the import workflow and supports customizing target namespace, infraenv name, pull secret, and BMC certificate verification behavior.

* **Documentation**
  * Updated the values example to include Import Agents settings and server examples.
  * Extended the values schema to validate the new Import Agents configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->