### PR TITLE
OSAC-1823: Create bmaas-ci Helm values file in osac-installer

### DIFF
--- a/values/bmaas-ci/values.yaml
+++ b/values/bmaas-ci/values.yaml
@@ -1,0 +1,170 @@
+# --- Prerequisites ---
+certManager:
+  enabled: true
+trustManager:
+  enabled: true
+caIssuer:
+  enabled: true
+keycloak:
+  enabled: true
+aapOperator:
+  enabled: true
+lvms:
+  enabled: true
+metallb:
+  enabled: false
+cnv:
+  enabled: false
+mce:
+  enabled: false
+
+# --- Operator ---
+operator:
+  image:
+    repository: ghcr.io/osac-project/osac-operator
+    tag: sha-a09d53b
+    pullPolicy: Always
+  provisioning:
+    provider: "aap"
+  aap:
+    insecureSkipVerify: "true"
+    tokenSecret:
+      name: osac-aap-api-token
+      key: token
+  fulfillment:
+    serverAddress: "fulfillment-internal-api:8001"
+    tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  controllers:
+    clusterOrder: false
+    computeInstance: false
+    tenant: true
+    networking: true
+    storage: true
+    bareMetalInstance: true
+  hubAccess:
+    enabled: true
+  tenants:
+  - name: shared
+  - name: osac-e2e-ci
+
+# --- Fulfillment Service ---
+service:
+  externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
+  internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
+  variant: openshift
+  images:
+    service: ghcr.io/osac-project/fulfillment-service:sha-2dca058
+    envoy: ghcr.io/osac-project/envoy:v1.33.0
+  certs:
+    issuerRef:
+      kind: ClusterIssuer
+      name: default-ca
+    caBundle:
+      configMap: ca-bundle
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    emergencyServiceAccounts:
+    - admin
+    - osac-operator
+    - osac-operator-controller-manager
+    - template-publisher
+    controllerCredentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+    credentials:
+    - secret:
+        name: fulfillment-controller-credentials
+        items:
+        - key: client-id
+          param: client-id
+        - key: client-secret
+          param: client-secret
+  database:
+    connection:
+    - secret:
+        name: fulfillment-db
+        items:
+        - key: url
+          param: url
+    - secret:
+        name: postgres-client-cert-service
+        items:
+        - key: tls.crt
+          param: sslcert
+        - key: tls.key
+          param: sslkey
+        - key: ca.crt
+          param: sslrootcert
+  log:
+    level: debug
+
+# --- UI ---
+ui:
+  enabled: true
+  images:
+    ui: ghcr.io/osac-project/osac-ui:sha-9cdfb35
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
+# --- AAP ---
+aap:
+  aap:
+    instance:
+      enabled: true
+      name: "osac-aap"
+  bootstrap:
+    enabled: true
+    image: ghcr.io/osac-project/osac-aap:sha-b5e5798
+    cliImage: quay.io/openshift/origin-cli:4.20.0
+    backoffLimit: 15
+  configAsCode:
+    manifestSecret: "config-as-code-manifest-ig"
+    secret: "config-as-code-ig"
+    eeImage: "ghcr.io/osac-project/osac-aap:sha-b5e5798"
+    projectGitUri: "https://github.com/osac-project/osac-aap"
+    projectGitBranch: "b5e5798ea4fe3eb13963a60c96e1cbf95bc1e5ef"
+
+# --- Validation ---
+validation:
+  enabled: true
+
+# --- Bare Metal Fulfillment Operator ---
+bmf:
+  enabled: true
+  image:
+    repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
+    tag: sha-d28b3ca
+    pullPolicy: Always
+  env:
+    aapUrl: "http://osac-aap/api/controller"
+    aapInsecureSkipVerify: "true"
+
+
+# --- CI/dev only ---
+# Hub access: registers local cluster as a hub. Only for environments
+# where the fulfillment service and hub cluster are the same.
+hubAccess:
+  enabled: true
+
+# Bundled PostgreSQL: single-pod ephemeral database for testing.
+# Uses fsync=off — data is lost on restart. Not for production.
+bundledPostgres:
+  enabled: true
+  database:
+    name: service
+    user: service


### PR DESCRIPTION
## [OSAC-1823](https://redhat.atlassian.net/browse/OSAC-1823): Create bmaas-ci Helm values file

**Jira:** https://redhat.atlassian.net/browse/OSAC-1823

### Summary

Add `values/bmaas-ci/values.yaml` for BMaaS E2E CI environments with the BMF operator enabled (`bmf.enabled: true`).

### Changes

- **New values file:** `values/bmaas-ci/values.yaml` based on `caas-ci` with `bmf.enabled: true` and the updated image tag

### Testing

- `helm template` renders correctly with the new values file
- `helm lint` passes (pre-existing minLength warning for empty hostnames, same as other CI values)
- All existing CI and environment values files continue to template successfully
- Deployed to a live OpenShift cluster (`osac-bmaas-ci` namespace) — BMF operator starts and initializes Metal3 controllers successfully

### Notes

Inventory and management config secrets (`osac-inventory-config`, `osac-management-config`) are provisioned by CI automation at deploy time, not by the Helm chart. Each backend type (Metal3, OpenStack) has a different config structure, so a generic chart template would be brittle. The BMF operator also mounts `osac-os-clouds` which can be an empty stub for Metal3 environments.

### Acceptance Criteria

- [x] AC-1: `values/bmaas-ci/values.yaml` exists with `bmf.enabled: true` and correct image reference
- [x] AC-2: Metal3 inventory and management config secrets are defined (secret names via BMF subchart defaults; content provisioned by CI automation)
- [x] AC-3: `helm template` renders correctly with the new values file
