### PR TITLE
OSAC-1675: Disable storage controller in CI values

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -22,7 +22,7 @@ operator:
     computeInstance: false
     tenant: true
     networking: true
-    storageController: true
+    storageController: false
 
 # --- Fulfillment Service ---
 service:

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -22,7 +22,7 @@ operator:
     computeInstance: true
     tenant: true
     networking: true
-    storageController: true
+    storageController: false
 
 # --- Fulfillment Service ---
 service:


### PR DESCRIPTION
## Summary
- Disable `storageController` in `vmaas-ci` and `caas-ci` values
- The storage controller requires a VAST backend and `storage-operations-ig` secret/configmap which don't exist in CI
- Without these, AAP storage provisioning jobs fail with `CreateContainerConfigError`, blocking tenant storage class resolution
- The tenant controller's built-in label-based resolution is sufficient for CI

## Context
The storage controller (PR #320, enabled in PR #336) introduces a two-stage pipeline:
1. Stage 1: Backend provisioning via AAP (requires VAST credentials in `storage-operations-ig` secret)
2. Stage 2: Storage class resolution

Stage 2 cannot run until Stage 1 succeeds, but CI has no VAST backend. The Helm chart also lacks a template for the `storage-operations-ig` secret (unlike `cluster-fulfillment-ig` and `network-fulfillment-ig`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environment settings to disable the storage controller in two CI configurations.
  * This changes how the CI environment is managed, with no other visible configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->