### PR TITLE
OSAC-1157: Remove it/charts postgres references from installer

### DIFF
--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -178,7 +178,7 @@ service:
         name: fulfillment-db
         items:
         - key: url
-          # Format: postgresql://user:pass@host:5432/dbname?sslmode=verify-full
+          # Format: postgresql://<user>:<password>@<host>:5432/<dbname>?sslmode=verify-full
           param: url
     - secret:
         name: postgres-client-cert-service
@@ -290,11 +290,10 @@ aap:
 # ---------------------
 bundledPostgres:
   # When true, auto-creates fulfillment-db secret and postgres-client-cert-service
-  # Certificate. Requires the bundled postgres chart to be deployed separately:
-  #   helm install fulfillment-db base/osac-fulfillment-service/it/charts/postgres/ \
-  #     -n ${NAMESPACE} --set certs.issuerRef.name=default-ca \
-  #     --set certs.caBundle.configMap=ca-bundle \
-  #     --set 'databases[0].name=service' --set 'databases[0].user=service'
+  # Certificate. Deploy in-cluster PostgreSQL via an operator per
+  # base/osac-fulfillment-service/docs/INSTALL.md first. With bundledPostgres
+  # enabled, the chart assumes a postgres Service at postgres:5432 in the
+  # install namespace.
   enabled: false
   database:
     name: service

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -125,8 +125,10 @@ instanceGroups:
 
 # --- Bundled PostgreSQL ---
 # When enabled, auto-creates the fulfillment-db secret and client certificate.
