### PR TITLE
OSAC-1906: Add osac-ui as subchart dependency in umbrella chart

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -45,10 +45,12 @@ jobs:
           OPERATOR=$(check_image osac-operator osac-operator)
           FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
           AAP=$(check_image osac-aap osac-aap)
+          UI=$(check_image osac-ui osac-ui)
 
           echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
           echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
           echo "aap=${AAP}" >> "$GITHUB_OUTPUT"
+          echo "ui=${UI}" >> "$GITHUB_OUTPUT"
 
       - name: Update submodules
         id: update
@@ -78,6 +80,7 @@ jobs:
           update_submodule base/osac-operator osac-operator "${{ steps.find.outputs.operator }}"
           update_submodule base/osac-fulfillment-service fulfillment-service "${{ steps.find.outputs.fulfillment }}"
           update_submodule base/osac-aap osac-aap "${{ steps.find.outputs.aap }}"
+          update_submodule base/osac-ui osac-ui "${{ steps.find.outputs.ui }}"
 
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo -e "${summary}" > /tmp/bump-summary.txt

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -27,6 +27,9 @@ on:
       bmf_version:
         description: 'bare-metal-fulfillment-operator chart version (e.g. 0.0.1)'
         required: true
+      ui_version:
+        description: 'osac-ui chart version (e.g. 0.0.1)'
+        required: true
 
 concurrency:
   group: publish-charts-${{ github.ref }}
@@ -67,6 +70,7 @@ jobs:
         INPUT_AAP_VERSION: ${{ inputs.aap_version }}
         INPUT_BMF_CRDS_VERSION: ${{ inputs.bmf_crds_version }}
         INPUT_BMF_VERSION: ${{ inputs.bmf_version }}
+        INPUT_UI_VERSION: ${{ inputs.ui_version }}
       run: |
         SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'
 
@@ -89,6 +93,7 @@ jobs:
         aap_ver="${INPUT_AAP_VERSION}"
         bmf_crds_ver="${INPUT_BMF_CRDS_VERSION}"
         bmf_ver="${INPUT_BMF_VERSION}"
+        ui_ver="${INPUT_UI_VERSION}"
 
         # When triggered by tag push (no inputs), use the umbrella version for all components
         : "${crds_ver:=${version}}"
@@ -97,9 +102,10 @@ jobs:
         : "${aap_ver:=${version}}"
         : "${bmf_crds_ver:=${version}}"
         : "${bmf_ver:=${version}}"
+        : "${ui_ver:=${version}}"
 
         # Validate all component versions
-        for pair in "osac-operator-crds:${crds_ver}" "osac-operator:${operator_ver}" "fulfillment-service:${service_ver}" "osac-aap:${aap_ver}" "bare-metal-fulfillment-operator-crds:${bmf_crds_ver}" "bare-metal-fulfillment-operator:${bmf_ver}"; do
+        for pair in "osac-operator-crds:${crds_ver}" "osac-operator:${operator_ver}" "fulfillment-service:${service_ver}" "osac-aap:${aap_ver}" "bare-metal-fulfillment-operator-crds:${bmf_crds_ver}" "bare-metal-fulfillment-operator:${bmf_ver}" "osac-ui:${ui_ver}"; do
           name="${pair%%:*}"
           ver="${pair#*:}"
           if ! [[ "${ver}" =~ ${SEMVER_RE} ]]; then
@@ -115,6 +121,7 @@ jobs:
         echo "aap_ver=${aap_ver}" >> "$GITHUB_OUTPUT"
         echo "bmf_crds_ver=${bmf_crds_ver}" >> "$GITHUB_OUTPUT"
         echo "bmf_ver=${bmf_ver}" >> "$GITHUB_OUTPUT"
+        echo "ui_ver=${ui_ver}" >> "$GITHUB_OUTPUT"
 
         echo "--- Resolved versions ---"
         echo "Umbrella:           ${version}"
@@ -124,6 +131,7 @@ jobs:
         echo "osac-aap:           ${aap_ver}"
         echo "bmf-operator-crds:  ${bmf_crds_ver}"
         echo "bmf-operator:       ${bmf_ver}"
+        echo "osac-ui:            ${ui_ver}"
 
     - name: Rewrite dependencies to OCI references
       env:
@@ -133,6 +141,7 @@ jobs:
         AAP_VER: ${{ steps.versions.outputs.aap_ver }}
         BMF_CRDS_VER: ${{ steps.versions.outputs.bmf_crds_ver }}
         BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
+        UI_VER: ${{ steps.versions.outputs.ui_ver }}
       run: |
         cd charts/osac
         OCI_REPO="oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}"
