### PR TITLE
NO-ISSUE: disable ComputeInstance and BMF in caas-ci helm values

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -19,6 +19,7 @@ operator:
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
     clusterOrder: true
+    computeInstance: false
     tenant: true
     networking: true
 
@@ -117,6 +118,7 @@ networkFulfillment:
 
 # --- Bare Metal Fulfillment Operator ---
 bmf:
+  enabled: false
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: sha-0a06955


### PR DESCRIPTION
The CaaS CI environment does not use ComputeInstance or bare metal fulfillment. Disable both to avoid deploying unused controllers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI deployment settings to use a new operator configuration.
  * Added support for additional code-as-configuration settings, including image, repository, and branch options.
  * Disabled the Bare Metal Fulfillment Operator by default while keeping its image settings available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->