### PR TITLE
OSAC-1682: Add GitHub Actions e2e job

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,35 @@
+---
+name: E2E Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'charts/**'
+      - 'values/**'
+      - 'scripts/**'
+      - 'base/**'
+      - 'prerequisites/**'
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (vmaas, caas, or empty for all)"
+        required: false
+        default: "vmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      deploy-mode:
+        description: "Deploy mode: snapshot or full-install"
+        required: false
+        default: "snapshot"
+
+jobs:
+  e2e:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e.yml@main
+    with:
+      test-suite: ${{ github.event.inputs.test-suite || 'vmaas' }}
+      test-filter: ${{ github.event.inputs.test-filter || '' }}
+      deploy-mode: ${{ github.event.inputs.deploy-mode || 'snapshot' }}
+      installer-ref: ${{ github.head_ref || 'main' }}


### PR DESCRIPTION
## Summary
- Add `e2e-test.yml` caller workflow for PR-triggered E2E testing via GitHub Actions
- Passes `installer-ref` pointing to the PR branch so the e2e workflow clones the PR's installer code
- Path-filtered: only triggers on changes to `charts/`, `values/`, `scripts/`, `base/`, `prerequisites/`
- Supports `workflow_dispatch` for manual execution with configurable test-suite, filter, and deploy-mode

**Depends on:** osac-project/osac-test-infra PR ([OSAC-1678](https://redhat.atlassian.net/browse/OSAC-1678)) for the `installer-ref` input on `e2e.yml`

## Jira
- [OSAC-1682](https://redhat.atlassian.net/browse/OSAC-1682)

## Test plan
- [ ] Verify workflow triggers on PR to main (only for relevant paths)
- [ ] Verify e2e workflow is invoked with correct installer-ref
- [ ] Verify manual dispatch works