### PR TITLE
OSAC-1675: Fix helm upgrade conflict for AAP token env var

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -546,6 +546,18 @@ def upgrade_osac(config: RefreshConfig) -> None:
     # The AAP subchart manages this secret; deleting forces a fresh render.
     oc("delete", "secret", "config-as-code-ig", "-n", config.namespace,
        "--ignore-not-found")
+    # Remove OSAC_AAP_URL and OSAC_AAP_TOKEN env vars that prepare-aap.sh
+    # injected via "oc set env" on the snapshot.  The chart now manages
+    # OSAC_AAP_TOKEN via valueFrom/secretKeyRef; leaving the old plain
+    # "value:" field causes a strategic-merge-patch conflict during upgrade.
+    for pattern in ("osac-operator", "bmf-operator"):
+        deploys = oc("get", "deploy", "-n", config.namespace, "-o", "name",
+                     capture=True, check=False).stdout.strip().splitlines()
+        for d in deploys:
+            if pattern in d:
+                oc("set", "env", d, "-n", config.namespace,
+                   "OSAC_AAP_URL-", "OSAC_AAP_TOKEN-")
+                break
     base_domain = "hosted." + config.cluster_domain.removeprefix("apps.")
     run(["helm", "upgrade", "osac", "charts/osac/",
          "--namespace", config.namespace,


### PR DESCRIPTION
## Summary
- The snapshot's operator deployment has `OSAC_AAP_TOKEN` and `OSAC_AAP_URL` injected by `prepare-aap.sh` via `oc set env` with plain `value:` fields
- The chart now manages `OSAC_AAP_TOKEN` via `valueFrom/secretKeyRef` (PR #316 / #328), causing a Kubernetes strategic-merge-patch conflict during `helm upgrade`: `may not be specified when value is not empty`
- Strip both env vars from operator deployments before `helm upgrade` so the chart can render them cleanly from the values file

## Test plan
- [ ] Trigger regular e2e workflow and verify `helm upgrade` succeeds
- [ ] Verify operator gets `OSAC_AAP_TOKEN` via `secretKeyRef` after upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an upgrade issue that could cause deployment conflicts during OSAC updates.
  * Snapshot-related environment variables are now removed before the upgrade, helping updates complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->