@@ -149,7 +158,9 @@ jobs:
           (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .repository = \"${OCI_REPO}\" |
           (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator-crds\")) .version = \"${BMF_CRDS_VER}\" |
           (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .repository = \"${OCI_REPO}\" |
-          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .version = \"${BMF_VER}\"
+          (.dependencies[] | select(.name == \"bare-metal-fulfillment-operator\")) .version = \"${BMF_VER}\" |
+          (.dependencies[] | select(.name == \"osac-ui\")) .repository = \"${OCI_REPO}\" |
+          (.dependencies[] | select(.name == \"osac-ui\")) .version = \"${UI_VER}\"
         " Chart.yaml
 
         # Remove stale Chart.lock so helm pulls fresh from OCI

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "base/bare-metal-fulfillment-operator"]
 	path = base/bare-metal-fulfillment-operator
 	url = https://github.com/osac-project/bare-metal-fulfillment-operator.git
+[submodule "base/osac-ui"]
+	path = base/osac-ui
+	url = https://github.com/osac-project/osac-ui.git

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -30,3 +30,8 @@ dependencies:
     repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator"
     alias: bmf
     condition: bmf.enabled
+  - name: osac-ui
+    version: ">=0.0.0"
+    repository: "file://../../base/osac-ui/charts/ui"
+    alias: ui
+    condition: ui.enabled

--- a/charts/osac/ci/bundled-postgres-values.yaml
+++ b/charts/osac/ci/bundled-postgres-values.yaml
@@ -5,6 +5,18 @@ bundledPostgres:
     name: service
     user: service
 
+ui:
+  enabled: true
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
 service:
   externalHostname: fulfillment-api.example.com
   internalHostname: fulfillment-internal-api.example.com

--- a/charts/osac/ci/default-values.yaml
+++ b/charts/osac/ci/default-values.yaml
@@ -1,6 +1,18 @@
 # Default scenario: validates that the chart renders with minimal overrides.
 # Only sets values that subcharts mark as required.
 
+ui:
+  enabled: true
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
 service:
   externalHostname: fulfillment-api.example.com
   internalHostname: fulfillment-internal-api.example.com

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -1,5 +1,22 @@
 # Full scenario: everything enabled, exercises all template branches.
 
+ui:
+  enabled: true
+  externalHostname: osac-ui.example.com
+  api:
+    fulfillment:
+      url: https://fulfillment-api:8000
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    oidcClientId: osac-ui
+    certs:
+      caBundle:
+        configMap: ca-bundle
+  images:
+    ui: ghcr.io/osac-project/osac-ui:latest
+
 operator:
   aap:
     url: "https://aap.example.com/api/controller"

--- a/charts/osac/ci/no-aap-values.yaml
+++ b/charts/osac/ci/no-aap-values.yaml
@@ -1,6 +1,18 @@
 # No-AAP scenario: AAP managed externally, bootstrap and validation disabled.
 # Exercises the disabled-AAP template branches.
 
+ui:
+  enabled: true
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
 service:
   externalHostname: fulfillment-api.example.com
   internalHostname: fulfillment-internal-api.example.com

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -577,6 +577,97 @@
         }
       }
     },
+    "ui": {
+      "type": "object",
+      "description": "OSAC UI web console configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy the OSAC UI web console",
+          "default": true
+        },
+        "externalHostname": {
+          "type": "string",
+          "description": "Hostname for the OpenShift Route (auto-assigned if empty)"
+        },
+        "api": {
+          "type": "object",
+          "description": "Backend API connection settings",
+          "properties": {
+            "fulfillment": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "description": "Fulfillment API URL",
+                  "default": "https://fulfillment-api:8000"
+                },
+                "certs": {
+                  "type": "object",
+                  "properties": {
+                    "caBundle": {
+                      "type": "object",
+                      "properties": {
+                        "configMap": {
+                          "type": "string",
+                          "description": "ConfigMap name containing the CA bundle for the fulfillment API"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "description": "Authentication configuration",
+          "properties": {
+            "oidcClientId": {
+              "type": "string",
+              "description": "OIDC client ID for the UI",
+              "default": "osac-ui"
+            },
+            "certs": {
+              "type": "object",
+              "properties": {
+                "caBundle": {
+                  "type": "object",
+                  "properties": {
+                    "configMap": {
+                      "type": "string",
+                      "description": "ConfigMap name containing the CA bundle for auth"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "log": {
+          "type": "object",
+          "description": "Logging configuration",
+          "properties": {
+            "level": {
+              "type": "string",
+              "description": "Log level (debug, info, warn, error)",
+              "default": "info"
+            }
+          }
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "ui": {
+              "type": "string",
+              "description": "UI container image",
+              "default": "ghcr.io/osac-project/osac-ui:latest"
+            }
+          }
+        }
+      }
+    },
     "bundledPostgres": {
       "type": "object",
       "description": "Auto-generate secrets for bundled PostgreSQL (dev/test only)",

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -136,6 +136,26 @@ bundledPostgres:
     name: service
     user: service
 
+# --- UI ---
+ui:
+  enabled: true
+  externalHostname: ""
+  api:
+    fulfillment:
+      url: https://fulfillment-api:8000
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    oidcClientId: osac-ui
+    certs:
+      caBundle:
+        configMap: ca-bundle
+  log:
+    level: info
+  images:
+    ui: ghcr.io/osac-project/osac-ui:latest
+
 # --- Bare Metal Fulfillment Operator CRDs ---
 bmfCrds: {}
 

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -14,16 +14,19 @@ declare -A IMAGE_NAME=(
   [osac-fulfillment-service]="ghcr.io/osac-project/fulfillment-service"
   [osac-aap]="osac-aap"
   [bare-metal-fulfillment-operator]="ghcr.io/osac-project/bare-metal-fulfillment-operator"
+  [osac-ui]="osac-ui"
 )
 
 errors=0
 
-for submodule in osac-operator osac-fulfillment-service osac-aap bare-metal-fulfillment-operator; do
+for submodule in osac-operator osac-fulfillment-service osac-aap bare-metal-fulfillment-operator osac-ui; do
   commit=$(git -C "${REPO_ROOT}" submodule status "base/${submodule}" | awk '{print $1}' | tr -d ' +-')
   short="${commit:0:7}"
   tag="sha-${short}"
   image="${IMAGE_NAME[$submodule]}"
 
+  # Skip components not referenced in kustomization.yaml (e.g. osac-ui is Helm-only).
+  grep -q "name: ${image}$" "${KUSTOMIZATION}" || continue
   current_tag=$(grep -A2 "name: ${image}$" "${KUSTOMIZATION}" | grep "newTag:" | awk '{print $2}')
 
   if [[ "${current_tag}" == "${tag}" ]]; then
@@ -76,6 +79,7 @@ operator_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-operator | 
 fulfillment_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-fulfillment-service | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 aap_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-aap | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 bmf_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/bare-metal-fulfillment-operator | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
+ui_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-ui | awk '{print $1}' | tr -d ' +-' | cut -c1-7)"
 
 for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
   [[ ! -f "${values_file}" ]] && continue
@@ -86,7 +90,8 @@ for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
     "osac-operator:tag ${operator_tag}" \
     "fulfillment-service:inline ${fulfillment_tag}" \
     "osac-aap:inline ${aap_tag}" \
-    "bare-metal-fulfillment-operator:tag ${bmf_tag}"; do
+    "bare-metal-fulfillment-operator:tag ${bmf_tag}" \
+    "osac-ui:inline ${ui_tag}"; do
     component="${pair%%:*}"
     rest="${pair#*:}"
     mode="${rest%% *}"
@@ -108,7 +113,7 @@ for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
         errors=$((errors + 1))
       fi
     else
-      current=$(grep -o "${component}:sha-[a-f0-9]\{7\}" "${values_file}" | head -1 | sed "s/${component}://")
+      current=$(grep -o "${component}:sha-[a-f0-9]\{7\}" "${values_file}" | head -1 | sed "s/${component}://" || true)
       [[ -z "${current}" ]] && continue
       if [[ "${current}" == "${expected}" ]]; then
         echo "${name} ${component}: OK (${expected})"

--- a/values/development/values.yaml
+++ b/values/development/values.yaml
@@ -82,6 +82,21 @@ service:
   log:
     level: info
 
+# --- UI ---
+ui:
+  enabled: true
+  images:
+    ui: ghcr.io/osac-project/osac-ui:latest
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
 # --- AAP ---
 aap:
   aap:

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -83,6 +83,21 @@ service:
   log:
     level: debug
 
+# --- UI ---
+ui:
+  enabled: true
+  images:
+    ui: ghcr.io/osac-project/osac-ui:sha-8314b32
+  api:
+    fulfillment:
+      certs:
+        caBundle:
+          configMap: ca-bundle
+  auth:
+    certs:
+      caBundle:
+        configMap: ca-bundle
+
 # --- AAP ---
 aap:
   aap:


### PR DESCRIPTION
## Summary
- Add `osac-ui` git submodule under `base/`
- Add subchart dependency in `Chart.yaml` (alias: `ui`, condition: `ui.enabled`)
- Add `ui:` values section to `values.yaml`, `values.schema.json`, all CI values files, and environment values files (development, vmaas-ci)
- Update `bump-submodules`, `publish-charts`, and `sync-image-tags.sh` automation to include osac-ui

## Why
The OSAC UI web console needs to be deployed as part of the umbrella Helm chart, following the same pattern used by operator, fulfillment-service, aap, and bmf.

## Dependencies
- Requires https://github.com/osac-project/osac-ui/pull/52 to be merged first (moves chart from `deploy/chart/` to `charts/ui/`)

## Test plan
- [ ] `helm dependency build charts/osac/` succeeds
- [ ] `helm template` with development values renders UI resources
- [ ] All CI values files template successfully
- [ ] `sync-image-tags.sh` reports `vmaas-ci osac-ui: OK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the OSAC UI to the platform’s default deployment and Helm chart packaging.
  - Updated release and CI configurations so the UI image and settings are included alongside other components.
  - Enabled deployment options for the UI in development and CI environments, including hostname, authentication, and certificate bundle settings.

- **Bug Fixes**
  - Improved image and submodule validation to ensure the UI component is only promoted when a matching published image is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->