### PR TITLE
OSAC-1675: Add periodic e2e full install workflow (8x/day)

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -4,6 +4,8 @@ name: E2E VMaaS Full Install
 on:
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       test-suite:


### PR DESCRIPTION
## Summary
- Add e2e-vmaas-full-install caller workflow with schedule trigger running every 3 hours (8x/day)
- Calls the reusable workflow from osac-test-infra to run full OSAC install + e2e tests against the installer's main branch

## Test plan
- [ ] Verify workflow appears in Actions tab after merge
- [ ] Verify scheduled runs trigger at expected times