### PR TITLE
OSAC-1806: Add dev/nightly chart publishing and cleanup workflows

### DIFF
--- a/.github/actions/compute-submodule-versions/action.yaml
+++ b/.github/actions/compute-submodule-versions/action.yaml
@@ -1,0 +1,39 @@
+name: Compute Submodule Versions
+description: Resolve short commit SHAs for all component submodules
+
+outputs:
+  operator_sha:
+    description: osac-operator submodule short SHA
+    value: ${{ steps.shas.outputs.operator_sha }}
+  service_sha:
+    description: fulfillment-service submodule short SHA
+    value: ${{ steps.shas.outputs.service_sha }}
+  aap_sha:
+    description: osac-aap submodule short SHA
+    value: ${{ steps.shas.outputs.aap_sha }}
+  bmf_sha:
+    description: bare-metal-fulfillment-operator submodule short SHA
+    value: ${{ steps.shas.outputs.bmf_sha }}
+
+runs:
+  using: composite
+  steps:
+  - name: Resolve submodule SHAs
+    id: shas
+    shell: bash
+    run: |
+      OPERATOR_SHA=$(git -C base/osac-operator rev-parse --short=7 HEAD)
+      SERVICE_SHA=$(git -C base/osac-fulfillment-service rev-parse --short=7 HEAD)
+      AAP_SHA=$(git -C base/osac-aap rev-parse --short=7 HEAD)
+      BMF_SHA=$(git -C base/bare-metal-fulfillment-operator rev-parse --short=7 HEAD)
+
+      echo "operator_sha=${OPERATOR_SHA}" >> "$GITHUB_OUTPUT"
+      echo "service_sha=${SERVICE_SHA}" >> "$GITHUB_OUTPUT"
+      echo "aap_sha=${AAP_SHA}" >> "$GITHUB_OUTPUT"
+      echo "bmf_sha=${BMF_SHA}" >> "$GITHUB_OUTPUT"
+
+      echo "--- Submodule SHAs ---"
+      echo "osac-operator:                    ${OPERATOR_SHA}"
+      echo "fulfillment-service:              ${SERVICE_SHA}"
+      echo "osac-aap:                         ${AAP_SHA}"
+      echo "bare-metal-fulfillment-operator:  ${BMF_SHA}"

--- a/.github/actions/publish-helm-chart/action.yaml
+++ b/.github/actions/publish-helm-chart/action.yaml
@@ -1,0 +1,44 @@
+name: Publish Helm Chart
+description: Package a Helm chart and push it to an OCI registry
+
+inputs:
+  chart-dir:
+    description: Path to the chart directory
+    required: true
+  version:
+    description: Chart version (e.g. 0.0.0-dev.abc1234)
+    required: true
+  floating-version:
+    description: Optional floating version to also publish (e.g. 0.0.0-dev)
+    required: false
+  registry:
+    description: OCI registry host (e.g. ghcr.io)
+    required: true
+  charts-repo:
+    description: OCI repository path under registry (e.g. osac-project/charts)
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Package and push chart
+    shell: bash
+    env:
+      CHART_DIR: ${{ inputs.chart-dir }}
+      VERSION: ${{ inputs.version }}
+      FLOATING_VERSION: ${{ inputs.floating-version }}
+      OCI_REPO: oci://${{ inputs.registry }}/${{ inputs.charts-repo }}
+    run: |
+      set -euo pipefail
+      name=$(yq -r '.name' "${CHART_DIR}/Chart.yaml")
+      mkdir -p /tmp/charts
+
+      echo "--- Publishing ${name} (${VERSION}) ---"
+      helm package "${CHART_DIR}" --version "${VERSION}" --app-version "${VERSION}" --destination /tmp/charts/
+      helm push "/tmp/charts/${name}-${VERSION}.tgz" "${OCI_REPO}"
+
+      if [ -n "${FLOATING_VERSION}" ]; then
+        echo "--- Publishing ${name} (${FLOATING_VERSION}, appVersion=${VERSION}) ---"
+        helm package "${CHART_DIR}" --version "${FLOATING_VERSION}" --app-version "${VERSION}" --destination /tmp/charts/
+        helm push "/tmp/charts/${name}-${FLOATING_VERSION}.tgz" "${OCI_REPO}"
+      fi

--- a/.github/workflows/cleanup-charts.yaml
+++ b/.github/workflows/cleanup-charts.yaml
@@ -1,0 +1,33 @@
+name: Cleanup Old Charts
+
+on:
+  schedule:
+    - cron: '41 4 * * 1'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Delete old dev/nightly chart versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - osac
+          - osac-operator-crds
+          - osac-operator
+          - fulfillment-service
+          - osac-aap
+          - bare-metal-fulfillment-operator-crds
+          - bare-metal-fulfillment-operator
+    steps:
+    - name: Delete old versions
+      uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53  # v3.1.0
+      with:
+        account: osac-project
+        token: ${{ secrets.OSAC_BOT_PAT }}
+        image-names: charts/${{ matrix.image }}
+        image-tags: "!0.0.0-dev !0.0.0-nightly 0.0.0-dev.* 0.0.0-nightly.*"
+        tag-selection: both
+        cut-off: 4w
+        timestamp-to-use: updated_at
+        dry-run: false

--- a/.github/workflows/helm-integration.yaml
+++ b/.github/workflows/helm-integration.yaml
@@ -14,11 +14,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        submodules: recursive
+        submodules: false
         persist-credentials: false
 
