### PR TITLE
NO-ISSUE: Remove deprecated fulfillment service flags

### DIFF
--- a/overlays/osac-integration/kustomization.yaml
+++ b/overlays/osac-integration/kustomization.yaml
@@ -188,7 +188,6 @@ patches:
                 - --grpc-listener-tls-crt=/etc/fulfillment-grpc-server/tls/tls.crt
                 - --grpc-listener-tls-key=/etc/fulfillment-grpc-server/tls/tls.key
                 - --grpc-authn-trusted-token-issuers=https://keycloak-keycloak.apps.osac-integration.svc.massopen.cloud/realms/osac
-                - --tenancy-logic=default
                 - --metrics-listener-address=0.0.0.0:8002
                 - --token-signer-crt=/etc/fulfillment-token-signer/tls.crt
                 - --token-signer-key=/etc/fulfillment-token-signer/tls.key


### PR DESCRIPTION
The `--tenancy-logic` flag of the fulfillment service has been deprecated and will be removed soon. This patch removes it from the Kustomize files in this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated service authentication settings to trust tokens issued by the configured identity provider, helping improve login and request validation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->