### PR TITLE
Update osac-operator submodule to latest main

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -33,7 +33,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-89f41e7
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-08991cc
+  newTag: sha-7e4222b
 - name: ghcr.io/osac-project/bare-metal-fulfillment-operator
   newTag: sha-0a06955
 - name: envoy

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-08991cc
+    tag: sha-7e4222b
     pullPolicy: Always
   provisioning:
     provider: "aap"

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-08991cc
+    tag: sha-7e4222b
     pullPolicy: Always
   provisioning:
     provider: "aap"


### PR DESCRIPTION
## Summary
- Update osac-operator submodule from `08991cc` to `7e4222b` (latest upstream/main)
- Sync image tags via `scripts/sync-image-tags.sh --fix`

## Problem
The previous submodule commit (`08991cc`) has no published container image on ghcr.io, causing `ImagePullBackOff` for `osac-operator` and `osac-operator-console-proxy` pods in CI deployments.

## Test plan
- [ ] CI image tag check passes
- [ ] E2E tests deploy without ImagePullBackOff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the operator image revision used by the deployment and CI environments to a newer build.
  * Applied the same image update across the base configuration and CI values for consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->