### PR TITLE
NO-ISSUE: Add CI check for values-to-schema coverage

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -51,5 +51,10 @@ jobs:
             > /dev/null
         done
 
-    - name: Validate values schema
+    - name: Validate values schema JSON
       run: python3 -m json.tool charts/osac/values.schema.json > /dev/null
+
+    - name: Check values keys have schema entries
+      run: |
+        pip install --quiet pyyaml
+        make validate-values-schema

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,10 @@ teardown: ## Teardown OSAC deployment
 helm-validate: helm-lint ## Validate Helm chart (lint + template)
 	helm template osac charts/osac/ --values $(VALUES_FILE) > /dev/null
 	@echo "Validation passed."
+
+.PHONY: validate-values-schema
+validate-values-schema: ## Check that every values key has a matching schema entry
+	python3 scripts/validate-values-schema.py charts/osac/values.schema.json \
+		charts/osac/values.yaml \
+		charts/osac/values-example.yaml \
+		values/*/values.yaml

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -92,7 +92,21 @@
             },
             "token": {
               "type": "string",
-              "description": "AAP API token"
+              "description": "AAP API token (literal value, alternative to tokenSecret)"
+            },
+            "tokenSecret": {
+              "type": "object",
+              "description": "Kubernetes Secret reference for the AAP API token (alternative to token)",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the Secret containing the AAP API token"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key within the Secret that holds the token value"
+                }
+              }
             },
             "insecureSkipVerify": {
               "type": "string",
@@ -125,6 +139,17 @@
             }
           }
         },
+        "provisioning": {
+          "type": "object",
+          "description": "Provisioning backend configuration",
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "Provisioning provider (e.g. aap)",
+              "default": "aap"
+            }
+          }
+        },
         "controllers": {
           "type": "object",
           "description": "Enable or disable individual operator controllers",
@@ -148,6 +173,11 @@
               "type": "boolean",
               "description": "Enable networking controllers",
               "default": true
+            },
+            "storageController": {
+              "type": "boolean",
+              "description": "Enable storage controller",
+              "default": false
             }
           }
         },
@@ -267,6 +297,13 @@
             "controllerCredentials": {
               "type": "array",
               "description": "Controller credential volume sources"
+            },
+            "emergencyServiceAccounts": {
+              "type": "array",
+              "description": "Service accounts granted emergency access (bypass normal OIDC auth)",
+              "items": {
+                "type": "string"
+              }
             }
           }
         },
@@ -572,6 +609,16 @@
             "config": {
               "type": "object",
               "description": "Additional key-value pairs for the network instance group ConfigMap"
+            }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "description": "Storage instance group extra config",
+          "properties": {
+            "config": {
+              "type": "object",
+              "description": "Additional key-value pairs for the storage instance group ConfigMap"
             }
           }
         }
@@ -941,6 +988,98 @@
             "SERVER_SSH_BASTION_KEY": {
               "type": "string",
               "description": "SSH private key for bastion access"
+            }
+          }
+        }
+      }
+    },
+    "importAgents": {
+      "type": "object",
+      "description": "ConfigMap-based bare metal agent import configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ConfigMap-based bare metal agent import (sets OSAC_IMPORT_AGENTS_ENABLED in config-as-code-ig Secret)",
+          "default": false
+        },
+        "servers": {
+          "type": "array",
+          "description": "Server inventory for bare metal agent import. Each entry provisions a BareMetalHost CR.",
+          "items": {
+            "type": "object",
+            "required": ["name", "bmc_url", "bmc_secret", "boot_mac", "netris_server_name", "resource_class"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Server hostname, used as the BareMetalHost CR name"
+              },
+              "bmc_url": {
+                "type": "string",
+                "description": "Redfish BMC address for virtual media boot"
+              },
+              "bmc_secret": {
+                "type": "string",
+                "description": "Name of the Kubernetes Secret with BMC credentials"
+              },
+              "boot_mac": {
+                "type": "string",
+                "description": "Boot NIC MAC address"
+              },
+              "netris_server_name": {
+                "type": "string",
+                "description": "Netris server name label for the Agent"
+              },
+              "resource_class": {
+                "type": "string",
+                "description": "Hardware type label for the Agent"
+              },
+              "disable_bmc_cert_verification": {
+                "type": "boolean",
+                "description": "Per-server override for BMC TLS certificate verification"
+              }
+            }
+          }
+        }
+      }
+    },
+    "storageFulfillment": {
+      "type": "object",
+      "description": "ConfigMap and Secret for the AAP storage-operations instance group",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Create storage-fulfillment ConfigMap and Secret",
+          "default": false
+        },
+        "config": {
+          "type": "object",
+          "description": "Environment variables for the storage-operations instance group",
+          "properties": {
+            "STORAGE_TIERS": {
+              "type": "string",
+              "description": "Comma-separated list of available storage tiers"
+            },
+            "STORAGE_SNAPSHOTS_ENABLED": {
+              "type": "string",
+              "description": "Enable storage snapshot support"
+            }
+          }
+        },
+        "secret": {
+          "type": "object",
+          "description": "Secret values for the storage-operations instance group",
+          "properties": {
+            "VAST_ENDPOINT": {
+              "type": "string",
+              "description": "VAST storage API endpoint URL"
+            },
+            "VAST_USERNAME": {
+              "type": "string",
+              "description": "VAST storage API username"
+            },
+            "VAST_PASSWORD": {
+              "type": "string",
+              "description": "VAST storage API password"
             }
           }
         }

--- a/scripts/validate-values-schema.py
+++ b/scripts/validate-values-schema.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate that every key in Helm values files has a matching entry in values.schema.json.
+
+Walks YAML values files recursively and checks that each dot-separated key path
+exists in the JSON Schema's properties hierarchy.
+
+Usage:
+    validate-values-schema.py <schema.json> <values.yaml> [<values.yaml> ...]
+
+Exit codes:
+    0 — all keys covered
+    1 — missing schema entries found
+"""
+
+import json
+import sys
+
+import yaml
+
+
+def extract_paths(obj, prefix=""):
+    """Yield all dot-separated key paths from a nested dict."""
+    if not isinstance(obj, dict):
+        return
+    for key, value in obj.items():
+        path = f"{prefix}.{key}" if prefix else key
+        yield path
+        if isinstance(value, dict) and value:
+            yield from extract_paths(value, path)
+
+
+def schema_has_path(schema, path):
+    """Check whether a dot-separated path exists in the JSON Schema properties tree."""
+    node = schema
+    for part in path.split("."):
+        props = node.get("properties", {})
+        if part not in props:
+            return False
+        node = props[part]
+    return True
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <schema.json> <values.yaml> [<values.yaml> ...]",
+              file=sys.stderr)
+        return 1
+
+    schema_path = sys.argv[1]
+    values_paths = sys.argv[2:]
+
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    errors = 0
+    for vpath in values_paths:
+        with open(vpath) as f:
+            values = yaml.safe_load(f)
+        if not isinstance(values, dict):
+            continue
+
+        missing = sorted(
+            p for p in extract_paths(values) if not schema_has_path(schema, p)
+        )
+        for p in missing:
+            print(f"{vpath}: key '{p}' has no schema entry")
+            errors += 1
+
+    if errors:
+        print(f"\n{errors} value key(s) missing from schema.", file=sys.stderr)
+        return 1
+
+    print("All value keys are covered by the schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a validation script that ensures every key in Helm values files has a corresponding entry in values.schema.json. Exposed as a Makefile target (make validate-values-schema) and as a step in the Helm Lint CI workflow. Also backfills three schema entries that were missing: operator.provisioning, operator.aap.tokenSecret, and service.auth.emergencyServiceAccounts.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger Helm chart validation to check that values files match the published schema during linting and local validation.

* **Bug Fixes**
  * Expanded chart configuration support for additional operator, authentication, provisioning, storage, import-agent, and storage-fulfillment settings.
  * Added checks to catch missing schema entries for provided values keys before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->