### PR TITLE
NO-ISSUE: Add missing configAsCode fields to caas-ci values

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -95,6 +95,9 @@ aap:
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"
     secret: "config-as-code-ig"
+    eeImage: "ghcr.io/osac-project/osac-aap:sha-89f41e7"
+    projectGitUri: "https://github.com/osac-project/osac-aap"
+    projectGitBranch: "89f41e712b550cae30fe9569c8a9614e2c462208"
 
 # --- Validation ---
 validation:


### PR DESCRIPTION
Add eeImage, projectGitUri, and projectGitBranch to the caas-ci configAsCode section to match vmaas-ci.