-    - name: Update submodules to pinned commits
-      run: git submodule update --init --recursive
+    - name: Checkout BMF submodule (still uses file:// deps)
+      run: git submodule update --init base/bare-metal-fulfillment-operator
 
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -51,5 +51,10 @@ jobs:
             > /dev/null
         done
 
-    - name: Validate values schema
+    - name: Validate values schema JSON
       run: python3 -m json.tool charts/osac/values.schema.json > /dev/null
+
+    - name: Check values keys have schema entries
+      run: |
+        pip install --quiet pyyaml
+        make validate-values-schema

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -15,8 +15,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        submodules: recursive
+        submodules: false
         persist-credentials: false
+
+    - name: Checkout BMF submodule (still uses file:// deps)
+      run: git submodule update --init base/bare-metal-fulfillment-operator
 
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -125,38 +125,16 @@ jobs:
         echo "bmf-operator-crds:  ${bmf_crds_ver}"
         echo "bmf-operator:       ${bmf_ver}"
 
-    - name: Rewrite dependencies to OCI references
+    - name: Rewrite umbrella dependencies to OCI
       env:
-        CRDS_VER: ${{ steps.versions.outputs.crds_ver }}
+        OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+        OPERATOR_CRDS_VER: ${{ steps.versions.outputs.crds_ver }}
         OPERATOR_VER: ${{ steps.versions.outputs.operator_ver }}
         SERVICE_VER: ${{ steps.versions.outputs.service_ver }}
         AAP_VER: ${{ steps.versions.outputs.aap_ver }}
         BMF_CRDS_VER: ${{ steps.versions.outputs.bmf_crds_ver }}
         BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
-      run: |
-        cd charts/osac
-        OCI_REPO="oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}"
-
-        yq -i "
-          (.dependencies[] | select(.name == \"osac-operator-crds\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"osac-operator-crds\")) .version = \"${CRDS_VER}\" |
-          (.dependencies[] | select(.name == \"osac-operator\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"osac-operator\")) .version = \"${OPERATOR_VER}\" |
-          (.dependencies[] | select(.name == \"fulfillment-service\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"fulfillment-service\")) .version = \"${SERVICE_VER}\" |
-          (.dependencies[] | select(.name == \"osac-aap\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"osac-aap\")) .version = \"${AAP_VER}\" |
-          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .version = \"${BMF_CRDS_VER}\" |
-          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .version = \"${BMF_VER}\"
-        " Chart.yaml
-
-        # Remove stale Chart.lock so helm pulls fresh from OCI
-        rm -f Chart.lock
-
-        echo "--- Updated Chart.yaml ---"
-        cat Chart.yaml
+      run: ./scripts/rewrite-chart-deps.sh
 
     - name: Build dependencies from OCI
       run: helm dependency build charts/osac/
@@ -169,17 +147,10 @@ jobs:
           -e "s|tag: latest|tag: v${VERSION}|g" \
           charts/osac/values.yaml
 
-    - name: Package chart
-      env:
-        VERSION: ${{ steps.versions.outputs.version }}
-      run: |
-        helm package charts/osac/ \
-          --version "${VERSION}" \
-          --app-version "${VERSION}"
-
-    - name: Push chart to GHCR
-      env:
-        VERSION: ${{ steps.versions.outputs.version }}
-      run: |
-        helm push "osac-${VERSION}.tgz" \
-          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+    - name: Publish umbrella chart
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: charts/osac
+        version: ${{ steps.versions.outputs.version }}
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}

--- a/.github/workflows/publish-dev-charts.yaml
+++ b/.github/workflows/publish-dev-charts.yaml
@@ -1,0 +1,126 @@
+name: Publish Dev Charts
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: publish-dev-charts
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  CHARTS_REPO: ${{ github.repository_owner }}/charts
+
+jobs:
+  publish-dev-charts:
+    name: Publish dev charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      with:
+        submodules: recursive
+        persist-credentials: false
+
+    - name: Set up Helm
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+    - name: Compute submodule versions
+      id: submodules
+      uses: ./.github/actions/compute-submodule-versions
+
+    - name: Compute installer version
+      id: versions
+      run: |
+        echo "installer_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+    # --- Dependency charts ---
+
+    - name: Publish osac-operator-crds
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-operator/charts/operator-crds
+        version: 0.0.0-dev.${{ steps.submodules.outputs.operator_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish osac-operator
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-operator/charts/operator
+        version: 0.0.0-dev.${{ steps.submodules.outputs.operator_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish fulfillment-service
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-fulfillment-service/charts/service
+        version: 0.0.0-dev.${{ steps.submodules.outputs.service_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish osac-aap
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-aap/charts/aap
+        version: 0.0.0-dev.${{ steps.submodules.outputs.aap_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish bare-metal-fulfillment-operator-crds
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/bare-metal-fulfillment-operator/charts/operator-crds
+        version: 0.0.0-dev.${{ steps.submodules.outputs.bmf_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish bare-metal-fulfillment-operator
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/bare-metal-fulfillment-operator/charts/operator
+        version: 0.0.0-dev.${{ steps.submodules.outputs.bmf_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    # --- Umbrella chart ---
+
+    - name: Rewrite umbrella dependencies to OCI
+      env:
+        OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+        OPERATOR_CRDS_VER: 0.0.0-dev.${{ steps.submodules.outputs.operator_sha }}
+        OPERATOR_VER: 0.0.0-dev.${{ steps.submodules.outputs.operator_sha }}
+        SERVICE_VER: 0.0.0-dev.${{ steps.submodules.outputs.service_sha }}
+        AAP_VER: 0.0.0-dev.${{ steps.submodules.outputs.aap_sha }}
+        BMF_CRDS_VER: 0.0.0-dev.${{ steps.submodules.outputs.bmf_sha }}
+        BMF_VER: 0.0.0-dev.${{ steps.submodules.outputs.bmf_sha }}
+      run: ./scripts/rewrite-chart-deps.sh
+
+    - name: Build umbrella dependencies from OCI
+      run: helm dependency build charts/osac/
+
+    - name: Publish umbrella chart
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: charts/osac
+        version: 0.0.0-dev.${{ steps.versions.outputs.installer_sha }}
+        floating-version: 0.0.0-dev
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}

--- a/.github/workflows/publish-nightly-charts.yaml
+++ b/.github/workflows/publish-nightly-charts.yaml
@@ -1,0 +1,129 @@
+name: Publish Nightly Charts
+
+on:
+  schedule:
+    - cron: '23 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-nightly-charts
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  CHARTS_REPO: ${{ github.repository_owner }}/charts
+
+jobs:
+  publish-nightly-charts:
+    name: Publish nightly charts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      with:
+        submodules: recursive
+        persist-credentials: false
+
+    - name: Update submodules to latest main
+      run: git submodule update --init --recursive --remote
+
+    - name: Set up Helm
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+    - name: Compute submodule versions
+      id: submodules
+      uses: ./.github/actions/compute-submodule-versions
+
+    - name: Compute nightly date
+      id: versions
+      run: |
+        echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+    # --- Dependency charts ---
+
+    - name: Publish osac-operator-crds
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-operator/charts/operator-crds
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish osac-operator
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-operator/charts/operator
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish fulfillment-service
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-fulfillment-service/charts/service
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.service_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish osac-aap
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/osac-aap/charts/aap
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.aap_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish bare-metal-fulfillment-operator-crds
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/bare-metal-fulfillment-operator/charts/operator-crds
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    - name: Publish bare-metal-fulfillment-operator
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: base/bare-metal-fulfillment-operator/charts/operator
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}
+
+    # --- Umbrella chart ---
+
+    - name: Rewrite umbrella dependencies to OCI
+      env:
+        OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+        OPERATOR_CRDS_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
+        OPERATOR_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
+        SERVICE_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.service_sha }}
+        AAP_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.aap_sha }}
+        BMF_CRDS_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
+        BMF_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
+      run: ./scripts/rewrite-chart-deps.sh
+
+    - name: Build umbrella dependencies from OCI
+      run: helm dependency build charts/osac/
+
+    - name: Publish umbrella chart
+      uses: ./.github/actions/publish-helm-chart
+      with:
+        chart-dir: charts/osac
+        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}
+        floating-version: 0.0.0-nightly
+        registry: ${{ env.REGISTRY }}
+        charts-repo: ${{ env.CHARTS_REPO }}

--- a/.github/workflows/publish-nightly-charts.yaml
+++ b/.github/workflows/publish-nightly-charts.yaml
@@ -24,11 +24,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
-        submodules: recursive
         persist-credentials: false
-
-    - name: Update submodules to latest main
-      run: git submodule update --init --recursive --remote
 
     - name: Set up Helm
       uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2  # v5.0.0
@@ -38,82 +34,24 @@ jobs:
     - name: Log in to GHCR
       run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
 
-    - name: Compute submodule versions
-      id: submodules
-      uses: ./.github/actions/compute-submodule-versions
-
     - name: Compute nightly date
       id: versions
       run: |
         echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
-    # --- Dependency charts ---
-
-    - name: Publish osac-operator-crds
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/osac-operator/charts/operator-crds
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    - name: Publish osac-operator
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/osac-operator/charts/operator
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    - name: Publish fulfillment-service
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/osac-fulfillment-service/charts/service
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.service_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    - name: Publish osac-aap
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/osac-aap/charts/aap
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.aap_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    - name: Publish bare-metal-fulfillment-operator-crds
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/bare-metal-fulfillment-operator/charts/operator-crds
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    - name: Publish bare-metal-fulfillment-operator
-      uses: ./.github/actions/publish-helm-chart
-      with:
-        chart-dir: base/bare-metal-fulfillment-operator/charts/operator
-        version: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
-        floating-version: 0.0.0-nightly
-        registry: ${{ env.REGISTRY }}
-        charts-repo: ${{ env.CHARTS_REPO }}
-
-    # --- Umbrella chart ---
+    # Subcharts are published at 0.0.0-dev by the dev workflow on each
+    # component merge to main.  The nightly just assembles the umbrella
+    # chart from the latest floating dev tags — no submodules needed.
 
     - name: Rewrite umbrella dependencies to OCI
       env:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
-        OPERATOR_CRDS_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
-        OPERATOR_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.operator_sha }}
-        SERVICE_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.service_sha }}
-        AAP_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.aap_sha }}
-        BMF_CRDS_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
-        BMF_VER: 0.0.0-nightly.${{ steps.versions.outputs.date }}.${{ steps.submodules.outputs.bmf_sha }}
+        OPERATOR_CRDS_VER: 0.0.0-dev
+        OPERATOR_VER: 0.0.0-dev
+        SERVICE_VER: 0.0.0-dev
+        AAP_VER: 0.0.0-dev
+        BMF_CRDS_VER: 0.0.0-dev
+        BMF_VER: 0.0.0-dev
       run: ./scripts/rewrite-chart-deps.sh
 
     - name: Build umbrella dependencies from OCI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,15 @@ oc apply -k overlays/<overlay-name> -n <namespace>
 # Automated end-to-end deployment (installs prerequisites + deploys + configures)
 INSTALLER_NAMESPACE=<namespace> INSTALLER_KUSTOMIZE_OVERLAY=<overlay-name> ./scripts/setup.sh
 
+# Build Helm chart dependencies from OCI registry (default)
+make helm-deps
+
+# Build Helm chart dependencies from local submodules (for development)
+make dev-deps
+
+# Bump a subchart version in the umbrella chart
+make bump-chart BUMP_CHART=fulfillment-service BUMP_VERSION=0.0.68
+
 # Run pre-commit hooks
 pre-commit run --all-files
 
@@ -102,6 +111,7 @@ for d in overlays/*/; do kustomize build "$d" > "/tmp/after-$(basename $d).yaml"
 
 ## Helm Chart Conventions
 
+- **Subchart dependencies use OCI registry references** -- `charts/osac/Chart.yaml` pins subchart versions from `oci://ghcr.io/osac-project/charts`. To update a subchart: merge the change in the component repo, tag a release, then run `make bump-chart BUMP_CHART=<name> BUMP_VERSION=<ver>` in osac-installer. For local development with uncommitted subchart changes, use `make dev-deps` to temporarily swap in file:// refs from submodules.
 - **Every new value must have a matching schema entry** -- when adding or modifying keys in `charts/osac/values.yaml`, always add the corresponding property definition to `charts/osac/values.schema.json`. Use `enum` constraints for fields with a known set of valid values (e.g., network/DNS backend classes). The schema is both validation and documentation -- incomplete schemas allow silent misconfiguration.
 
 ## Key Conventions

--- a/Containerfile.helm
+++ b/Containerfile.helm
@@ -1,0 +1,15 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG HELM_VERSION=v3.17.0
+ARG YQ_VERSION=v4.44.6
+
+RUN microdnf install -y tar gzip git make python3 && \
+    microdnf clean all && \
+    ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')" && \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | \
+    tar xz --strip-components=1 -C /usr/local/bin "linux-${ARCH}/helm" && \
+    curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH}" && \
+    chmod +x /usr/local/bin/yq
+
+WORKDIR /charts
+ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,35 @@ DEPLOY_MODE ?= helm
 help: ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
+BUMP_CHART ?=
+BUMP_VERSION ?=
+
 ##@ Helm Chart Management
 
 .PHONY: sync-charts
-sync-charts: ## Update submodules to latest main and rebuild chart dependencies
+sync-charts: ## Update submodules to latest main (for kustomize and dev-deps)
 	git submodule update --init --recursive --remote
-	helm dependency build charts/osac/
 
 .PHONY: helm-deps
-helm-deps: ## Build Helm chart dependencies
+helm-deps: ## Build Helm chart dependencies (pulls from OCI registry)
 	helm dependency build charts/osac/
+
+.PHONY: dev-deps
+dev-deps: ## Build chart deps from local submodules (for development)
+	git submodule update --init --recursive
+	cp charts/osac/Chart.yaml charts/osac/Chart.yaml.bak
+	./scripts/rewrite-chart-deps-local.sh && \
+		helm dependency build charts/osac/; \
+		rc=$$?; mv charts/osac/Chart.yaml.bak charts/osac/Chart.yaml; exit $$rc
+
+.PHONY: bump-chart
+bump-chart: ## Bump a subchart version: make bump-chart BUMP_CHART=fulfillment-service BUMP_VERSION=0.0.68
+	@test -n "$(BUMP_CHART)" || { echo "Usage: make bump-chart BUMP_CHART=<name> BUMP_VERSION=<ver>"; exit 1; }
+	@test -n "$(BUMP_VERSION)" || { echo "Usage: make bump-chart BUMP_CHART=<name> BUMP_VERSION=<ver>"; exit 1; }
+	yq -i '(.dependencies[] | select(.name == "$(BUMP_CHART)")).version = "$(BUMP_VERSION)"' charts/osac/Chart.yaml
+	rm -f charts/osac/Chart.lock
+	helm dependency build charts/osac/
+	@echo "Bumped $(BUMP_CHART) to $(BUMP_VERSION)"
 
 .PHONY: helm-lint
 helm-lint: ## Lint the umbrella chart
@@ -50,6 +69,19 @@ setup: ## Run setup.sh with DEPLOY_MODE=helm
 .PHONY: teardown
 teardown: ## Teardown OSAC deployment
 	./scripts/teardown.sh
+
+##@ Container
+
+HELM_IMAGE ?= osac-installer-helm:latest
+
+.PHONY: container-build
+container-build: ## Build the helm tooling container
+	podman build -t $(HELM_IMAGE) -f Containerfile.helm .
+
+.PHONY: container-run
+container-run: ## Run a make target in the container: make container-run TARGET=helm-lint
+	@test -n "$(TARGET)" || { echo "Usage: make container-run TARGET=<target>"; exit 1; }
+	podman run --rm -v "$$(pwd):/charts:Z" -w /charts $(HELM_IMAGE) $(TARGET)
 
 ##@ Validation
 

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,10 @@ teardown: ## Teardown OSAC deployment
 helm-validate: helm-lint ## Validate Helm chart (lint + template)
 	helm template osac charts/osac/ --values $(VALUES_FILE) > /dev/null
 	@echo "Validation passed."
+
+.PHONY: validate-values-schema
+validate-values-schema: ## Check that every values key has a matching schema entry
+	python3 scripts/validate-values-schema.py charts/osac/values.schema.json \
+		charts/osac/values.yaml \
+		charts/osac/values-example.yaml \
+		values/*/values.yaml

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -6,21 +6,23 @@ version: 0.0.1
 
 dependencies:
   - name: osac-operator-crds
-    version: ">=0.0.0"
-    repository: "file://../../base/osac-operator/charts/operator-crds"
+    version: "0.0.2"
+    repository: "oci://ghcr.io/osac-project/charts"
     alias: operatorCrds
   - name: osac-operator
-    version: ">=0.0.0"
-    repository: "file://../../base/osac-operator/charts/operator"
+    version: "0.0.2"
+    repository: "oci://ghcr.io/osac-project/charts"
     alias: operator
   - name: fulfillment-service
-    version: ">=0.0.0"
-    repository: "file://../../base/osac-fulfillment-service/charts/service"
+    version: "0.0.67"
+    repository: "oci://ghcr.io/osac-project/charts"
     alias: service
   - name: osac-aap
-    version: ">=0.0.0"
-    repository: "file://../../base/osac-aap/charts/aap"
+    version: "0.0.4"
+    repository: "oci://ghcr.io/osac-project/charts"
     alias: aap
+  # TODO: Switch to OCI once bare-metal-fulfillment-operator publishes its first
+  # tagged release (requires fixing publish-charts.yaml in that repo first).
   - name: bare-metal-fulfillment-operator-crds
     version: ">=0.0.0"
     repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator-crds"

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -92,7 +92,21 @@
             },
             "token": {
               "type": "string",
-              "description": "AAP API token"
+              "description": "AAP API token (literal value, alternative to tokenSecret)"
+            },
+            "tokenSecret": {
+              "type": "object",
+              "description": "Kubernetes Secret reference for the AAP API token (alternative to token)",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the Secret containing the AAP API token"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key within the Secret that holds the token value"
+                }
+              }
             },
             "insecureSkipVerify": {
               "type": "string",
@@ -125,6 +139,17 @@
             }
           }
         },
+        "provisioning": {
+          "type": "object",
+          "description": "Provisioning backend configuration",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Provisioning provider (e.g. aap)",
+              "default": "aap"
+            }
+          }
+        },
         "controllers": {
           "type": "object",
           "description": "Enable or disable individual operator controllers",
@@ -148,6 +173,11 @@
               "type": "boolean",
               "description": "Enable networking controllers",
               "default": true
+            },
+            "storageController": {
+              "type": "boolean",
+              "description": "Enable storage controller",
+              "default": false
             }
           }
         },
