### PR TITLE
OSAC-1675: Add slash commands and rename e2e job key

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -24,7 +24,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  e2e-full-install:
+  e2e-vmaas-full-install:
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -1,0 +1,22 @@
+---
+name: Slash Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  checks: write
+
+jobs:
+  slash-command:
+    if: >-
+      github.event.issue.pull_request &&
+      (startsWith(github.event.comment.body, '/test') ||
+       startsWith(github.event.comment.body, '/retest') ||
+       startsWith(github.event.comment.body, '/cancel'))
+    uses: osac-project/osac-test-infra/.github/workflows/slash-command-handler.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add `slash-command.yml` caller workflow enabling `/test`, `/retest`, and `/cancel` PR comment commands (delegates to the shared handler in osac-test-infra)
- Rename e2e caller job key from `e2e-full-install` to `e2e-vmaas-full-install` to avoid future collisions when CaaS tests are added

## Dependencies
- Merge **github-config** PR #109 first (updates `required_status_checks` to match the new job key name)

## Test plan
- [ ] After merge, comment `/test ?` on a PR to verify help table
- [ ] Comment `/test e2e` to verify e2e rerun works