### PR TITLE
Bumping the channel for aap

### DIFF
--- a/prerequisites/aap-installation.yaml
+++ b/prerequisites/aap-installation.yaml
@@ -29,7 +29,7 @@ metadata:
   name: dev-ansible-automation-platform
   namespace: ansible-aap
 spec:
-  channel: stable-2.5-cluster-scoped
+  channel: stable-2.7-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators


### PR DESCRIPTION
OCP4.22 uses stable-2.7 insteaf of stable-2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation prerequisites to point to the latest supported operator release channel, keeping setup guidance aligned with current availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->