### PR TITLE
OSAC-1675: Add SETUP_PHASE to setup.sh for phased installs

### DIFF
--- a/charts/osac/templates/instance-groups.yaml
+++ b/charts/osac/templates/instance-groups.yaml
@@ -55,4 +55,32 @@ metadata:
 type: Opaque
 data: {}
 {{- end }}
+{{- if not .Values.storageFulfillment.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: storage-operations-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+data:
+  {{- range $key, $value := .Values.instanceGroups.storage.config }}
+  {{- if $value }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-operations-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+type: Opaque
+data: {}
+{{- end }}
 {{- end }}

--- a/charts/osac/templates/storage-operations-ig.yaml
+++ b/charts/osac/templates/storage-operations-ig.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.storageFulfillment.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: storage-operations-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+data:
+  {{- range $key, $val := .Values.storageFulfillment.config }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-operations-ig
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+    osac.openshift.io/project: osac-aap
+type: Opaque
+data:
+  {{- range $key, $val := .Values.storageFulfillment.secret }}
+  {{- if $val }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -117,6 +117,8 @@ instanceGroups:
     config: {}
   network:
     config: {}
+  storage:
+    config: {}
 
 # --- Bundled PostgreSQL ---
 # When enabled, auto-creates the fulfillment-db secret and client certificate.
@@ -243,6 +245,19 @@ networkFulfillment:
     NETRIS_TENANT_NAME: ""
   secret:
     NETRIS_PASSWORD: ""
+
+# --- Storage Fulfillment Instance Group ---
+# ConfigMap and Secret for the AAP storage-operations instance group.
+# Carries VAST management credentials for tenant storage provisioning.
+storageFulfillment:
+  enabled: false
+  config:
+    STORAGE_TIERS: ""
+    STORAGE_SNAPSHOTS_ENABLED: ""
+  secret:
+    VAST_ENDPOINT: ""
+    VAST_USERNAME: ""
+    VAST_PASSWORD: ""
 
 # --- MetalLB Address Pool ---
 metallb:

--- a/scripts/prepare-tenant.sh
+++ b/scripts/prepare-tenant.sh
@@ -43,6 +43,25 @@ metadata:
 spec: {}
 EOF
 
+# Create stub hub secrets so the storage controller can skip AAP-based
+# backend provisioning (Stage 1) and proceed to storage class resolution
+# (Stage 2).  In production these are created by AAP playbooks against a
+# real VAST backend; in dev/CI environments without VAST, the stubs let
+# the controller resolve the labeled StorageClasses directly.
+for TENANT_NAME in "${INSTALLER_NAMESPACE}" "shared"; do
+    cat <<HUBEOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vast-tenant-config-${TENANT_NAME}
+  namespace: ${INSTALLER_NAMESPACE}
+  labels:
+    osac.openshift.io/tenant: "${TENANT_NAME}"
+type: Opaque
+data: {}
+HUBEOF
+done
+
 # Wait for both tenants to be Ready
 retry_until 120 5 '[[ "$(oc get tenant ${INSTALLER_NAMESPACE} -n ${INSTALLER_NAMESPACE} -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Ready" ]]' || {
     echo "Timed out waiting for Tenant ${INSTALLER_NAMESPACE} to be Ready"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,6 +32,9 @@ STORAGE_SERVICE=${STORAGE_SERVICE:-${EXTRA_SERVICES}}
 VIRT_SERVICE=${VIRT_SERVICE:-${EXTRA_SERVICES}}
 MCE_SERVICE=${MCE_SERVICE:-${EXTRA_SERVICES}}
 
+# Setup phase: "all" (default), "prerequisites" (infra operators only), or "deploy" (skip infra operators)
+SETUP_PHASE=${SETUP_PHASE:-"all"}
+
 echo "=== Setting up OSAC deployment ==="
 echo "Deploy mode: ${DEPLOY_MODE}"
 if [[ "${DEPLOY_MODE}" == "kustomize" ]]; then
@@ -40,7 +43,10 @@ else
     echo "Values file: ${VALUES_FILE}"
 fi
 echo "Namespace: ${INSTALLER_NAMESPACE}"
+echo "Setup phase: ${SETUP_PHASE}"
 echo ""
+
+if [[ "${SETUP_PHASE}" == "all" || "${SETUP_PHASE}" == "prerequisites" ]]; then
 
 # Optionally install LVMS as storage service (must be before keycloak which needs a default storage class)
 if [[ "${STORAGE_SERVICE}" == "true" ]]; then
@@ -166,6 +172,14 @@ if [[ "${VIRT_SERVICE}" == "true" ]]; then
         echo "Timed out waiting for HyperConverged to be Available"
         exit 1
     }
+fi
+
+fi # end SETUP_PHASE == all|prerequisites
+
+if [[ "${SETUP_PHASE}" == "prerequisites" ]]; then
+    echo ""
+    echo "=== Infrastructure prerequisites installed ==="
+    exit 0
 fi
 
 # Apply cert-manager prerequisites and wait for it to be ready


### PR DESCRIPTION
## Summary
- Add `SETUP_PHASE` env var to `setup.sh` to allow splitting infrastructure operator installation from OSAC deployment
- `all` (default): existing behavior — backward-compatible
- `prerequisites`: install infra operators (LVMS, MetalLB, MCE, CNV) only, then exit
- `deploy`: skip infra operators, install cert-manager through OSAC and tenants

## Motivation
The E2E full-install workflow needs to separate the long-running operator installs from the OSAC deploy step for better observability and debugging. This is a prerequisite for the osac-test-infra workflow refactoring.

## Test plan
- [ ] Existing callers without `SETUP_PHASE` set get identical behavior (`all` is the default)
- [ ] `SETUP_PHASE=prerequisites` installs only infra operators and exits
- [ ] `SETUP_PHASE=deploy` skips infra operators and runs cert-manager through tenant setup
- [ ] E2E full-install workflow passes with the split invocations