@@ -267,6 +297,13 @@
             "controllerCredentials": {
               "type": "array",
               "description": "Controller credential volume sources"
+            },
+            "emergencyServiceAccounts": {
+              "type": "array",
+              "description": "Service accounts granted emergency access (bypass normal OIDC auth)",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
@@ -572,6 +609,16 @@
             "config": {
               "type": "object",
               "description": "Additional key-value pairs for the network instance group ConfigMap"
+            }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "description": "Storage instance group extra config",
+          "properties": {
+            "config": {
+              "type": "object",
+              "description": "Additional key-value pairs for the storage instance group ConfigMap"
             }
           }
         }
@@ -941,6 +988,98 @@
             "SERVER_SSH_BASTION_KEY": {
               "type": "string",
               "description": "SSH private key for bastion access"
+            }
+          }
+        }
+      }
+    },
+    "importAgents": {
+      "type": "object",
+      "description": "ConfigMap-based bare metal agent import configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ConfigMap-based bare metal agent import (sets OSAC_IMPORT_AGENTS_ENABLED in config-as-code-ig Secret)",
+          "default": false
+        },
+        "servers": {
+          "type": "array",
+          "description": "Server inventory for bare metal agent import. Each entry provisions a BareMetalHost CR.",
+          "items": {
+            "type": "object",
+            "required": ["name", "bmc_url", "bmc_secret", "boot_mac", "netris_server_name", "resource_class"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Server hostname, used as the BareMetalHost CR name"
+              },
+              "bmc_url": {
+                "type": "string",
+                "description": "Redfish BMC address for virtual media boot"
+              },
+              "bmc_secret": {
+                "type": "string",
+                "description": "Name of the Kubernetes Secret with BMC credentials"
+              },
+              "boot_mac": {
+                "type": "string",
+                "description": "Boot NIC MAC address"
+              },
+              "netris_server_name": {
+                "type": "string",
+                "description": "Netris server name label for the Agent"
+              },
+              "resource_class": {
+                "type": "string",
+                "description": "Hardware type label for the Agent"
+              },
+              "disable_bmc_cert_verification": {
+                "type": "boolean",
+                "description": "Per-server override for BMC TLS certificate verification"
+              }
+            }
+          }
+        }
+      }
+    },
+    "storageFulfillment": {
+      "type": "object",
+      "description": "ConfigMap and Secret for the AAP storage-operations instance group",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create storage-fulfillment ConfigMap and Secret",
+          "default": false
+        },
+        "config": {
+          "type": "object",
+          "description": "Environment variables for the storage-operations instance group",
+          "properties": {
+            "STORAGE_TIERS": {
+              "type": "string",
+              "description": "Comma-separated list of available storage tiers"
+            },
+            "STORAGE_SNAPSHOTS_ENABLED": {
+              "type": "string",
+              "description": "Enable storage snapshot support"
+            }
+          }
+        },
+        "secret": {
+          "type": "object",
+          "description": "Secret values for the storage-operations instance group",
+          "properties": {
+            "VAST_ENDPOINT": {
+              "type": "string",
+              "description": "VAST storage API endpoint URL"
+            },
+            "VAST_USERNAME": {
+              "type": "string",
+              "description": "VAST storage API username"
+            },
+            "VAST_PASSWORD": {
+              "type": "string",
+              "description": "VAST storage API password"
             }
           }
         }

