### PR TITLE
OSAC-1694: Expose BCM inventory backend configuration in installer helm chart

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -65,6 +65,8 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:latest
+  configAsCode:
+    importBcmAgentsEnabled: false
 
 validation:
   enabled: true
@@ -96,6 +98,9 @@ clusterFulfillment:
     IMPORT_AGENTS_INFRAENV_NAME: "infraenv"
     IMPORT_AGENTS_PULL_SECRET_NAME: "pull-secret"
     IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: "true"
+    BCM_API_URL: "https://bcm-head.example.com:8081"
+    BCM_VALIDATE_CERTS: "false"
+    BCM_DISABLE_BMC_CERT_VERIFICATION: "true"
   secret:
     NETRIS_PASSWORD: "test-password"
 

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -264,6 +264,10 @@ aap:
     # OSAC_IMPORT_AGENTS_ENABLED=true in the config-as-code-ig Secret
     # and gates the import-agents-inventory ConfigMap.
     importAgentsEnabled: false
+    # Enable BCM (NVIDIA Base Command Manager) inventory backend. Sets
+    # OSAC_IMPORT_BCM_AGENTS_ENABLED=true in the config-as-code-ig Secret
+    # and gates the bcm-certs Secret.
+    importBcmAgentsEnabled: false
 
   # Server inventory for bare metal agent import.
   # Each entry provisions a BareMetalHost CR via the import-agents playbook.
@@ -285,6 +289,16 @@ aap:
     #     netris_server_name: "server-02"
     #     resource_class: "fc430"
     #     disable_bmc_cert_verification: false
+
+  # BCM (NVIDIA Base Command Manager) mTLS client credentials.
+  # When importBcmAgentsEnabled is true, these are written to the bcm-certs Secret.
+  # BCM API connection settings are configured in clusterFulfillment.config below.
+  # See osac-aap/docs/bcm-inventory-integration.md for setup details.
+  importBcmAgents:
+    # PEM-encoded client certificate for BCM mTLS authentication.
+    cert: ""
+    # PEM-encoded client private key for BCM mTLS authentication.
+    key: ""
 
 # ---------------------
 # Bundled PostgreSQL (dev/test)
@@ -387,6 +401,18 @@ clusterFulfillment:
     IMPORT_AGENTS_PULL_SECRET_NAME: ""
     # Effective default: "true"
     IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: ""
+
+    # --- BCM Inventory ---
+    # Playbook variables for BCM-based agent import.
+    # These override the playbook defaults when non-empty.
+    # BCM head node API endpoint (e.g., https://bcm-head:8081).
+    BCM_API_URL: ""
+    # Verify BCM TLS certificates. Set to "false" for lab environments
+    # with self-signed certificates. Effective default: "true" (production).
+    BCM_VALIDATE_CERTS: "true"
+    # Skip BMC TLS certificate verification during system discovery.
+    # Effective default: "false".
+    BCM_DISABLE_BMC_CERT_VERIFICATION: "false"
   secret:
     NETRIS_PASSWORD: ""
     # AWS credentials (used by the Route 53 DNS backend).

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -497,6 +497,11 @@
               "type": "boolean",
               "description": "Enable ConfigMap-based bare metal agent import. Sets OSAC_IMPORT_AGENTS_ENABLED=true in the config-as-code-ig Secret and gates the import-agents-inventory ConfigMap.",
               "default": false
+            },
+            "importBcmAgentsEnabled": {
+              "type": "boolean",
+              "description": "Enable BCM inventory backend. Sets OSAC_IMPORT_BCM_AGENTS_ENABLED=true in the config-as-code-ig Secret and gates the bcm-certs Secret.",
+              "default": false
             }
           }
         },
@@ -541,6 +546,20 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "importBcmAgents": {
+          "type": "object",
+          "description": "BCM mTLS client credentials. Enable via aap.configAsCode.importBcmAgentsEnabled.",
+          "properties": {
+            "cert": {
+              "type": "string",
+              "description": "PEM-encoded client certificate for BCM mTLS authentication"
+            },
+            "key": {
+              "type": "string",
+              "description": "PEM-encoded client private key for BCM mTLS authentication"
             }
           }
         }
