### PR TITLE
NO-ISSUE: Add emergency service accounts to Helm values

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -35,6 +35,11 @@ service:
       configMap: ca-bundle
   auth:
     issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    emergencyServiceAccounts:
+    - admin
+    - osac-operator
+    - osac-operator-controller-manager
+    - template-publisher
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials

--- a/values/development/values.yaml
+++ b/values/development/values.yaml
@@ -39,6 +39,11 @@ service:
       configMap: ca-bundle
   auth:
     issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    emergencyServiceAccounts:
+    - admin
+    - osac-operator
+    - osac-operator-controller-manager
+    - template-publisher
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -36,6 +36,11 @@ service:
       configMap: ca-bundle
   auth:
     issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    emergencyServiceAccounts:
+    - admin
+    - osac-operator
+    - osac-operator-controller-manager
+    - template-publisher
     controllerCredentials:
     - secret:
         name: fulfillment-controller-credentials


### PR DESCRIPTION
## Summary

Add `template-publisher`, `osac-operator`, and `osac-operator-controller-manager` to `auth.emergencyServiceAccounts` in all values files. The fulfillment-service subchart defaults to `[admin]` only, which blocks `publish-templates` during boot.

## Test plan

- [ ] e2e-vmaas boot completes without publish-templates 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Configured emergency service accounts across multiple environments to enable critical system access for administration, operations, and publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->