### PR TITLE
OSAC-1675: Fix Helm adoption labels and console-proxy namespace

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -402,16 +402,18 @@ INSTALLER_NAMESPACE="${INSTALLER_NAMESPACE}" \
 INSTALLER_KUSTOMIZE_OVERLAY="${INSTALLER_KUSTOMIZE_OVERLAY}" \
     ./scripts/aap-configuration.sh
 
-# Detect console-proxy namespace (shared-dev pins it to "osac")
-if grep -q 'console-proxy-shared-dev' \
+# Detect console-proxy namespace and deployment name.
+# In kustomize mode, the shared-dev overlay pins the console-proxy to "osac".
+# In helm mode, everything deploys into INSTALLER_NAMESPACE.
+if [[ "${DEPLOY_MODE}" == "helm" ]]; then
+  CONSOLE_PROXY_NS="${INSTALLER_NAMESPACE}"
+  CONSOLE_PROXY_DEPLOY="fulfillment-console-proxy"
+elif grep -q 'console-proxy-shared-dev' \
     "overlays/${INSTALLER_KUSTOMIZE_OVERLAY}/kustomization.yaml" 2>/dev/null; then
   CONSOLE_PROXY_NS="osac"
+  CONSOLE_PROXY_DEPLOY="osac-console-proxy"
 else
   CONSOLE_PROXY_NS="${INSTALLER_NAMESPACE}"
-fi
-if [[ "${DEPLOY_MODE}" == "helm" ]]; then
-  CONSOLE_PROXY_DEPLOY="fulfillment-console-proxy"
-else
   CONSOLE_PROXY_DEPLOY="osac-console-proxy"
 fi
 wait_for_resource deployment/${CONSOLE_PROXY_DEPLOY} condition=Available 300 "${CONSOLE_PROXY_NS}"


### PR DESCRIPTION
## Summary

Two fixes for `setup.sh` in Helm deployment mode:

1. **Label pre-created secrets for Helm adoption** — `setup.sh` creates secrets (`config-as-code-ig`, `config-as-code-manifest-ig`, `fulfillment-controller-credentials`, `fulfillment-db`) and the `ca-bundle` configmap before `helm install`. The chart also declares these resources, causing `helm install` to fail with `invalid ownership metadata`. Fix: add Helm ownership labels/annotations right before `helm install`.

2. **Fix console-proxy namespace detection** — In Helm mode, the console-proxy deploys into `INSTALLER_NAMESPACE`, but the kustomize shared-dev overlay check was incorrectly applying to all modes, hardcoding the namespace to `osac`. This caused `Timed out waiting for namespace osac to exist` when using a different namespace (e.g. `osac-e2e-ci`). Fix: check deploy mode first; Helm always uses `INSTALLER_NAMESPACE`.

## Verification

Ran the patched `setup.sh` directly on the CI server against a freshly booted `sno64withdisk` clone with `INSTALLER_NAMESPACE=osac-e2e-ci`:
- Helm labeling: all secrets labeled, `helm install` succeeded
- Console-proxy: `fulfillment-console-proxy` found in `osac-e2e-ci` (not `osac`)
- AAP bootstrap: completed successfully
- All post-deploy resource waits passed

## Test plan

- [ ] Run `setup.sh` with `DEPLOY_MODE=helm` on a fresh cluster — confirm no Helm ownership errors
- [ ] Run with `INSTALLER_NAMESPACE` != `osac` — confirm console-proxy wait uses correct namespace
- [ ] Run with `DEPLOY_MODE=kustomize` + shared-dev overlay — confirm kustomize behavior preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced setup script to properly apply Helm ownership metadata to managed Kubernetes resources in Helm deployment mode.
  * Improved deployment location detection logic to correctly identify console-proxy deployment based on the selected deployment method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->