### PR TITLE
OSAC-1675: Label pre-created secrets for Helm adoption

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -361,6 +361,26 @@ EOF
         -n "${INSTALLER_NAMESPACE}" \
         --dry-run=client -o yaml | oc apply -f -
 
+    # Label pre-created resources for Helm adoption.
+    # setup.sh creates secrets/configmaps before helm install, but the chart
+    # also declares them. Without Helm ownership labels, helm install fails
+    # with "invalid ownership metadata".
+    echo "Labeling pre-created resources for Helm adoption..."
+    for resource in \
+        secret/config-as-code-ig \
+        secret/config-as-code-manifest-ig \
+        secret/fulfillment-controller-credentials \
+        secret/fulfillment-db \
+        configmap/ca-bundle; do
+      if oc get "${resource}" -n "${INSTALLER_NAMESPACE}" &>/dev/null; then
+        oc label "${resource}" -n "${INSTALLER_NAMESPACE}" \
+            app.kubernetes.io/managed-by=Helm --overwrite
+        oc annotate "${resource}" -n "${INSTALLER_NAMESPACE}" \
+            meta.helm.sh/release-name=osac \
+            meta.helm.sh/release-namespace="${INSTALLER_NAMESPACE}" --overwrite
+      fi
+    done
+
     echo "Deploying OSAC using Helm..."
     CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}')
     EXTERNAL_HOSTNAME="fulfillment-api-${INSTALLER_NAMESPACE}.${CLUSTER_DOMAIN}"


### PR DESCRIPTION
## Summary

- Add Helm ownership labels/annotations to secrets and configmaps created by `setup.sh` before `helm install`
- Without these, `helm install` fails with `invalid ownership metadata` because the chart declares the same resources

## Root cause

`setup.sh` creates these resources before calling `helm install`:
- `secret/config-as-code-ig`
- `secret/config-as-code-manifest-ig`
- `secret/fulfillment-controller-credentials`
- `secret/fulfillment-db`
- `configmap/ca-bundle`

The Helm chart also declares them. When `helm install` finds existing resources without Helm ownership labels (`app.kubernetes.io/managed-by=Helm`, `meta.helm.sh/release-name`, `meta.helm.sh/release-namespace`), it refuses to adopt them.

## Fix

Add a labeling loop right before `helm install` that marks all pre-created resources with the required Helm ownership metadata.

## Test plan

- [ ] Run `setup.sh` on a fresh cluster — confirm `helm install` succeeds without ownership errors
- [ ] Run `setup.sh` twice (idempotent) — confirm second run also succeeds