--- a/docs/helm-chart-builds.md
+++ b/docs/helm-chart-builds.md
@@ -1,0 +1,251 @@
+# Helm Chart Build Modes
+
+The OSAC umbrella chart (`charts/osac/`) assembles six component subcharts into a single deployable unit. There are four distinct modes for building and consuming these charts, each serving a different stage of the development lifecycle.
+
+All published charts live in the OCI registry at `oci://ghcr.io/osac-project/charts`.
+
+## Overview
+
+| Mode | Subchart source | Umbrella version | Trigger | Use case |
+|------|----------------|-----------------|---------|----------|
+| **Local dev** | Local submodules (`file://`) | N/A (not published) | `make dev-deps` | Iterating on uncommitted subchart changes |
+| **Dev** | OCI, pinned to submodule SHAs | `0.0.0-dev.<sha>` | Push to `main` | CI environments tracking latest main |
+| **Nightly** | OCI, floating `0.0.0-dev` tags | `0.0.0-nightly.<date>` | Daily at 03:23 UTC | Nightly integration testing |
+| **Release** | OCI, pinned to tagged versions | `<semver>` (e.g. `0.1.0`) | `v*` tag or manual dispatch | Production deployments |
+
+## Local Development
+
+**Purpose:** Iterate on subchart changes before they're merged or published.
+
+The committed `Chart.yaml` points to pinned OCI versions for most subcharts. The `make dev-deps` target temporarily rewrites those to `file://` references against local git submodules, builds dependencies, then restores `Chart.yaml`.
+
+```bash
+# Sync submodules to latest main
+make sync-charts
+
+# Build from local submodules
+make dev-deps
+```
+
+**What happens under the hood:**
+
+1. `git submodule update --init --recursive` ensures submodules are checked out
+2. `scripts/rewrite-chart-deps-local.sh` replaces OCI refs with `file://` paths
+3. `helm dependency build charts/osac/` resolves charts from submodule directories
+4. `Chart.yaml` is restored to its committed state (OCI refs)
+
+**Resulting chart versions:**
+
+```
+osac-operator-crds          0.0.0   (from base/osac-operator/charts/operator-crds)
+osac-operator               0.0.0   (from base/osac-operator/charts/operator)
+fulfillment-service         0.0.0   (from base/osac-fulfillment-service/charts/service)
+osac-aap                    0.0.0   (from base/osac-aap/charts/aap)
+bmf-crds                    0.0.0   (from base/bare-metal-fulfillment-operator/charts/operator-crds)
+bmf                         0.0.0   (from base/bare-metal-fulfillment-operator/charts/operator)
+```
+
+All versions are `0.0.0` because that's what the component `Chart.yaml` files have hardcoded — real versions are assigned at publish time.
+
+**When to use:** You're changing a subchart template or values and want to test the umbrella chart locally before pushing.
+
+## Dev Builds
+
+**Purpose:** Provide a traceable, per-commit build of every chart from the latest `main` of each component.
+
+**Trigger:** Every push to `main` on `osac-installer` (workflow: `publish-dev-charts.yaml`).
+
+**How it works:**
+
+1. Checks out `osac-installer` with all submodules at their pinned commits
+2. Computes short SHAs for each submodule (e.g. `8220502` for osac-operator)
+3. Publishes each subchart from its submodule directory with version `0.0.0-dev.<sha>` and a floating `0.0.0-dev` tag
+4. Rewrites the umbrella `Chart.yaml` to reference each subchart at its `0.0.0-dev.<sha>` version
+5. Publishes the umbrella chart as `0.0.0-dev.<installer-sha>` with a floating `0.0.0-dev` tag
+
+**Resulting chart versions (example):**
+
+```
+osac (umbrella)             0.0.0-dev.925a351        (also tagged 0.0.0-dev)
+├── osac-operator-crds      0.0.0-dev.8220502
+├── osac-operator           0.0.0-dev.8220502
+├── fulfillment-service     0.0.0-dev.6b1f439
+├── osac-aap                0.0.0-dev.89f41e7
+├── bmf-crds                0.0.0-dev.0a06955
+└── bmf                     0.0.0-dev.0a06955
+```
+
+**Key properties:**
+
+- **Traceable:** Each version embeds the exact submodule commit SHA — you can map any deployed chart back to a source commit
+- **Floating tag:** `0.0.0-dev` always points to the latest dev build of each chart — use it when you want "whatever is latest" without tracking SHAs
+- **Submodule-driven:** The subchart versions come from whatever commits the submodules are pinned to in `osac-installer`, not from the component repos directly. Bumping a submodule pointer and merging to `main` triggers new dev charts.
+
+**To deploy the latest dev build:**
+
+```bash
+helm install osac oci://ghcr.io/osac-project/charts/osac --version 0.0.0-dev
+```
+
+**To deploy a specific dev build:**
+
+```bash
+helm install osac oci://ghcr.io/osac-project/charts/osac --version 0.0.0-dev.925a351
+```
+
+## Nightly Builds
+
+**Purpose:** Assemble the umbrella chart from the latest floating `0.0.0-dev` subcharts — a single daily snapshot that always picks up the most recent component merges without submodule management.
+
+**Trigger:** Daily at 03:23 UTC (workflow: `publish-nightly-charts.yaml`). Also available via manual dispatch.
+
+**How it works:**
+
+1. Checks out `osac-installer` (no submodules needed)
+2. Rewrites the umbrella `Chart.yaml` to reference all subcharts at the `0.0.0-dev` floating tag
+3. `helm dependency build` pulls whatever `0.0.0-dev` resolves to at that moment
+4. Publishes the umbrella chart as `0.0.0-nightly.<YYYYMMDD>` with a floating `0.0.0-nightly` tag
+
+**Resulting chart versions (example for 2026-06-26):**
+
+```
+osac (umbrella)             0.0.0-nightly.20260626   (also tagged 0.0.0-nightly)
+├── osac-operator-crds      0.0.0-dev               (floating, resolves to latest)
+├── osac-operator           0.0.0-dev
+├── fulfillment-service     0.0.0-dev
+├── osac-aap                0.0.0-dev
+├── bmf-crds                0.0.0-dev
+└── bmf                     0.0.0-dev
+```
+
+**Key properties:**
+
+- **All-latest:** Every subchart is the most recent `0.0.0-dev` version — no submodule pinning involved
+- **Date-stamped:** Nightly versions include the date for easy identification
+- **No submodules required:** Unlike dev builds, the nightly workflow doesn't check out submodules — it relies entirely on previously published `0.0.0-dev` charts in the OCI registry
+- **Less traceable:** Subcharts are pinned to the floating `0.0.0-dev` tag, so you can't determine exact component commits from the chart metadata alone
+
+**To deploy the latest nightly:**
+
+```bash
+helm install osac oci://ghcr.io/osac-project/charts/osac --version 0.0.0-nightly
+```
+
+**To deploy a specific nightly:**
+
+```bash
+helm install osac oci://ghcr.io/osac-project/charts/osac --version 0.0.0-nightly.20260626
+```
+
+## Release Builds
+
+**Purpose:** Produce a versioned, production-grade umbrella chart with each subchart pinned to a specific tagged release.
+
+**Trigger:** Pushing a `v*` tag on `osac-installer`, or manual dispatch with explicit version inputs.
+
+**How it works:**
+
+1. Resolves component versions from workflow inputs (manual dispatch) or defaults to the umbrella version (tag push)
+2. Rewrites the umbrella `Chart.yaml` to reference each subchart at its specified version
+3. `helm dependency build` pulls the exact tagged versions from the OCI registry
+4. Replaces `tag: latest` in `values.yaml` with `tag: v<version>` for container images
+5. Publishes the umbrella chart at the specified version
+
+**Inputs (manual dispatch):**
+
+| Input | Example | Description |
+|-------|---------|-------------|
+| `version` | `0.1.0` | Umbrella chart version (defaults to git tag) |
+| `operator_crds_version` | `0.0.2` | osac-operator-crds chart version |
+| `operator_version` | `0.0.2` | osac-operator chart version |
+| `service_version` | `0.0.67` | fulfillment-service chart version |
+| `aap_version` | `0.0.4` | osac-aap chart version |
+
+**Resulting chart versions (example):**
+
+```
+osac (umbrella)             0.1.0
+├── osac-operator-crds      0.0.2
+├── osac-operator           0.0.2
+├── fulfillment-service     0.0.67
+├── osac-aap                0.0.4
+├── bmf-crds                0.1.0                    (defaults to umbrella version)
+└── bmf                     0.1.0
+```
+
+**Key properties:**
+
+- **Fully pinned:** Every subchart version is explicit and immutable
+- **Requires pre-published subcharts:** Each component must have its chart published at the specified version before the umbrella release can succeed
+- **Image tags updated:** Container image references in `values.yaml` are rewritten to match the release version
+
+**To deploy a release:**
+
+```bash
+helm install osac oci://ghcr.io/osac-project/charts/osac --version 0.1.0
+```
+
+## The Committed Chart.yaml
+
+The `Chart.yaml` checked into `main` represents the **dev build baseline** — it uses hardcoded OCI versions that track the latest known-good releases:
+
+```yaml
+dependencies:
+  - name: osac-operator-crds
+    version: "0.0.2"
+    repository: "oci://ghcr.io/osac-project/charts"
+  - name: osac-operator
+    version: "0.0.2"
+    repository: "oci://ghcr.io/osac-project/charts"
+  - name: fulfillment-service
+    version: "0.0.67"
+    repository: "oci://ghcr.io/osac-project/charts"
+  - name: osac-aap
+    version: "0.0.4"
+    repository: "oci://ghcr.io/osac-project/charts"
+```
+
+These versions are updated manually when a component publishes a new release:
+
+```bash
+make bump-chart BUMP_CHART=fulfillment-service BUMP_VERSION=0.0.68
+```
+
+All three publish workflows (`dev`, `nightly`, `release`) override these versions at build time via `scripts/rewrite-chart-deps.sh`. The committed versions serve two purposes:
+
+1. **`make helm-deps` works out of the box** — anyone can `helm dependency build charts/osac/` without submodules or special tooling
+2. **PR validation uses real published charts** — the CI lint workflow pulls from the OCI registry, catching version reference errors before merge
+
+## Version Lifecycle and Cleanup
+
+Chart versions accumulate in the OCI registry. The `cleanup-charts.yaml` workflow runs weekly (Mondays at 04:41 UTC) and deletes `0.0.0-dev.*` and `0.0.0-nightly.*` versions older than 4 weeks. The floating tags (`0.0.0-dev`, `0.0.0-nightly`) and tagged releases are preserved indefinitely.
+
+```
+Kept forever:      0.0.0-dev, 0.0.0-nightly, 0.0.2, 0.0.67, 0.1.0, ...
+Cleaned after 4w:  0.0.0-dev.8220502, 0.0.0-nightly.20260601, ...
+```
+
+## Quick Reference
+
+```bash
+# Local development (uncommitted subchart changes)
+make sync-charts      # update submodules
+make dev-deps         # build from local submodules
+
+# Default OCI build (uses committed pinned versions)
+make helm-deps        # pull from registry
+
+# Bump a subchart after a new component release
+make bump-chart BUMP_CHART=osac-operator BUMP_VERSION=0.0.3
+
+# Lint and validate
+make helm-lint        # lint with OCI deps
+make helm-validate    # lint + template
+
+# Deploy
+make helm-deploy      # deploy to current cluster
+
+# Run targets in a container (has helm, yq, make, git)
+make container-build
+make container-run TARGET=helm-lint
+```

