### PR TITLE
NO-ISSUE: bump fulfillment-service to v0.0.69

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -28,7 +28,7 @@ images:
   newName: quay.io/sclorg/postgresql-18-c10s
   newTag: latest
 - name: ghcr.io/osac-project/fulfillment-service
-  newTag: sha-075185e
+  newTag: sha-2f4822c
 - name: osac-aap
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-140bdb4

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -30,7 +30,7 @@ service:
   externalHostname: ""  # Set to fulfillment-api-<namespace>.apps.<cluster>.<domain>
   internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-075185e
+    service: ghcr.io/osac-project/fulfillment-service:sha-2f4822c
     envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
@@ -108,7 +108,7 @@ validation:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-075185e
+  image: ghcr.io/osac-project/fulfillment-service:sha-2f4822c
 
 clusterFulfillment:
   enabled: true

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -30,7 +30,7 @@ service:
   internalHostname: ""  # Set to fulfillment-internal-api-<namespace>.apps.<cluster>.<domain>
   variant: openshift
   images:
-    service: ghcr.io/osac-project/fulfillment-service:sha-075185e
+    service: ghcr.io/osac-project/fulfillment-service:sha-2f4822c
     envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
@@ -112,7 +112,7 @@ bmf:
 # --- Database migration ---
 dbMigrate:
   enabled: false
-  image: ghcr.io/osac-project/fulfillment-service:sha-075185e
+  image: ghcr.io/osac-project/fulfillment-service:sha-2f4822c
 
 # CI full-install: chart-managed DB secrets; setup.sh deploys the integration-test
 # postgres chart when the postgres Service has no ready endpoints (see lib.sh).


### PR DESCRIPTION
Update submodule and image tags from sha-075185e to sha-2f4822c.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the fulfillment service deployment to use a newer container image tag.
  * Aligned the main service and database migration image references across CI environments.
  * Synced the base configuration and environment Helm values with the latest pinned fulfillment-service revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->