### PR TITLE
OSAC-24: add tenant RBAC to hub-access role

### DIFF
--- a/base/hub-access/README.md
+++ b/base/hub-access/README.md
@@ -2,7 +2,7 @@ The fulfillment service interacts with the target hub using the credentials you 
 
 This directory creates a `hub-access` service account with permissions to manage OSAC resources in the target namespace:
 
-- ClusterOrders, ComputeInstances, VirtualNetworks, Subnets, SecurityGroups (full CRUD + status read)
+- ClusterOrders, ComputeInstances, Tenants, VirtualNetworks, Subnets, SecurityGroups (full CRUD + status read)
 - Console access (`console.osac.openshift.io/computeinstances/console`)
 - Secrets (create only, for cloud-init user-data)
 

--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -178,6 +178,24 @@ rules:
       - baremetalinstances/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - tenants
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - tenants/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/osac/templates/hub-access.yaml
+++ b/charts/osac/templates/hub-access.yaml
@@ -201,6 +201,24 @@ rules:
       - baremetalinstances/status
     verbs:
       - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - tenants
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - tenants/status
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

- Adds RBAC permissions for Tenant CRDs to the hub-access Role (both kustomize base and Helm chart)
- Required by the new tenant controller in fulfillment-service ([PR](https://github.com/danielerez/fulfillment-service/pull/1))

## Changes

- `base/hub-access/rbac.yaml` — add tenants and tenants/status rules
- `charts/osac/templates/hub-access.yaml` — same for Helm deployment path

Assisted-by: Claude Code <noreply@anthropic.com>