### PR TITLE
OSAC-1890: Point operator to internal Envoy listener for private API

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -8,7 +8,7 @@ operator:
     statusPollInterval: "30s"
     templatePrefix: "osac"
   fulfillment:
-    serverAddress: "fulfillment-api:8000"
+    serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
 service:

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -73,8 +73,9 @@ operator:
   # Fulfillment service gRPC connection. The operator reports resource state
   # back to the fulfillment service for multi-cluster coordination.
   fulfillment:
-    # In-cluster gRPC address. Change only if the service name differs.
-    serverAddress: "fulfillment-api:8000"
+    # Internal gRPC address — must use the internal Envoy listener that
+    # routes both public and private API methods.
+    serverAddress: "fulfillment-internal-api:8001"
     # Path to the ServiceAccount token file used for authentication.
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
 

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -117,7 +117,7 @@
             "serverAddress": {
               "type": "string",
               "description": "Fulfillment service gRPC address",
-              "default": "fulfillment-api:8000"
+              "default": "fulfillment-internal-api:8001"
             },
             "tokenFile": {
               "type": "string",

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -26,7 +26,7 @@ operator:
     statusPollInterval: "30s"
     templatePrefix: "osac"
   fulfillment:
-    serverAddress: "fulfillment-api:8000"
+    serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
     clusterOrder: true

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -15,7 +15,7 @@ operator:
       name: osac-aap-api-token
       key: token
   fulfillment:
-    serverAddress: "fulfillment-api:8000"
+    serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
     clusterOrder: true

--- a/values/development/values.yaml
+++ b/values/development/values.yaml
@@ -15,7 +15,7 @@ operator:
     statusPollInterval: "30s"
     templatePrefix: "osac"
   fulfillment:
-    serverAddress: "fulfillment-api:8000"
+    serverAddress: "fulfillment-internal-api:8001"
     tokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   controllers:
     clusterOrder: true


### PR DESCRIPTION
## Summary

- Change `operator.fulfillment.serverAddress` from `fulfillment-api:8000` (external Envoy listener) to `fulfillment-internal-api:8001` (internal listener) across all Helm values, schema, and environment overlays
- After the Envoy split (PR #444), the external listener only routes `osac.public.*` paths — the operator's 9 feedback controllers call `osac.private.*` methods and get `Unimplemented` from Envoy
- The `vmaas-ci` overlay already had the correct address; this brings the remaining files in line

## Test plan

- [x] Deploy OSAC using the updated Helm values
- [x] Create a cluster via `osac create cluster`
- [x] Verify operator logs show no `Unimplemented` errors for feedback controllers
- [x] Confirm cluster transitions to `CLUSTER_STATE_READY`

Fixes: https://redhat.atlassian.net/browse/OSAC-1890
Related: https://redhat.atlassian.net/browse/OSAC-710

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default fulfillment service address across operator and environment settings to use the internal endpoint.
  * Aligned example and CI values with the same internal address for more consistent deployments.
  * Refreshed the configuration schema to match the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->