### PR TITLE
OSAC-1744: Remove stale sync-authconfig-rego step from bump workflow

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -86,10 +86,6 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         run: ./scripts/sync-image-tags.sh --fix
 
-      - name: Sync AuthConfig Rego
-        if: steps.update.outputs.changed == 'true'
-        run: pip install pyyaml && python3 scripts/sync-authconfig-rego.py --fix
-
       - name: Create or update PR
         if: steps.update.outputs.changed == 'true'
         env:


### PR DESCRIPTION
## Summary

- Remove the "Sync AuthConfig Rego" step from `.github/workflows/bump-submodules.yaml`

PR #323 deleted `scripts/sync-authconfig-rego.py` (as part of Authorino removal) but missed updating the bump workflow, which still references the script. This causes every bump run to fail with `No such file or directory`.

**Failing run:** https://github.com/osac-project/osac-installer/actions/runs/28095031660/job/83182304533

## Test plan

- [ ] Re-run the bump-submodules workflow after merge and verify it passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the submodule update workflow to sync image tags after submodule changes.
  * Removed the previous post-update sync step tied to AuthConfig-related processing.
  * PR creation/update behavior still runs only when submodules actually change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->