### PR TITLE
NO-ISSUE: use server-side apply for AAP license secret in setup.sh

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -285,10 +285,12 @@ VALUES_DIR="$(dirname "${VALUES_FILE}")"
 AAP_LICENSE_FILE=${AAP_LICENSE_FILE:-"${VALUES_DIR}/license.zip"}
 if [[ -f "${AAP_LICENSE_FILE}" ]]; then
     echo "Creating config-as-code-manifest-ig secret from ${AAP_LICENSE_FILE}..."
+    # Server-side apply avoids last-applied-configuration (256KiB limit on large license.zip)
+    # while remaining idempotent when the license file changes.
     oc create secret generic config-as-code-manifest-ig \
         --from-file=license.zip="${AAP_LICENSE_FILE}" \
         -n "${INSTALLER_NAMESPACE}" \
-        --dry-run=client -o yaml | oc apply -f -
+        --dry-run=client -o yaml | oc apply --server-side -f -
     oc label secret config-as-code-manifest-ig \
         osac.openshift.io/project=osac-aap \
         -n "${INSTALLER_NAMESPACE}" --overwrite


### PR DESCRIPTION
Client-side `oc apply` stores the full secret manifest in `last-applied-configuration`, which exceeds the 256KiB annotation limit for large `license.zip` files.

Use `oc apply --server-side` instead: it avoids that annotation while remaining idempotent when the license file changes.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm-based deployment of the AAP license secret so updates apply more reliably by switching to server-side apply.
  * Prevented repeat/apply failures caused by oversized `last-applied-configuration` annotations when the license artifact changes, while keeping setup behavior idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->