@@ -1006,6 +1025,21 @@
             "IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION": {
               "type": "string",
               "description": "Default BMC TLS certificate verification skip (effective default: true)"
+            },
+            "BCM_API_URL": {
+              "type": "string",
+              "pattern": "^$|^https?://",
+              "description": "BCM head node API endpoint (e.g., https://bcm-head:8081)"
+            },
+            "BCM_VALIDATE_CERTS": {
+              "type": "string",
+              "enum": ["", "true", "false"],
+              "description": "Verify BCM TLS certificates (effective default: true)"
+            },
+            "BCM_DISABLE_BMC_CERT_VERIFICATION": {
+              "type": "string",
+              "enum": ["", "true", "false"],
+              "description": "Skip BMC TLS certificate verification during BCM system discovery (effective default: false)"
             }
           }
         },

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -110,8 +110,12 @@ aap:
     projectGitUri: ""
     projectGitBranch: ""
     importAgentsEnabled: false
+    importBcmAgentsEnabled: false
   importAgents:
     servers: []
+  importBcmAgents:
+    cert: ""
+    key: ""
 
 # --- Instance Groups ---
 instanceGroups:
@@ -242,6 +246,9 @@ clusterFulfillment:
     IMPORT_AGENTS_INFRAENV_NAME: ""
     IMPORT_AGENTS_PULL_SECRET_NAME: ""
     IMPORT_AGENTS_DISABLE_BMC_CERT_VERIFICATION: ""
+    BCM_API_URL: ""
+    BCM_VALIDATE_CERTS: "true"
+    BCM_DISABLE_BMC_CERT_VERIFICATION: "false"
   secret:
     NETRIS_PASSWORD: ""
     AWS_ACCESS_KEY_ID: ""


### PR DESCRIPTION
## [OSAC-1694](https://redhat.atlassian.net/browse/OSAC-1694): Expose BCM inventory backend configuration in installer helm chart

**Jira:** https://redhat.atlassian.net/browse/OSAC-1694
**Related:** https://redhat.atlassian.net/browse/OSAC-1602
**Depends on:** https://github.com/osac-project/osac-aap/pull/380

### Summary

Exposes the BCM (NVIDIA Base Command Manager) inventory backend configuration in the installer Helm chart so the Enclave UI can present configuration options to admins. This is the BCM counterpart to [OSAC-1693](https://redhat.atlassian.net/browse/OSAC-1693) (ConfigMap inventory backend) and follows the same split pattern established by PR #335 — BCM templates and Secret gating live in the osac-aap subchart, while the installer passes values through.

### Changes

- **values.yaml / values-example.yaml:** Added `aap.configAsCode.importBcmAgentsEnabled` and `aap.importBcmAgents` (cert/key) under the `aap` subchart values. Added BCM config keys (`BCM_API_URL`, `BCM_VALIDATE_CERTS`, `BCM_DISABLE_BMC_CERT_VERIFICATION`) to `clusterFulfillment.config`. Removed stale top-level `importAgents` and `importBcmAgents` blocks.
- **values.schema.json:** Added schema entries for `importBcmAgentsEnabled` and `importBcmAgents` under the `aap` section; removed top-level `importBcmAgents` schema.
- **templates/bcm-certs.yaml:** Removed — now lives in the osac-aap subchart (osac-aap#380).
- **ci/full-values.yaml:** Added BCM values under `aap` to exercise all template branches in CI.

### Testing

- **Unit tests:** N/A — Helm chart change
- **Integration tests:** N/A
- **Validation:** JSON schema validates. Manually verified values flow through to osac-aap subchart correctly.

### Acceptance Criteria

- [x] BCM values are scoped under `aap` (consistent with import-agents pattern from PR #335)
- [x] Schema validates correctly
- [x] Default values disable the feature (opt-in)
- [x] BCM config keys in `clusterFulfillment.config` are preserved
- [x] Stale top-level `importAgents`/`importBcmAgents` blocks removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to support BCM inventory import via config-as-code, including an `importBcmAgentsEnabled` toggle (default: disabled).
  * Added BCM mTLS credential inputs (`cert` and `key`) for the inventory import.
  * Added BCM connectivity and TLS controls: `BCM_API_URL`, `BCM_VALIDATE_CERTS`, and `BCM_DISABLE_BMC_CERT_VERIFICATION`.
* **Documentation**
  * Updated the example values and the configuration schema to document the new BCM options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->