--- a/scripts/rewrite-chart-deps-local.sh
+++ b/scripts/rewrite-chart-deps-local.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Rewrite umbrella Chart.yaml OCI dependencies back to file:// for local dev.
+# Counterpart to rewrite-chart-deps.sh.
+#
+# Usage:
+#   ./scripts/rewrite-chart-deps-local.sh [charts/osac/Chart.yaml]
+#
+set -euo pipefail
+
+CHART_YAML="${1:-charts/osac/Chart.yaml}"
+
+yq -i '
+  (.dependencies[] | select(.name == "osac-operator-crds")) .repository = "file://../../base/osac-operator/charts/operator-crds" |
+  (.dependencies[] | select(.name == "osac-operator-crds")) .version = ">=0.0.0" |
+  (.dependencies[] | select(.name == "osac-operator")) .repository = "file://../../base/osac-operator/charts/operator" |
+  (.dependencies[] | select(.name == "osac-operator")) .version = ">=0.0.0" |
+  (.dependencies[] | select(.name == "fulfillment-service")) .repository = "file://../../base/osac-fulfillment-service/charts/service" |
+  (.dependencies[] | select(.name == "fulfillment-service")) .version = ">=0.0.0" |
+  (.dependencies[] | select(.name == "osac-aap")) .repository = "file://../../base/osac-aap/charts/aap" |
+  (.dependencies[] | select(.name == "osac-aap")) .version = ">=0.0.0"
+' "${CHART_YAML}"
+
+rm -f "$(dirname "${CHART_YAML}")/Chart.lock"
+
+echo "--- Rewrote ${CHART_YAML} to local file:// deps ---"

