### PR TITLE
NO-ISSUE: enable MetalLB autoAssign on prerequisites IPAddressPool

### DIFF
--- a/prerequisites/metallb/metallb-config.yaml
+++ b/prerequisites/metallb/metallb-config.yaml
@@ -29,7 +29,7 @@ spec:
   addresses:
     # Replace with your environment's IP range for LoadBalancer services
     - 192.168.100.240-192.168.100.250
-  autoAssign: false
+  autoAssign: true
   avoidBuggyIPs: true  # safeguard: exclude .0 and .255 if the address range is ever extended
 ---
 apiVersion: metallb.io/v1beta1


### PR DESCRIPTION
## Summary
- Set `autoAssign: true` on the MetalLB `caas-address-pool` IPAddressPool in `prerequisites/metallb/metallb-config.yaml`
- This aligns the prerequisites config with the Helm chart template (`charts/osac/templates/metallb.yaml`) which already uses `autoAssign: true`

## Jira
N/A

## Test plan
- [x] YAML validated
- [x] Change is consistent with Helm chart template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LoadBalancer services can now automatically receive IP addresses from the configured MetalLB address pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->