-# Use this for dev/test with the bundled postgres chart
-# (helm install fulfillment-db base/osac-fulfillment-service/it/charts/postgres/).
+# Deploy in-cluster PostgreSQL via an operator per
+# base/osac-fulfillment-service/docs/INSTALL.md before enabling. With
+# bundledPostgres, the chart assumes a postgres Service at postgres:5432 in
+# the install namespace (dev convenience; still in-cluster).
 # For production, leave disabled and create secrets manually per the deployment guide.
 bundledPostgres:
   enabled: false

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -300,9 +300,13 @@ oc wait deployment/automation-controller-operator-controller-manager -n ${AAP_NS
 
 ### 1.9 PostgreSQL (Fulfillment Database)
 
-The fulfillment-service requires an in-cluster PostgreSQL database deployed via
-an operator (CloudNativePG, Crunchy PGO, or Zalando). Off-cluster databases
-(RDS, external hosts) are not supported by `setup.sh` prerequisite checks.
+The fulfillment-service connects to PostgreSQL via the URL in the
+`fulfillment-db` secret — any hostname routable from the pod network can work.
+This guide documents the **osac-installer supported path**: in-cluster
+PostgreSQL deployed via an operator (CloudNativePG, Crunchy PGO, or Zalando).
+`setup.sh` validates that the hostname in `fulfillment-db` resolves to a
+Kubernetes Service with ready endpoints; off-cluster databases (RDS, external
+hosts) are not validated by the installer prerequisite check.
 
 Deploy PostgreSQL **before Phase 2** using one of the operator paths documented
 in [`base/osac-fulfillment-service/docs/INSTALL.md`](../base/osac-fulfillment-service/docs/INSTALL.md).
@@ -371,9 +375,10 @@ oc get configmap ca-bundle -n ${NAMESPACE}
 
 ### 2.2 PostgreSQL Database
 
-The fulfillment-service requires a PostgreSQL database running **in the
-cluster**. Connection details are provided via a `fulfillment-db` secret and a
-`postgres-client-cert-service` secret for mutual TLS client authentication.
+For **osac-installer** deployments, use an in-cluster operator-managed
+PostgreSQL cluster (see Phase 1.9). Connection details are provided via a
+`fulfillment-db` secret and a `postgres-client-cert-service` secret for mutual
+TLS client authentication.
 
 > **Shortcut:** If `bundledPostgres.enabled: true` is set in your values file,
 > the chart auto-creates the `fulfillment-db` secret and
@@ -381,7 +386,7 @@ cluster**. Connection details are provided via a `fulfillment-db` secret and a
 > PostgreSQL Service named `postgres` on port 5432 in the install namespace
 > before Helm install — see [Phase 1.9](#19-postgresql-fulfillment-database).
 
-**Deploy PostgreSQL via an in-cluster operator** (production path):
+**Deploy PostgreSQL via an in-cluster operator** (installer-supported path):
 
 1. Follow [`base/osac-fulfillment-service/docs/INSTALL.md`](../base/osac-fulfillment-service/docs/INSTALL.md)
    to install CloudNativePG, Crunchy PGO, or Zalando and create a PostgreSQL
@@ -436,10 +441,10 @@ oc wait certificate/postgres-client-service -n ${NAMESPACE} \
 > the `postgres-client-cert-service` secret into the projected volume at
 > `/etc/fulfillment-grpc-server/db/`. This provides the `sslcert`, `sslkey`,
 > and `sslrootcert` files referenced in the connection URL above.
-> **Supported deployments:** Only in-cluster operator-managed PostgreSQL per
-> INSTALL.md is supported for production. `setup.sh` validates that the resolved
-> Kubernetes Service has ready endpoints; unrecognized or off-cluster hostnames
-> fail with a pointer to INSTALL.md.
+> **Supported deployments:** The installer-supported production path is
+> in-cluster operator-managed PostgreSQL per INSTALL.md. `setup.sh` validates
+> that the resolved Kubernetes Service has ready endpoints; unrecognized or
+> off-cluster hostnames fail with a pointer to INSTALL.md.
 
 ### 2.3 Fulfillment Controller Credentials
 
@@ -913,10 +918,10 @@ VALUES_FILE=values/caas-ci/values.yaml \
 The script handles prerequisite installation, secret creation, Helm deploy,
 and all post-install steps. Set `DEPLOY_MODE=helm` (default) to use Helm.
 
-PostgreSQL must be deployed in-cluster via an operator **before** running
-`setup.sh` (see [Phase 1.9](#19-postgresql-fulfillment-database)). The script
-validates that the database Service has ready endpoints; it does not deploy
-PostgreSQL.
+For **osac-installer**, deploy in-cluster PostgreSQL via an operator **before**
+running `setup.sh` (see [Phase 1.9](#19-postgresql-fulfillment-database)). The
+script validates that the database Service has ready endpoints; it does not
+deploy PostgreSQL.
 
 **Shared cluster deployments:** If multiple developers share the same cluster
 and you need to impersonate a different user, set `OC_IMPERSONATE`:

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -15,6 +15,7 @@ using the Helm umbrella chart. Covers VMaaS and CaaS profiles.
   - [1.6 CA Issuer](#16-ca-issuer)
   - [1.7 Keycloak](#17-keycloak)
   - [1.8 AAP Operator](#18-aap-operator)
+  - [1.9 PostgreSQL (Fulfillment Database)](#19-postgresql-fulfillment-database)
 - [Phase 2: Prepare Secrets and Configuration](#phase-2-prepare-secrets-and-configuration)
   - [2.1 CA Trust Bundle](#21-ca-trust-bundle)
   - [2.2 PostgreSQL Database](#22-postgresql-database)
@@ -86,6 +87,7 @@ Install in the order shown — some prerequisites depend on earlier ones
 | CA Issuer | **Yes** | Self-signed CA for internal certificates |
 | Keycloak | **Yes** | Identity provider for OAuth/OIDC |
 | AAP Operator | **Yes** | Ansible Automation Platform for provisioning workflows |
+| PostgreSQL (fulfillment DB) | **Yes** | In-cluster operator-managed database for fulfillment-service |
 | LVMS | Only if no default StorageClass exists | Provides `lvms-vg1` StorageClass |
 | MetalLB | Only if no LoadBalancer service exists | Provides bare-metal load balancing |
 | MCE | Only for CaaS (cluster provisioning) | Multicluster Engine + infrastructure operator |
@@ -296,6 +298,27 @@ oc wait deployment/automation-controller-operator-controller-manager -n ${AAP_NS
   --for=condition=Available --timeout=300s
 ```
 
+### 1.9 PostgreSQL (Fulfillment Database)
+
+The fulfillment-service requires an in-cluster PostgreSQL database deployed via
+an operator (CloudNativePG, Crunchy PGO, or Zalando). Off-cluster databases
+(RDS, external hosts) are not supported by `setup.sh` prerequisite checks.
+
+Deploy PostgreSQL **before Phase 2** using one of the operator paths documented
+in [`base/osac-fulfillment-service/docs/INSTALL.md`](../base/osac-fulfillment-service/docs/INSTALL.md).
+The operator creates Kubernetes Services (typically in a `postgres` namespace)
+with cluster DNS hostnames such as `osac-rw.postgres.svc.cluster.local`.
+
+Verify the database Service has ready endpoints before continuing:
+
+```bash
+# Example for CNPG — adjust service/namespace for your operator
+oc get endpoints osac-rw -n postgres
+```
+
+Phase 2 covers creating the `fulfillment-db` and `postgres-client-cert-service`
+secrets that point fulfillment-service at this database.
+
 ---
 
 ## Phase 2: Prepare Secrets and Configuration
@@ -348,48 +371,51 @@ oc get configmap ca-bundle -n ${NAMESPACE}
 
 ### 2.2 PostgreSQL Database
 
-The fulfillment-service requires a PostgreSQL database. The connection details
-are provided via a `fulfillment-db` secret.
+The fulfillment-service requires a PostgreSQL database running **in the
+cluster**. Connection details are provided via a `fulfillment-db` secret and a
+`postgres-client-cert-service` secret for mutual TLS client authentication.
 
 > **Shortcut:** If `bundledPostgres.enabled: true` is set in your values file,
 > the chart auto-creates the `fulfillment-db` secret and
-> `postgres-client-cert-service` Certificate. You only need to deploy the
-> postgres chart itself — skip the manual `oc create secret` and
-> `oc apply -f Certificate` steps below.
+> `postgres-client-cert-service` Certificate. You must still deploy an in-cluster
+> PostgreSQL Service named `postgres` on port 5432 in the install namespace
+> before Helm install — see [Phase 1.9](#19-postgresql-fulfillment-database).
 
-**Option A: Deploy the bundled dev postgres chart** (single-replica, non-HA,
-suitable for dev/test):
+**Deploy PostgreSQL via an in-cluster operator** (production path):
+
+1. Follow [`base/osac-fulfillment-service/docs/INSTALL.md`](../base/osac-fulfillment-service/docs/INSTALL.md)
+   to install CloudNativePG, Crunchy PGO, or Zalando and create a PostgreSQL
+   cluster. The operator exposes a Kubernetes Service (e.g.
+   `osac-rw.postgres.svc.cluster.local` for CNPG).
+2. Create the `fulfillment-db` connection secret using the operator's hostname
+   and credentials. Example for CNPG (set variables from your operator cluster;
+   see INSTALL.md § "Create the service secrets"):
 
 ```bash
-# Deploy PostgreSQL with TLS and a 'service' database
-helm install fulfillment-db base/osac-fulfillment-service/it/charts/postgres/ \
-  -n ${NAMESPACE} \
-  --set certs.issuerRef.name=default-ca \
-  --set certs.caBundle.configMap=ca-bundle \
-  --set 'databases[0].name=service' \
-  --set 'databases[0].user=service'
+POSTGRES_USER=service
+POSTGRES_HOST=<operator-service-host>   # e.g. osac-rw.postgres.svc.cluster.local
+POSTGRES_PORT=5432
+POSTGRES_DB=service
 
-# Create the connection secret.
-# The postgres chart enforces mutual TLS (pg_hba.conf uses "hostssl ... cert"),
-# so the URL must use sslmode=verify-full with paths to the client certificate
-# files. These paths correspond to where the fulfillment-service chart mounts
-# the projected database volume.
 oc create secret generic fulfillment-db \
-  --from-literal=url='postgres://service@postgres:5432/service?sslmode=verify-full&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert&sslcert=/etc/fulfillment-grpc-server/db/sslcert&sslkey=/etc/fulfillment-grpc-server/db/sslkey' \
+  --from-literal=url="postgres://${POSTGRES_USER}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}?sslmode=verify-full&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert&sslcert=/etc/fulfillment-grpc-server/db/sslcert&sslkey=/etc/fulfillment-grpc-server/db/sslkey" \
   -n ${NAMESPACE}
 ```
 
-The postgres chart only creates a **server** certificate — client certificates
-must be created separately. Create a cert-manager Certificate for the
-`service` database user:
+> **Note:** Replace `<operator-service-host>` with your operator's cluster DNS
+> name — see INSTALL.md for PGO (`osac-primary.postgres.svc.cluster.local`) and
+> Zalando (`osac.postgres.svc.cluster.local`) examples.
+
+1. Create a cert-manager Certificate for the database user's client certificate
+   (required for mutual TLS):
 
 ```bash
-cat <<'EOF' | oc apply -f -
+cat <<EOF | oc apply -f -
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: postgres-client-service
-  namespace: osac
+  namespace: ${NAMESPACE}
 spec:
   issuerRef:
     kind: ClusterIssuer
@@ -402,24 +428,18 @@ spec:
     rotationPolicy: Always
 EOF
 
-# Wait for the certificate to be issued
 oc wait certificate/postgres-client-service -n ${NAMESPACE} \
   --for=condition=Ready --timeout=60s
 ```
 
-> **Note:** The values files already include a `database.connection` entry
-> that mounts the `postgres-client-cert-service` secret into the projected
-> volume at `/etc/fulfillment-grpc-server/db/`. This provides the `sslcert`,
-> `sslkey`, and `sslrootcert` files referenced in the connection URL above.
-
-**Option B: Use an existing database** — create the secret manually with
-your connection details:
-
-```bash
-oc create secret generic fulfillment-db \
-  --from-literal=url='postgres://user:password@host:5432/dbname?sslmode=require' \
-  -n ${NAMESPACE}
-```
+> **Note:** The values files include a `database.connection` entry that mounts
+> the `postgres-client-cert-service` secret into the projected volume at
+> `/etc/fulfillment-grpc-server/db/`. This provides the `sslcert`, `sslkey`,
+> and `sslrootcert` files referenced in the connection URL above.
+> **Supported deployments:** Only in-cluster operator-managed PostgreSQL per
+> INSTALL.md is supported for production. `setup.sh` validates that the resolved
+> Kubernetes Service has ready endpoints; unrecognized or off-cluster hostnames
+> fail with a pointer to INSTALL.md.
 
 ### 2.3 Fulfillment Controller Credentials
 
@@ -893,6 +913,11 @@ VALUES_FILE=values/caas-ci/values.yaml \
 The script handles prerequisite installation, secret creation, Helm deploy,
 and all post-install steps. Set `DEPLOY_MODE=helm` (default) to use Helm.
 
+PostgreSQL must be deployed in-cluster via an operator **before** running
+`setup.sh` (see [Phase 1.9](#19-postgresql-fulfillment-database)). The script
+validates that the database Service has ready endpoints; it does not deploy
+PostgreSQL.
+
 **Shared cluster deployments:** If multiple developers share the same cluster
 and you need to impersonate a different user, set `OC_IMPERSONATE`:
 
@@ -1028,13 +1053,16 @@ oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
 # Uninstall OSAC
 helm uninstall osac -n ${NAMESPACE}
 
-# Uninstall the fulfillment-db postgres (separate Helm release)
-helm uninstall fulfillment-db -n ${NAMESPACE} 2>/dev/null || true
-
 # Delete the namespace (waits for all resources to terminate).
 # This also removes AAP operator-managed resources (postgres StatefulSet,
 # PVCs) that are not part of any Helm release.
 oc delete namespace ${NAMESPACE} --wait
+
+# Operator-managed PostgreSQL (e.g. CNPG Cluster in the postgres namespace)
+# is not removed by helm uninstall. Delete it separately if needed:
+#   oc delete cluster -n postgres osac
+# or delete the entire postgres namespace:
+#   oc delete namespace postgres --wait
 
 # CRDs are preserved. To remove them:
 oc delete crd -l app.kubernetes.io/part-of=osac

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -206,6 +206,43 @@ _verify_postgres_endpoints() {
         -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .
 }
 
+readonly POSTGRES_IT_CHART="base/osac-fulfillment-service/it/charts/postgres/"
+
+# CI-only: deploy the integration-test postgres chart when bundledPostgres is enabled
+# but the postgres Service has no ready endpoints (e.g. e2e-full-install from a bare
+# OpenShift flavor). Mirrors maybe_upgrade_fulfillment_db() in refresh-after-snapshot.py.
+# Production installs with bundledPostgres disabled use operator-managed Postgres per
+# INSTALL.md; snapshot refresh uses the Python helper instead of this function.
+maybe_deploy_ci_postgres() {
+    local namespace="$1"
+    local values_file="$2"
+    local repo_root bundled_status
+
+    repo_root="$(cd "${_LIB_DIR}/.." && pwd)"
+    _bundled_postgres_enabled "${values_file}"
+    bundled_status=$?
+    if [[ ${bundled_status} -eq 2 ]]; then
+        _postgres_prereq_error "Values file ${values_file} not found or unreadable."
+    elif [[ ${bundled_status} -ne 0 ]]; then
+        return 0
+    fi
+
+    if _verify_postgres_endpoints "postgres" "${namespace}"; then
+        echo "PostgreSQL already available, skipping CI postgres deploy"
+        return 0
+    fi
+
+    echo "Deploying CI PostgreSQL (${POSTGRES_IT_CHART}) for bundledPostgres..."
+    helm upgrade --install fulfillment-db "${repo_root}/${POSTGRES_IT_CHART}" \
+        --namespace "${namespace}" \
+        --set certs.issuerRef.name=default-ca \
+        --set certs.caBundle.configMap=ca-bundle \
+        --set "databases[0].name=service" \
+        --set "databases[0].user=service" \
+        --timeout 5m \
+        --wait
+}
+
 # Verify in-cluster PostgreSQL is deployed before Helm install.
 # Usage: check_postgres_prerequisites <namespace> <values_file>
 check_postgres_prerequisites() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -127,5 +127,125 @@ http_json() {
     return 1
 }
 
+readonly POSTGRES_INSTALL_DOC="base/osac-fulfillment-service/docs/INSTALL.md"
+
+# PostgreSQL prerequisite helpers (production install via setup.sh).
+# Snapshot CI refresh mirrors host/endpoint resolution in
+# scripts/refresh-after-snapshot.py (_postgres_target and related helpers).
+# Keep both in sync when changing URL parsing or endpoint checks.
+
+_postgres_prereq_error() {
+    echo "ERROR: $1" >&2
+    echo "Deploy in-cluster PostgreSQL via an operator per ${POSTGRES_INSTALL_DOC}" >&2
+    exit 1
+}
+
+_bundled_postgres_enabled() {
+    local values_file="$1"
+    [[ -r "${values_file}" ]] || return 2
+    awk '
+        /^bundledPostgres:/ { bp=1; next }
+        bp && /^[^[:space:]#]/ { bp=0 }
+        bp && /^[[:space:]]+enabled:[[:space:]]*true([[:space:]]*#.*)?$/ { found=1 }
+        END { exit !found }
+    ' "$values_file"
+}
+
+_parse_db_host_from_url() {
+    local url="$1"
+    case "${url}" in
+        postgres://*) ;;
+        postgresql://*) url="postgres://${url#postgresql://}" ;;
+        *) return 1 ;;
+    esac
+    local hostport="${url#postgres://}"
+    hostport="${hostport#*@}"
+    hostport="${hostport%%/*}"
+    hostport="${hostport%%\?*}"
+    echo "${hostport%%:*}"
+}
+
+# Resolve a PostgreSQL host from fulfillment-db URL to service and namespace.
+# Prints "service target_namespace" on stdout; returns 1 if unrecognized.
+_resolve_postgres_service() {
+    local host="$1"
+    local install_namespace="$2"
+    local -a parts
+    local i
+
+    if [[ -z "${host}" ]]; then
+        return 1
+    fi
+
+    if [[ "${host}" != *.* ]]; then
+        printf '%s %s\n' "${host}" "${install_namespace}"
+        return 0
+    fi
+
+    IFS='.' read -ra parts <<< "${host}"
+    for i in "${!parts[@]}"; do
+        if [[ "${parts[$i]}" == "svc" ]] && (( i >= 2 )); then
+            printf '%s %s\n' "${parts[0]}" "${parts[1]}"
+            return 0
+        fi
+    done
+
+    if ((${#parts[@]} == 2)); then
+        printf '%s %s\n' "${parts[0]}" "${parts[1]}"
+        return 0
+    fi
+
+    return 1
+}
+
+_verify_postgres_endpoints() {
+    local service="$1"
+    local target_namespace="$2"
+
+    oc get endpoints "${service}" -n "${target_namespace}" \
+        -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .
+}
+
+# Verify in-cluster PostgreSQL is deployed before Helm install.
+# Usage: check_postgres_prerequisites <namespace> <values_file>
+check_postgres_prerequisites() {
+    local namespace="$1"
+    local values_file="$2"
+    local service target_namespace db_url db_host resolved bundled_status
+
+    _bundled_postgres_enabled "${values_file}"
+    bundled_status=$?
+    if [[ ${bundled_status} -eq 2 ]]; then
+        _postgres_prereq_error "Values file ${values_file} not found or unreadable."
+    elif [[ ${bundled_status} -eq 0 ]]; then
+        echo "Checking in-cluster PostgreSQL prerequisites (bundledPostgres)..."
+        service="postgres"
+        target_namespace="${namespace}"
+    else
+        echo "Checking in-cluster PostgreSQL prerequisites..."
+        oc get secret fulfillment-db -n "${namespace}" &>/dev/null || \
+            _postgres_prereq_error "Secret fulfillment-db not found in namespace ${namespace}."
+        oc get secret postgres-client-cert-service -n "${namespace}" &>/dev/null || \
+            _postgres_prereq_error "Secret postgres-client-cert-service not found in namespace ${namespace}."
+
+        db_url=$(oc get secret fulfillment-db -n "${namespace}" \
+            -o jsonpath='{.data.url}' | base64 -d 2>/dev/null || true)
+        [[ -n "${db_url}" ]] || \
+            _postgres_prereq_error "Secret fulfillment-db in ${namespace} has an empty url key."
+
+        db_host=$(_parse_db_host_from_url "${db_url}") || \
+            _postgres_prereq_error "Secret fulfillment-db in ${namespace} has an invalid PostgreSQL url."
+        resolved=$(_resolve_postgres_service "${db_host}" "${namespace}") || \
+            _postgres_prereq_error "Unrecognized database hostname in fulfillment-db url."
+        read -r service target_namespace <<< "${resolved}"
+    fi
+
+    if ! _verify_postgres_endpoints "${service}" "${target_namespace}"; then
+        _postgres_prereq_error "PostgreSQL Service referenced by fulfillment-db has no ready endpoints."
+    fi
+
+    echo "PostgreSQL prerequisites satisfied."
+}
+
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${_LIB_DIR}/oc.sh"

--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -55,14 +55,17 @@ class RefreshConfig:
 
     @property
     def values_dir(self) -> str:
+        """Directory containing the Helm values file."""
         return str(Path(self.values_file).parent)
 
     @property
     def external_host(self) -> str:
+        """Public fulfillment API route hostname."""
         return f"fulfillment-api-{self.namespace}.{self.cluster_domain}"
 
     @property
     def internal_host(self) -> str:
+        """Internal fulfillment API route hostname."""
         return f"fulfillment-internal-api-{self.namespace}.{self.cluster_domain}"
 
 
@@ -106,15 +109,18 @@ def run(args: list[str], *, check: bool = True, capture: bool = False) -> subpro
 
 
 def oc(*args: str, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run oc with the given arguments."""
     return run(["oc", *args], check=check, capture=capture)
 
 
 def oc_json(*args: str) -> dict:
+    """Run oc with -o json and return the parsed object."""
     result = oc(*args, "-o", "json", capture=True)
     return json.loads(result.stdout)
 
 
 def retry_until(*, description: str, timeout: int, interval: int, condition: Callable[[], bool]) -> None:
+    """Poll condition until it returns True or timeout expires."""
     deadline = time.time() + timeout
     while not condition():
         if time.time() >= deadline:
@@ -123,6 +129,7 @@ def retry_until(*, description: str, timeout: int, interval: int, condition: Cal
 
 
 def oc_exists(resource: str, namespace: str | None = None) -> bool:
+    """Return True when oc get succeeds for the given resource."""
     ns_args = ["-n", namespace] if namespace else []
     result = oc("get", resource, *ns_args, "--no-headers", check=False, capture=True)
     return result.returncode == 0
@@ -198,12 +205,14 @@ def _get_pod_failure(pod: dict) -> str | None:
 
 
 def _get_pod_logs(pod_name: str, namespace: str) -> str:
+    """Return the last 20 log lines for a pod."""
     result = oc("logs", f"pod/{pod_name}", "-n", namespace,
                 "--tail=20", "--all-containers", check=False, capture=True)
     return result.stdout.strip() if result.stdout else "(no logs)"
 
 
 def _get_pod_events(pod_name: str, namespace: str) -> str:
+    """Return recent Kubernetes events involving the pod."""
     result = oc(
         "get", "events", "-n", namespace,
         "--field-selector", f"involvedObject.name={pod_name}",
@@ -285,6 +294,7 @@ def check_all_pods(namespace: str) -> None:
 
 
 def patch_stale_routes(config: RefreshConfig) -> None:
+    """Rewrite route hosts that still reference the snapshot cluster domain."""
     for ns in [config.namespace, config.keycloak_ns, "multicluster-engine"]:
         if not oc_exists(f"namespace/{ns}"):
             continue
@@ -302,6 +312,7 @@ def patch_stale_routes(config: RefreshConfig) -> None:
 
 
 def refresh_cdi_certificates() -> None:
+    """Regenerate CDI TLS certificates after a cold snapshot boot."""
     if not oc_exists("namespace/openshift-cnv"):
         return
     print("  Refreshing CDI certificates...")
@@ -324,6 +335,7 @@ def refresh_cdi_certificates() -> None:
 
 
 def refresh_metallb_and_subnet() -> None:
+    """Refresh MetalLB webhook certs and apply the node subnet address pool."""
     if not oc_exists("crd/ipaddresspools.metallb.io"):
         return
     print("  Refreshing MetalLB webhook certificates...")
@@ -357,6 +369,7 @@ def refresh_metallb_and_subnet() -> None:
         "spec": {"addresses": [f"{subnet_prefix}.240-{subnet_prefix}.250"], "autoAssign": True},
     })
     def _try_apply_pool() -> bool:
+        """Apply the MetalLB IPAddressPool manifest."""
         r = subprocess.run(
             ["oc", "apply", "-f", "-"],
             input=pool_yaml, text=True, capture_output=True, cwd=str(REPO_ROOT),
@@ -374,6 +387,7 @@ def refresh_metallb_and_subnet() -> None:
 
 
 def wait_keycloak_cert(config: RefreshConfig) -> None:
+    """Wait for the Keycloak TLS certificate to become Ready."""
     print("  Waiting for Keycloak TLS certificate...")
     oc("wait", "--for=condition=Ready", "certificate/keycloak-tls",
        "-n", config.keycloak_ns, "--timeout=300s")
@@ -414,6 +428,7 @@ def pre_fix_cert_sans(config: RefreshConfig) -> None:
 
 
 def keycloak_sync(config: RefreshConfig) -> None:
+    """Re-apply Keycloak manifests and wait for the realm endpoint."""
     print("  Re-applying Keycloak from scratch...")
     oc("apply", "-k", "prerequisites/keycloak/")
     oc("rollout", "status", "deploy/keycloak-service", "-n", config.keycloak_ns,
@@ -434,6 +449,7 @@ def keycloak_sync(config: RefreshConfig) -> None:
 
 
 def create_secrets(config: RefreshConfig) -> None:
+    """Create fulfillment, AAP license, and pull secrets for the namespace."""
     print("  Creating secrets...")
     realm = json.loads((REPO_ROOT / config.realm_json).read_text())
 
@@ -467,10 +483,12 @@ def create_secrets(config: RefreshConfig) -> None:
 
 
 def ensure_ca_bundle(config: RefreshConfig) -> None:
+    """Ensure the cluster CA bundle ConfigMap exists in the install namespace."""
     run([str(SCRIPT_DIR / "ensure-ca-bundle.sh"), config.namespace])
 
 
 def wait_tls_certs(config: RefreshConfig) -> None:
+    """Wait for all cert-manager Certificates in the namespace to become Ready."""
     print("  Waiting for TLS certificates...")
     certs_data = oc_json("get", "certificates.cert-manager.io", "-n", config.namespace)
     for cert in certs_data["items"]:
@@ -484,6 +502,7 @@ def wait_tls_certs(config: RefreshConfig) -> None:
 
 
 def scale_csv_to(*, csv_name: str, namespace: str, replicas: int) -> None:
+    """Patch a ClusterServiceVersion to scale all owned Deployments."""
     csv_data = oc_json("get", "csv", csv_name, "-n", namespace)
     deploys: list[dict] = csv_data["spec"]["install"]["spec"]["deployments"]
     patch = [
@@ -500,6 +519,7 @@ def scale_csv_to(*, csv_name: str, namespace: str, replicas: int) -> None:
 
 
 def find_csv(*, namespace: str, deploy_name: str) -> str:
+    """Return the CSV name that owns the given Deployment."""
     data = oc_json("get", "csv", "-n", namespace)
     for item in data["items"]:
         deploys = item.get("spec", {}).get("install", {}).get("spec", {}).get("deployments", [])
@@ -514,6 +534,7 @@ def find_csv(*, namespace: str, deploy_name: str) -> str:
 # changing URL parsing or endpoint checks.
 
 def _bundled_postgres_enabled(values_file: str) -> bool:
+    """Return True when bundledPostgres.enabled is true in the Helm values file."""
     in_section = False
     path = REPO_ROOT / values_file
     for line in path.read_text().splitlines():
@@ -528,6 +549,7 @@ def _bundled_postgres_enabled(values_file: str) -> bool:
 
 
 def _parse_db_host_from_url(url: str) -> str:
+    """Extract the hostname from a postgres:// or postgresql:// URL."""
     if url.startswith("postgresql://"):
         url = "postgres://" + url.removeprefix("postgresql://")
     elif not url.startswith("postgres://"):
@@ -540,6 +562,7 @@ def _parse_db_host_from_url(url: str) -> str:
 
 
 def _resolve_postgres_service(host: str, install_namespace: str) -> tuple[str, str] | None:
+    """Map a DB hostname to a Kubernetes Service name and namespace."""
     if not host:
         return None
     if "." not in host:
@@ -554,6 +577,7 @@ def _resolve_postgres_service(host: str, install_namespace: str) -> tuple[str, s
 
 
 def _service_has_ready_endpoints(service: str, namespace: str) -> bool:
+    """Return True when the Service has at least one ready endpoint address."""
     result = oc(
         "get", "endpoints", service, "-n", namespace,
         "-o", "jsonpath={.subsets[0].addresses[0].ip}",
@@ -563,6 +587,7 @@ def _service_has_ready_endpoints(service: str, namespace: str) -> bool:
 
 
 def _postgres_target(config: RefreshConfig) -> tuple[str, str]:
+    """Resolve the PostgreSQL Service and namespace for snapshot refresh."""
     if _bundled_postgres_enabled(config.values_file):
         return "postgres", config.namespace
     result = oc(
@@ -601,6 +626,7 @@ def upgrade_fulfillment_db(config: RefreshConfig) -> None:
 
 
 def maybe_upgrade_fulfillment_db(config: RefreshConfig) -> None:
+    """Deploy the test postgres chart when no ready DB endpoints are present."""
     service, target_namespace = _postgres_target(config)
     if _service_has_ready_endpoints(service, target_namespace):
         print("  PostgreSQL already available, skipping fulfillment-db upgrade")
@@ -609,12 +635,14 @@ def maybe_upgrade_fulfillment_db(config: RefreshConfig) -> None:
 
 
 def adopt_resources_for_helm(config: RefreshConfig) -> None:
+    """Annotate existing namespace resources so Helm can manage them."""
     print("  Adopting existing resources for Helm...")
     result = oc("get", "all,configmap,secret,route", "-n", config.namespace,
                 "-o", "name", capture=True, check=False)
     resources = [r for r in result.stdout.strip().splitlines() if r]
 
     def _adopt(resource: str) -> None:
+        """Add Helm release metadata annotations to a single resource."""
         r = oc("annotate", resource, "-n", config.namespace,
                "meta.helm.sh/release-name=osac",
                f"meta.helm.sh/release-namespace={config.namespace}",
@@ -628,6 +656,7 @@ def adopt_resources_for_helm(config: RefreshConfig) -> None:
 
 
 def upgrade_osac(config: RefreshConfig) -> None:
+    """Upgrade the osac Helm release and adopt pre-existing namespace resources."""
     print("  Upgrading osac chart...")
     (REPO_ROOT / "charts/osac/Chart.lock").unlink(missing_ok=True)
     run(["helm", "dependency", "build", "charts/osac/"])
@@ -660,6 +689,7 @@ def upgrade_osac(config: RefreshConfig) -> None:
 
 
 def wait_fulfillment(config: RefreshConfig) -> None:
+    """Wait for fulfillment-service and osac-operator Deployments to become healthy."""
     print("  Waiting for fulfillment deployments...")
     deploys = oc_json("get", "deploy", "-n", config.namespace,
                       "-l", "app=fulfillment-service")
@@ -686,6 +716,7 @@ def scale_aap_operator(config: RefreshConfig) -> None:
 
 
 def _aap_controller_reconciled(config: RefreshConfig) -> bool:
+    """Return True when the AAP controller has reconciled since the stale timestamp."""
     result = oc(
         "get", "automationcontroller", "osac-aap-controller",
         "-n", config.namespace,
@@ -731,6 +762,7 @@ def wait_aap_ready(config: RefreshConfig) -> None:
 
 
 def fix_assisted_service() -> None:
+    """Reset assisted-service credentials after snapshot identity drift."""
     if oc_exists("secret/assisted-servicelocal-auth", "multicluster-engine"):
         print("  Deleting stale assisted-service auth keypair...")
         oc("delete", "secret", "assisted-servicelocal-auth", "-n", "multicluster-engine")
@@ -743,6 +775,7 @@ def fix_assisted_service() -> None:
 
 
 def post_flight(config: RefreshConfig) -> None:
+    """Run post-deploy prepare scripts and wait for fulfillment rollouts."""
     oc("config", "set-context", "--current", f"--namespace={config.namespace}")
 
     os.environ["INSTALLER_NAMESPACE"] = config.namespace
@@ -779,6 +812,7 @@ def post_flight(config: RefreshConfig) -> None:
 
 
 def main() -> None:
+    """Run the post-snapshot refresh workflow (prepare, deploy, post-flight)."""
     values_file = os.environ.get("VALUES_FILE")
     if not values_file:
         print("ERROR: VALUES_FILE must be set (e.g. values/vmaas-ci/values.yaml)", file=sys.stderr)

--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -13,7 +13,9 @@ detected during rollout waits.
 
 from __future__ import annotations
 
+import base64
 import json
+import re
 import os
 import subprocess
 import sys
@@ -506,7 +508,87 @@ def find_csv(*, namespace: str, deploy_name: str) -> str:
     raise RuntimeError(f"CSV not found for deployment {deploy_name} in {namespace}")
 
 
+# Postgres target resolution for vmaas snapshot refresh (CI-only test chart path).
+# Production install uses the Bash helpers in scripts/lib.sh
+# (check_postgres_prerequisites and related functions). Keep both in sync when
+# changing URL parsing or endpoint checks.
+
+def _bundled_postgres_enabled(values_file: str) -> bool:
+    in_section = False
+    path = REPO_ROOT / values_file
+    for line in path.read_text().splitlines():
+        if line.startswith("bundledPostgres:"):
+            in_section = True
+            continue
+        if in_section and line and not line[0].isspace() and not line.lstrip().startswith("#"):
+            in_section = False
+        if in_section and re.match(r"^\s+enabled:\s*true\s*$", line.split("#", 1)[0]):
+            return True
+    return False
+
+
+def _parse_db_host_from_url(url: str) -> str:
+    if url.startswith("postgresql://"):
+        url = "postgres://" + url.removeprefix("postgresql://")
+    elif not url.startswith("postgres://"):
+        raise ValueError("invalid PostgreSQL URL scheme")
+    hostport = url.removeprefix("postgres://")
+    if "@" in hostport:
+        hostport = hostport.split("@", 1)[1]
+    hostport = hostport.split("/", 1)[0].split("?", 1)[0]
+    return hostport.split(":", 1)[0]
+
+
+def _resolve_postgres_service(host: str, install_namespace: str) -> tuple[str, str] | None:
+    if not host:
+        return None
+    if "." not in host:
+        return host, install_namespace
+    parts = host.split(".")
+    for i, part in enumerate(parts):
+        if part == "svc" and i >= 2:
+            return parts[0], parts[1]
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return None
+
+
+def _service_has_ready_endpoints(service: str, namespace: str) -> bool:
+    result = oc(
+        "get", "endpoints", service, "-n", namespace,
+        "-o", "jsonpath={.subsets[0].addresses[0].ip}",
+        capture=True, check=False,
+    )
+    return result.returncode == 0 and bool(result.stdout.strip())
+
+
+def _postgres_target(config: RefreshConfig) -> tuple[str, str]:
+    if _bundled_postgres_enabled(config.values_file):
+        return "postgres", config.namespace
+    result = oc(
+        "get", "secret", "fulfillment-db", "-n", config.namespace,
+        "-o", "jsonpath={.data.url}",
+        capture=True, check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            url = base64.b64decode(result.stdout.strip()).decode()
+            resolved = _resolve_postgres_service(
+                _parse_db_host_from_url(url), config.namespace,
+            )
+        except (ValueError, UnicodeDecodeError):
+            resolved = None
+        if resolved:
+            return resolved
+    return "postgres", config.namespace
+
+
 def upgrade_fulfillment_db(config: RefreshConfig) -> None:
+    """Deploy the integration-test postgres chart for vmaas snapshot refresh.
+
+    Production installs use operator-managed Postgres (see setup.sh). This path
+    exists only for CI clusters booted from snapshots that expect postgres:5432.
+    """
     print("  Upgrading fulfillment-db...")
     run(["helm", "upgrade", "--install", "fulfillment-db",
          "base/osac-fulfillment-service/it/charts/postgres/",
@@ -516,6 +598,14 @@ def upgrade_fulfillment_db(config: RefreshConfig) -> None:
          "--set", "databases[0].name=service",
          "--set", "databases[0].user=service",
          "--timeout", "5m", "--wait"])
+
+
+def maybe_upgrade_fulfillment_db(config: RefreshConfig) -> None:
+    service, target_namespace = _postgres_target(config)
+    if _service_has_ready_endpoints(service, target_namespace):
+        print("  PostgreSQL already available, skipping fulfillment-db upgrade")
+        return
+    upgrade_fulfillment_db(config)
 
 
 def adopt_resources_for_helm(config: RefreshConfig) -> None:
@@ -734,7 +824,7 @@ def main() -> None:
         ("create secrets", lambda: create_secrets(config)),
         ("ensure CA bundle", lambda: ensure_ca_bundle(config)),
         ("wait TLS certs", lambda: wait_tls_certs(config)),
-        ("upgrade fulfillment-db", lambda: upgrade_fulfillment_db(config)),
+        ("upgrade fulfillment-db", lambda: maybe_upgrade_fulfillment_db(config)),
     ])
     print(f"[Phase 2] Done ({time.time() - phase_start:.0f}s)\n")
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -294,6 +294,8 @@ if [[ "${DEPLOY_MODE}" == "helm" ]]; then
     # In-cluster PostgreSQL must exist before Helm install (operator-managed per
     # INSTALL.md). Creates fulfillment-db and postgres-client-cert-service secrets
     # separately, or enable bundledPostgres in values for secret auto-generation.
+    # CI full-install (bundledPostgres) may deploy the integration-test chart first.
+    maybe_deploy_ci_postgres "${INSTALLER_NAMESPACE}" "${VALUES_FILE}"
     check_postgres_prerequisites "${INSTALLER_NAMESPACE}" "${VALUES_FILE}"
 
     # Create AAP license secret (required by the bootstrap job).

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -291,50 +291,10 @@ if [[ "${DEPLOY_MODE}" == "helm" ]]; then
         -n "${INSTALLER_NAMESPACE}" \
         --dry-run=client -o yaml | oc apply -f -
 
-    # Deploy the fulfillment database. The fulfillment-service chart expects an
-    # external PostgreSQL with connection details in 'fulfillment-db' and client
-    # TLS in 'postgres-client-cert-service'.
-    echo "Deploying fulfillment database..."
-    helm upgrade --install fulfillment-db \
-        base/osac-fulfillment-service/it/charts/postgres/ \
-        --namespace "${INSTALLER_NAMESPACE}" \
-        --set certs.issuerRef.name=default-ca \
-        --set certs.caBundle.configMap=ca-bundle \
-        --set 'databases[0].name=service' \
-        --set 'databases[0].user=service' \
-        --timeout 5m \
-        --wait
-
-    # Create client certificate for the 'service' database user.
-    # The postgres chart does not generate per-user client certs yet.
-    oc apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  namespace: ${INSTALLER_NAMESPACE}
-  name: postgres-client-cert-service
-spec:
-  issuerRef:
-    kind: ClusterIssuer
-    name: default-ca
-  commonName: service
-  usages:
-  - client auth
-  secretName: postgres-client-cert-service
-  privateKey:
-    rotationPolicy: Always
-EOF
-    oc wait certificate/postgres-client-cert-service -n "${INSTALLER_NAMESPACE}" --for=condition=Ready --timeout=60s
-
-    # Create the connection secret for the fulfillment gRPC server.
-    DB_URL="postgres://service@postgres:5432/service?sslmode=verify-full"
-    DB_URL+="&sslcert=/etc/fulfillment-grpc-server/db/sslcert"
-    DB_URL+="&sslkey=/etc/fulfillment-grpc-server/db/sslkey"
-    DB_URL+="&sslrootcert=/etc/fulfillment-grpc-server/db/sslrootcert"
-    oc create secret generic fulfillment-db \
-        --from-literal=url="${DB_URL}" \
-        -n "${INSTALLER_NAMESPACE}" \
-        --dry-run=client -o yaml | oc apply -f -
+    # In-cluster PostgreSQL must exist before Helm install (operator-managed per
+    # INSTALL.md). Creates fulfillment-db and postgres-client-cert-service secrets
+    # separately, or enable bundledPostgres in values for secret auto-generation.
+    check_postgres_prerequisites "${INSTALLER_NAMESPACE}" "${VALUES_FILE}"
 
     # Create AAP license secret (required by the bootstrap job).
     # In kustomize mode this is handled by secretGenerator; in Helm mode we

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -113,3 +113,11 @@ bmf:
 dbMigrate:
   enabled: false
   image: ghcr.io/osac-project/fulfillment-service:sha-075185e
+
+# CI full-install: chart-managed DB secrets; setup.sh deploys the integration-test
+# postgres chart when the postgres Service has no ready endpoints (see lib.sh).
+bundledPostgres:
+  enabled: true
+  database:
+    name: service
+    user: service


### PR DESCRIPTION
## Summary

- Remove production use of `fulfillment-service/it/charts/postgres/` from `setup.sh` (operator-managed Postgres per INSTALL.md)
- Add `check_postgres_prerequisites()` in `lib.sh` to validate in-cluster PostgreSQL before Helm install
- Update helm deployment guide and `bundledPostgres` comments to document CNPG/PGO/Zalando operator path per INSTALL.md
- **CI-only exception:** `refresh-after-snapshot.py` conditionally deploys `it/charts/postgres` via `maybe_upgrade_fulfillment_db()` when snapshot clusters lack ready Postgres endpoints (vmaas e2e compatibility; not used on production install)

## Persona impact (runtime)

| Persona | Impact | Manner |
|---------|--------|--------|
| **Cloud Infrastructure Admin** | Direct | Must provision in-cluster production-grade PostgreSQL before install; prerequisite check validates Service endpoints |
| **Cloud Provider Admin** | Indirect | `setup.sh` no longer deploys fulfillment DB; platform bring-up docs updated |
| **Tenant Admin** | None direct | Indirect — fulfillment unavailable if DB not provisioned |
| **Tenant User** | None direct | Indirect — self-service unavailable if DB not provisioned |

## Project contributor impact (open source)

Not the four runtime personas — people who build, test, and contribute to OSAC.

| Stakeholder | Impact | Manner |
|-------------|--------|--------|
| **OSAC developer** | Direct | `./scripts/setup.sh` no longer one-shot for fulfillment DB; BYO Postgres before install; `values/development/` path harder |
| **CI maintainer** | Direct | vmaas snapshot refresh uses conditional test-chart Postgres when endpoints missing; e2e-vmaas passed on `39b1a28` |
| **OSS contributor (non–Red Hat)** | Direct | Fork PR flow unchanged; higher onboarding bar (cluster, license, Postgres per INSTALL.md) |

## Jira

[OS[AC-1](https://redhat.atlassian.net/browse/AC-1)157](https://issues.redhat.com/browse/OS[AC-1](https://redhat.atlassian.net/browse/AC-1)157)

## Related

Related: fulfillment-service#766

## Test plan

- [x] `pre-commit run --all-files`
- [x] `bash scripts/kustomize-build-all.sh`
- [x] `ct lint --all --config ct.yaml`
- [x] `bash -n scripts/lib.sh scripts/setup.sh`
- [x] `python3 -m py_compile scripts/refresh-after-snapshot.py`
- [x] `rg 'it/charts' scripts/` — production install scripts have no direct `it/charts` refs (`setup.sh`, `lib.sh`); CI refresh exception documented in `refresh-after-snapshot.py`
- [x] `ci/prow/e2e-vmaas` — pass on build `2070377526986805248` (`39b1a28`)
- [ ] caas-ci: confirm in-cluster postgres exists before `setup.sh` on fresh installs

## Acceptance Criteria

- [x] **[AC-1](https://redhat.atlassian.net/browse/AC-1):** Production install paths (`setup.sh`, deployment docs, helm values) do not deploy or depend on `fulfillment-service/it/charts/postgres/`. CI snapshot refresh (`refresh-after-snapshot.py`) retains a conditional test-chart deploy for vmaas compatibility only.
- [x] **AC-2:** Production instructions document operator-based in-cluster deployment per INSTALL.md
- [x] **[AC-3](https://redhat.atlassian.net/browse/AC-3):** Documentation-only production path (`setup.sh` validates prerequisites, does not deploy postgres)

## Open questions (stakeholder-scoped)

1. **CI maintainer + OSAC developer:** Long-term, should vmaas snapshots pre-bake operator Postgres so refresh can drop the test-chart shim entirely?
2. **OSS contributor:** Should we add a contributor-focused dev quickstart for Postgres (without `it/charts/postgres`)?
3. **Cloud Provider Admin vs ticket author:** Is Keycloak bundled Postgres (`prerequisites/keycloak/`) an explicit dev-only exception?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm/installer flow now validates PostgreSQL prerequisites and service endpoint readiness before continuing.
  * Refresh/upgrade logic can detect already-ready PostgreSQL endpoints and avoid unnecessary work.
* **Bug Fixes**
  * Improved PostgreSQL-backed upgrades by skipping redundant `fulfillment-db` upgrades when endpoints are already ready.
  * Updated bundled PostgreSQL expectations to the in-namespace `postgres:5432` service model.
* **Documentation**
  * Updated PostgreSQL setup prerequisites, supported deployment paths, and “clean reinstall”/automated alternative guidance for operator-managed in-cluster PostgreSQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->