### PR TITLE
OSAC-1768: Enable storage controller in CI values

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -33,7 +33,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-89f41e7
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-7e4222b
+  newTag: sha-773d078
 - name: ghcr.io/osac-project/bare-metal-fulfillment-operator
   newTag: sha-0a06955
 - name: envoy

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-7e4222b
+    tag: sha-773d078
     pullPolicy: Always
   provisioning:
     provider: "aap"
@@ -22,6 +22,7 @@ operator:
     computeInstance: false
     tenant: true
     networking: true
+    storageController: true
 
 # --- Fulfillment Service ---
 service:

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-7e4222b
+    tag: sha-773d078
     pullPolicy: Always
   provisioning:
     provider: "aap"
@@ -22,6 +22,7 @@ operator:
     computeInstance: true
     tenant: true
     networking: true
+    storageController: true
 
 # --- Fulfillment Service ---
 service:


### PR DESCRIPTION
## Summary
- Enable `storageController: true` in both `vmaas-ci` and `caas-ci` values
- Requires osac-operator PR osac-project/osac-operator#320 to be merged and submodule bumped first

## Context
The Storage Controller populates `Tenant.Status.StorageClasses`, which the ComputeInstance Controller reads and passes to AAP as `tenant_storage_classes`. Without it, all VM provisioning fails with "no tenant_storage_classes available".

## Test plan
- [ ] Merge operator PR #320, bump submodule
- [ ] Run e2e-full-install and verify ComputeInstance tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled additional storage management capabilities in CI environments by turning on storage-related operator controls.

* **Chores**
  * Updated the bundled operator to a newer revision across the CI and kustomization configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->