### PR TITLE
NO-ISSUE: Bump osac-operator submodule to include ExternalIP CRDs

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -33,7 +33,7 @@ images:
   newName: ghcr.io/osac-project/osac-aap
   newTag: sha-77cd796
 - name: ghcr.io/osac-project/osac-operator
-  newTag: sha-c4ee968
+  newTag: sha-75f48c7
 - name: ghcr.io/osac-project/bare-metal-fulfillment-operator
   newTag: sha-0a06955
 - name: envoy

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-c4ee968
+    tag: sha-75f48c7
     pullPolicy: Always
   provisioning:
     provider: "aap"

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: sha-c4ee968
+    tag: sha-75f48c7
     pullPolicy: Always
   provisioning:
     provider: "aap"


### PR DESCRIPTION
## Summary
- Bumps `base/osac-operator` submodule from `c4ee968` to `75f48c7` (latest `main`)
- Picks up [OSAC-1442](https://redhat.atlassian.net/browse/OSAC-1442) (PR osac-project/osac-operator#318) which adds `ExternalIP`, `ExternalIPAttachment`, and `ExternalIPPool` CRD types and chart templates
- Without this bump, the operator binary crashes on startup with `no matches for kind "ExternalIP"` because the CRDs are not installed by the Helm chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled component to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->