--- a/scripts/rewrite-chart-deps.sh
+++ b/scripts/rewrite-chart-deps.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Rewrite umbrella Chart.yaml dependencies from file:// to OCI references.
+#
+# Usage:
+#   OCI_REPO=oci://ghcr.io/osac-project/charts \
+#   OPERATOR_CRDS_VER=0.0.1 OPERATOR_VER=0.0.1 \
+#   SERVICE_VER=0.0.1 AAP_VER=0.0.1 \
+#   BMF_CRDS_VER=0.0.1 BMF_VER=0.0.1 \
+#     ./scripts/rewrite-chart-deps.sh
+#
+set -euo pipefail
+
+: "${OCI_REPO:?OCI_REPO is required}"
+: "${OPERATOR_CRDS_VER:?OPERATOR_CRDS_VER is required}"
+: "${OPERATOR_VER:?OPERATOR_VER is required}"
+: "${SERVICE_VER:?SERVICE_VER is required}"
+: "${AAP_VER:?AAP_VER is required}"
+: "${BMF_CRDS_VER:?BMF_CRDS_VER is required}"
+: "${BMF_VER:?BMF_VER is required}"
+
+CHART_YAML="${1:-charts/osac/Chart.yaml}"
+
+yq -i "
+  (.dependencies[] | select(.name == \"osac-operator-crds\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"osac-operator-crds\")) .version = \"${OPERATOR_CRDS_VER}\" |
+  (.dependencies[] | select(.name == \"osac-operator\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"osac-operator\")) .version = \"${OPERATOR_VER}\" |
+  (.dependencies[] | select(.name == \"fulfillment-service\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"fulfillment-service\")) .version = \"${SERVICE_VER}\" |
+  (.dependencies[] | select(.name == \"osac-aap\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"osac-aap\")) .version = \"${AAP_VER}\" |
+  (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .version = \"${BMF_CRDS_VER}\" |
+  (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .repository = \"${OCI_REPO}\" |
+  (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .version = \"${BMF_VER}\"
+" "${CHART_YAML}"
+
+rm -f "$(dirname "${CHART_YAML}")/Chart.lock"
+
+echo "--- Updated ${CHART_YAML} ---"
+cat "${CHART_YAML}"

--- a/scripts/validate-values-schema.py
+++ b/scripts/validate-values-schema.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate that every key in Helm values files has a matching entry in values.schema.json.
+
+Walks YAML values files recursively and checks that each dot-separated key path
+exists in the JSON Schema's properties hierarchy.
+
+Usage:
+    validate-values-schema.py <schema.json> <values.yaml> [<values.yaml> ...]
+
+Exit codes:
+    0 — all keys covered
+    1 — missing schema entries found
+"""
+
+import json
+import sys
+
+import yaml
+
+
+def extract_paths(obj, prefix=""):
+    """Yield all dot-separated key paths from a nested dict."""
+    if not isinstance(obj, dict):
+        return
+    for key, value in obj.items():
+        path = f"{prefix}.{key}" if prefix else key
+        yield path
+        if isinstance(value, dict) and value:
+            yield from extract_paths(value, path)
+
+
+def schema_has_path(schema, path):
+    """Check whether a dot-separated path exists in the JSON Schema properties tree."""
+    node = schema
+    for part in path.split("."):
+        props = node.get("properties", {})
+        if part not in props:
+            return False
+        node = props[part]
+    return True
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <schema.json> <values.yaml> [<values.yaml> ...]",
+              file=sys.stderr)
+        return 1
+
+    schema_path = sys.argv[1]
+    values_paths = sys.argv[2:]
+
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    errors = 0
+    for vpath in values_paths:
+        with open(vpath) as f:
+            values = yaml.safe_load(f)
+        if not isinstance(values, dict):
+            continue
+
+        missing = sorted(
+            p for p in extract_paths(values) if not schema_has_path(schema, p)
+        )
+        for p in missing:
+            print(f"{vpath}: key '{p}' has no schema entry")
+            errors += 1
+
+    if errors:
+        print(f"\n{errors} value key(s) missing from schema.", file=sys.stderr)
+        return 1
+
+    print("All value keys are covered by the schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Extract publish-helm-chart composite action for package+push logic
- Extract compute-submodule-versions composite action for SHA resolution
- Extract rewrite-chart-deps.sh for Chart.yaml dependency rewriting
- Refactor publish-charts.yaml to use shared action and script
- Add publish-dev-charts.yaml: publish on every merge to main with version 0.0.0-dev.<sha> and floating 0.0.0-dev
- Add publish-nightly-charts.yaml: daily build from latest submodules with version 0.0.0-nightly.<date>.<sha> and floating 0.0.0-nightly
- Add cleanup-charts.yaml: weekly pruning of dev/nightly versions older than 4 weeks, preserving floating tags and released versions

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing for dev and nightly Helm charts, plus reusable chart packaging/publishing actions.
  * Introduced chart version management for subcomponents and a new way to bump chart dependencies.
  * Added support for more Helm configuration options, including additional auth, storage, and import settings.

* **Bug Fixes**
  * Improved chart dependency handling for local development and OCI-based publishing.
  * Added schema validation to catch mismatches between chart values and supported configuration.

* **Documentation**
  * Expanded Helm chart build and release documentation with usage examples and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->