### PR TITLE
OSAC-1675: Bump fulfillment-service to remove Authorino dependency

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -28,7 +28,7 @@ service:
   externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
   internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
+    service: ghcr.io/osac-project/fulfillment-service:sha-5f07d15
     envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
@@ -103,7 +103,7 @@ validation:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
+  image: ghcr.io/osac-project/fulfillment-service:sha-5f07d15
 
 clusterFulfillment:
   enabled: true

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -29,7 +29,7 @@ service:
   internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   variant: openshift
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
+    service: ghcr.io/osac-project/fulfillment-service:sha-5f07d15
     envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
@@ -111,4 +111,4 @@ bmf:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-ffdfd9f
+  image: ghcr.io/osac-project/fulfillment-service:sha-5f07d15


### PR DESCRIPTION
## Summary

- Bump `base/osac-fulfillment-service` submodule from `ffdfd9f` to `5f07d15` (latest main)
- This removes the `AuthConfig` and `Authorino` templates from the Helm chart that were causing `helm install` to fail with `no matches for kind "AuthConfig" in version "authorino.kuadrant.io/v1beta3"` since Authorino is no longer installed as a prerequisite (removed in PR #323)
- Update fulfillment-service image tags in vmaas-ci and caas-ci values

## Context

The e2e-full-install CI workflow fails at the "Install OSAC" step because the fulfillment-service Helm chart unconditionally renders Authorino CRDs (`AuthConfig`, `Authorino`) but the Authorino operator is no longer installed. The upstream fulfillment-service has already removed these templates.

## Test plan

- [ ] Trigger `e2e-full-install-test.yml` after merge