### PR TITLE
OSAC-1675: Add E2E full-install presubmit workflow

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -1,0 +1,37 @@
+---
+name: E2E VMaaS Full Install
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (vmaas, caas, or empty for all)"
+        required: false
+        default: "vmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e-full-install:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'vmaas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      # Clone the installer from the PR's fork/branch so we test the actual PR content
+      installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
## Summary
- Adds `e2e-vmaas-full-install.yml` caller workflow that triggers on PRs to main
- Calls `osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main`
- Passes the PR's fork/branch as `installer-repo` and `installer-ref` so the E2E test deploys the actual PR content
- Sets `test-infra-repository` to ensure osac-test-infra is checked out for tests/Containerfile

## Test plan
- [ ] Open a test PR and verify the E2E workflow triggers
- [ ] Confirm the installer clone uses the PR branch (check "Install infrastructure operators" and "Install OSAC" step logs)
- [ ] Verify `workflow_dispatch` works with default inputs