### PR TITLE
OSAC-1675: Set AAP token on operator deployments

### DIFF
--- a/scripts/prepare-aap.sh
+++ b/scripts/prepare-aap.sh
@@ -38,14 +38,16 @@ oc create secret generic osac-aap-api-token \
     -n "${INSTALLER_NAMESPACE}" \
     --dry-run=client -o yaml | oc apply -f -
 
-# Set the AAP URL on operator deployments (triggers rollout).
+# Set the AAP URL and token on operator deployments (triggers rollout).
 for pattern in osac-operator bmf-operator; do
     deploy=$(oc get deploy -n "${INSTALLER_NAMESPACE}" -o name | grep -m1 "${pattern}" || true)
     if [[ -z "${deploy}" ]]; then
         echo "  ${pattern}: not found, skipping"
         continue
     fi
-    oc set env "${deploy}" -n "${INSTALLER_NAMESPACE}" OSAC_AAP_URL="${AAP_URL}/api/controller"
+    oc set env "${deploy}" -n "${INSTALLER_NAMESPACE}" \
+        OSAC_AAP_URL="${AAP_URL}/api/controller" \
+        OSAC_AAP_TOKEN="${AAP_TOKEN}"
 done
 
 echo "AAP API token created and stored in secret osac-aap-api-token"


### PR DESCRIPTION
## Summary

- Fix `prepare-aap.sh` to also set `OSAC_AAP_TOKEN` (not just `OSAC_AAP_URL`) on operator deployments via `oc set env`
- Without the token, the operator cannot authenticate with AAP to launch provisioning jobs, causing VirtualNetwork and PublicIPPool resources to remain stuck at "Progressing" indefinitely
- In kustomize mode, the token was injected via a `valueFrom.secretKeyRef` patch in `kustomization.yaml`, but in Helm mode `prepare-aap.sh` is the only mechanism that injects these env vars post-install

## Test plan

- [x] Deployed fresh full-install (sno64withdisk + Helm mode) on CI server
- [x] Verified operator has both `OSAC_AAP_URL` and `OSAC_AAP_TOKEN` set after running `prepare-aap.sh`
- [x] `test_virtual_network_lifecycle` — PASSED
- [x] `test_subnet_lifecycle` — PASSED
- [x] `test_security_group_lifecycle` — PASSED
- [ ] Trigger full CI run via `e2e-full-install-test.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deployment preparation step so both required environment settings are applied, helping operator updates roll out correctly.
  * Added a clearer note to make the deployment behavior easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->