### PR TITLE
NO-ISSUE: Remove Authorino from installer scripts

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -2,7 +2,7 @@
 """Refresh a Helm-deployed OSAC cluster after booting from a cold snapshot.
 
 All OSAC pods are at zero replicas. This script:
-  1. Starts slow operators (AAP, Authorino) early + fixes cluster identity
+  1. Starts slow operators (AAP) early + fixes cluster identity
   2. Prepares the environment (Keycloak, secrets, CA bundle, DB)
   3. Deploys via helm upgrade + waits with health monitoring
   4. Runs post-flight configuration (AAP token, hub, tenants)
@@ -506,28 +506,6 @@ def find_csv(*, namespace: str, deploy_name: str) -> str:
     raise RuntimeError(f"CSV not found for deployment {deploy_name} in {namespace}")
 
 
-def scale_authorino_operator() -> None:
-    print("  Scaling Authorino operator to 1...")
-    csv = find_csv(namespace="openshift-operators", deploy_name="authorino-operator")
-    scale_csv_to(csv_name=csv, namespace="openshift-operators", replicas=1)
-    print(f"  Authorino operator scaled via CSV {csv}")
-
-
-def wait_authorino(config: RefreshConfig) -> None:
-    print("  Waiting for Authorino...")
-    retry_until(
-        description="Authorino deployment replicas > 0",
-        timeout=120, interval=5,
-        condition=lambda: int(
-            oc("get", "deploy", "authorino", "-n", config.namespace,
-               "-o", "jsonpath={.spec.replicas}", capture=True, check=False
-               ).stdout.strip() or "0"
-        ) > 0,
-    )
-    wait_rollout_healthy("authorino", config.namespace, timeout=120)
-    print("  Authorino running")
-
-
 def upgrade_fulfillment_db(config: RefreshConfig) -> None:
     print("  Upgrading fulfillment-db...")
     run(["helm", "upgrade", "--install", "fulfillment-db",
@@ -728,7 +706,6 @@ def main() -> None:
     print("[Phase 1] Starting operators + fixing cluster identity...")
     run_parallel([
         ("scale AAP operator", lambda: scale_aap_operator(config)),
-        ("scale Authorino operator", scale_authorino_operator),
         ("patch routes", lambda: patch_stale_routes(config)),
         ("pre-fix cert SANs", lambda: pre_fix_cert_sans(config)),
         ("refresh CDI certs", refresh_cdi_certificates),
@@ -754,7 +731,6 @@ def main() -> None:
     print("[Phase 3] Deploying + waiting...")
     upgrade_osac(config)
     run_parallel([
-        ("wait Authorino", lambda: wait_authorino(config)),
         ("wait fulfillment", lambda: wait_fulfillment(config)),
         ("wait AAP", lambda: wait_aap_ready(config)),
     ])

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -198,20 +198,6 @@ retry_until 60 5 'oc apply -f prerequisites/ca-issuer.yaml 2>/dev/null' || {
 }
 wait_for_resource clusterissuer/default-ca condition=Ready 300
 
-# Apply authorino prerequisites and wait for it to be ready
-if oc get deployment authorino-operator -n openshift-operators &>/dev/null; then
-    echo "Authorino operator is already installed, skipping..."
-else
-    oc apply -f prerequisites/authorino-operator.yaml
-    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n openshift-operators | grep authorino)" ]]' 'oc apply -f prerequisites/authorino-operator.yaml || true' || {
-        echo "Timed out waiting for authorino CSV to exist"
-        exit 1
-    }
-fi
-AUTHORINO_CSV=$(oc get csv --no-headers -n openshift-operators | awk '/authorino/ { print $1 }' | tail -1)
-wait_for_resource clusterserviceversion/${AUTHORINO_CSV} jsonpath='{.status.phase}'=Succeeded 300 openshift-operators
-wait_for_resource deployment/authorino-operator condition=Available 300 openshift-operators
-
 # Apply keycloak prerequisites and wait for it to be ready
 KEYCLOAK_NS=""
 if oc get deployment keycloak-service -n keycloak &>/dev/null; then
@@ -439,19 +425,6 @@ if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
     wait_for_resource job/aap-bootstrap condition=complete 2400 "${INSTALLER_NAMESPACE}"
 else
     wait_for_resource job/osac-aap-bootstrap condition=complete 2400 "${INSTALLER_NAMESPACE}"
-fi
-
-# Wait for Authorino to be ready (gRPC auth depends on it)
-wait_for_resource deployment/authorino condition=Available 300 ${INSTALLER_NAMESPACE}
-
-# Ensure Authorino can perform token reviews (required for Kubernetes SA authentication)
-if oc get clusterrolebinding authorino-tokenreview &>/dev/null; then
-    if ! oc get clusterrolebinding authorino-tokenreview -o json | \
-        jq -e '.subjects[] | select(.name=="authorino-authorino" and .namespace=="'"${INSTALLER_NAMESPACE}"'")' &>/dev/null; then
-        echo "Adding ${INSTALLER_NAMESPACE} Authorino SA to authorino-tokenreview ClusterRoleBinding..."
-        oc patch clusterrolebinding authorino-tokenreview --type=json \
-            -p '[{"op":"add","path":"/subjects/-","value":{"kind":"ServiceAccount","name":"authorino-authorino","namespace":"'"${INSTALLER_NAMESPACE}"'"}}]'
-    fi
 fi
 
 # Wait for fulfillment stack to be ready before running prepare scripts

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -190,11 +190,6 @@ if [[ "${INGRESS_SERVICE}" == "true" ]]; then
     delete_manifests < prerequisites/metallb/metallb-config.yaml
 fi
 
-echo "Deleting Authorino CRs..."
-if resource_type_exists authorino; then
-    timeout 30 oc delete authorino --all -A --ignore-not-found --wait=false
-fi
-
 echo "Deleting CA issuer and trust-manager..."
 delete_manifests < prerequisites/ca-issuer.yaml
 delete_manifests < prerequisites/trust-manager.yaml
@@ -244,13 +239,6 @@ fi
 if [[ "${INGRESS_SERVICE}" == "true" ]]; then
     echo "  MetalLB operator..."
     uninstall_operator metallb-system metallb-operator
-fi
-
-echo "  Authorino operator..."
-csv=$(timeout 10 oc get csv --no-headers -n openshift-operators 2>/dev/null | awk '/authorino/ {print $1}')
-timeout 30 oc delete subscription authorino-operator -n openshift-operators --ignore-not-found
-if [[ -n "${csv}" ]]; then
-    timeout 120 oc delete csv "${csv}" -n openshift-operators --ignore-not-found
 fi
 
 echo "  cert-manager operator..."


### PR DESCRIPTION
## Summary

The fulfillment-service subchart no longer deploys Authorino resources (Authorino CR, AuthConfig, certificate) — it uses built-in JWT authentication instead. This causes boot failures in CI because:

1. `helm upgrade` deletes the Helm-managed Authorino CR (no longer in the chart)
2. The Authorino operator tears down the `authorino` deployment
3. The refresh script times out waiting for a deployment that will never return

This PR removes all Authorino references from the installer scripts:

- **refresh-after-snapshot.py**: Remove `scale_authorino_operator()` from Phase 1 and `wait_authorino()` from Phase 3
- **setup.sh**: Remove Authorino operator installation, deployment wait, and tokenreview RBAC setup
- **teardown.sh**: Remove Authorino CR deletion and operator uninstall

Defensive webhook/CRD grep patterns in teardown.sh still include `authorino` for backward-compatible cleanup of existing clusters.

## Test plan

- [ ] Merge this PR first, then retest PR #310 (submodule bump) — it should pass boot without the Authorino timeout
- [ ] Verify full-install (`setup.sh`) still works without Authorino prerequisites
- [ ] Verify teardown still cleans up clusters that had Authorino installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified setup and teardown workflows by removing Authorino prerequisite installation and cleanup steps.
* Updated snapshot refresh orchestration to exclude Authorino-related tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->