### PR TITLE
OSAC-1638: add namespaces RBAC to hub-access ClusterRole

### DIFF
--- a/base/hub-access/README.md
+++ b/base/hub-access/README.md
@@ -3,6 +3,7 @@ The fulfillment service interacts with the target hub using the credentials you 
 This directory creates a `hub-access` service account with permissions to manage OSAC resources in the target namespace:
 
 - ClusterOrders, ComputeInstances, Tenants, VirtualNetworks, Subnets, SecurityGroups (full CRUD + status read)
+- Namespaces (full CRUD, cluster-scoped)
 - Console access (`console.osac.openshift.io/computeinstances/console`)
 - Secrets (create only, for cloud-init user-data)
 

--- a/base/hub-access/rbac.yaml
+++ b/base/hub-access/rbac.yaml
@@ -227,3 +227,15 @@ rules:
       - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/charts/osac/templates/hub-access.yaml
+++ b/charts/osac/templates/hub-access.yaml
@@ -255,6 +255,18 @@ rules:
       - secrets
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary

* Adds RBAC permissions for Namespaces to the hub-access ClusterRole (both kustomize base and Helm chart)
* Required by tenant onboarding in fulfillment-service, which creates or reads the tenant workload namespace on hub clusters. See: https://github.com/osac-project/fulfillment-service/pull/812

## Changes

* `base/hub-access/rbac.yaml` — add `namespaces` rules to `hub-access-hosted-clusters` ClusterRole
* `charts/osac/templates/hub-access.yaml` — same for Helm deployment path
* `base/hub-access/README.md` — document Namespaces permission

Assisted-by: Claude Code <noreply@anthropic.com>

## Test plan

- [ ] `oc auth can-i get namespaces --as=system:serviceaccount:<ns>:hub-access` returns `yes` after deploy
- [ ] Tenant onboarding reconciler can create/get namespace on hub without forbidden errors
- [ ] `./scripts/kustomize-build-all.sh` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded access so the hub-access service account can manage namespaces in the target cluster, including creating, updating, and deleting them.
* **Documentation**
  * Updated the access documentation to reflect the added namespace management permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->