### PR TITLE
OSAC-1442: Add ExternalIP RBAC entries to hub-access ClusterRole

### DIFF
--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -163,6 +163,60 @@ rules:
   - apiGroups:
       - osac.openshift.io
     resources:
+      - externalippools
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - externalippools/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - externalips
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - externalips/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - externalipattachments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - externalipattachments/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
       - baremetalinstances
     verbs:
       - create


### PR DESCRIPTION
Grant the fulfillment-service controller RBAC access to ExternalIPPool, ExternalIP, and ExternalIPAttachment CRD resources on the hub cluster, matching the existing PublicIP entries.