### PR TITLE
OSAC-1675: Pass fork-pr-author for org membership check

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -36,6 +36,7 @@ jobs:
       installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
## Summary
- Add `fork-pr-author` input to the e2e caller workflow, passing `github.event.pull_request.user.login` for fork PRs

## Context
The reusable workflow in osac-test-infra now uses a two-tier fork PR authorization: tier 1 checks `author_association` (fast-pass), tier 2 queries the GitHub org membership API using a Vault-stored PAT. This PR passes the author login needed for tier 2.

Depends on osac-project/osac-test-infra#150.

## Test plan
- [ ] Fork PR from an org member — tier 2 returns 204, e2e runs
- [ ] Non-fork PR — validation step skipped (inputs are empty)