### PR TITLE
OSAC-1909: Enable Slack notification for scheduled E2E runs

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -39,3 +39,4 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      notify-on-failure: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Summary
- Pass `notify-on-failure: ${{ github.event_name == 'schedule' }}` to the reusable E2E workflow so that scheduled run failures are reported to Slack

## Test plan
- [ ] Merge companion PR first: https://github.com/osac-project/osac-test-infra/pull/149
- [ ] Verify scheduled E2E failures send Slack notification

**Depends on:** osac-project/osac-test-infra#149