### PR TITLE
OSAC-1908: align installer with storage controller restructuring

### DIFF
--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -148,6 +148,16 @@
               "type": "boolean",
               "description": "Enable networking controllers",
               "default": true
+            },
+            "bareMetalInstance": {
+              "type": "boolean",
+              "description": "Enable BareMetalInstance controller",
+              "default": true
+            },
+            "storage": {
+              "type": "boolean",
+              "description": "Enable Storage controller",
+              "default": true
             }
           }
         },

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -33,6 +33,8 @@ operator:
     computeInstance: true
     tenant: true
     networking: true
+    bareMetalInstance: true
+    storage: true
   configSecret:
     name: "osac-config"
     optional: true

--- a/scripts/prepare-tenant.sh
+++ b/scripts/prepare-tenant.sh
@@ -39,9 +39,30 @@ metadata:
 spec: {}
 EOF
 
+# Create stub hub secrets so the storage controller can skip backend
+# provisioning and proceed to StorageClass resolution. In production
+# these are created by AAP playbooks against a real VAST backend; in
+# dev/CI environments without VAST, the stubs let the controller
+# resolve the labeled StorageClasses directly.
+# TODO(OSAC-1957): remove once the Backend API lets the controller
+# detect "no backend registered" and skip backend provisioning.
+for TENANT_NAME in "${INSTALLER_NAMESPACE}" "shared"; do
+    cat <<HUBEOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vast-tenant-config-${TENANT_NAME}
+  namespace: ${INSTALLER_NAMESPACE}
+  labels:
+    osac.openshift.io/tenant: "${TENANT_NAME}"
+type: Opaque
+data: {}
+HUBEOF
+done
+
 # Wait for both tenants to be Ready
-# The storage controller populates status.storageClasses from the labeled
-# default StorageClass above when no AAP/VAST backend is configured.
+# The storage controller resolves tenant-specific StorageClasses first,
+# falling back to the shared Default-labeled SC when none exist.
 retry_until 120 5 '[[ "$(oc get tenant ${INSTALLER_NAMESPACE} -n ${INSTALLER_NAMESPACE} -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Ready" ]]' || {
     echo "Timed out waiting for Tenant ${INSTALLER_NAMESPACE} to be Ready"
     exit 1

--- a/scripts/prepare-tenant.sh
+++ b/scripts/prepare-tenant.sh
@@ -39,26 +39,9 @@ metadata:
 spec: {}
 EOF
 
-# Create stub hub secrets so the storage controller can skip AAP-based
-# backend provisioning (Stage 1) and proceed to storage class resolution
-# (Stage 2).  In production these are created by AAP playbooks against a
-# real VAST backend; in dev/CI environments without VAST, the stubs let
-# the controller resolve the labeled StorageClasses directly.
-for TENANT_NAME in "${INSTALLER_NAMESPACE}" "shared"; do
-    cat <<HUBEOF | oc apply -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vast-tenant-config-${TENANT_NAME}
-  namespace: ${INSTALLER_NAMESPACE}
-  labels:
-    osac.openshift.io/tenant: "${TENANT_NAME}"
-type: Opaque
-data: {}
-HUBEOF
-done
-
 # Wait for both tenants to be Ready
+# The storage controller populates status.storageClasses from the labeled
+# default StorageClass above when no AAP/VAST backend is configured.
 retry_until 120 5 '[[ "$(oc get tenant ${INSTALLER_NAMESPACE} -n ${INSTALLER_NAMESPACE} -o jsonpath='"'"'{.status.phase}'"'"' 2>/dev/null)" == "Ready" ]]' || {
     echo "Timed out waiting for Tenant ${INSTALLER_NAMESPACE} to be Ready"
     exit 1

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -27,7 +27,7 @@ operator:
     computeInstance: false
     tenant: true
     networking: true
-    storageController: true
+    storage: true
 
 # --- Fulfillment Service ---
 service:

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -22,7 +22,7 @@ operator:
     computeInstance: true
     tenant: true
     networking: true
-    storageController: true
+    storage: true
 
 # --- Fulfillment Service ---
 service:


### PR DESCRIPTION
## Summary

[OSAC-1908](https://redhat.atlassian.net/browse/OSAC-1908): Align the installer with the storage controller changes in [osac-operator#333](https://github.com/osac-project/osac-operator/pull/333).

## Why

The operator renamed `controllers.storageController` to `controllers.storage` for consistency with other controller keys (`clusterOrder`, `computeInstance`, `tenant`, etc.), enabled the storage controller by default, and added Default SC fallback logic in StorageClass Resolution.

**Changes:**
- Add `storage` and `bareMetalInstance` to the umbrella chart values and schema. (`bareMetalInstance` was added to the operator chart in [osac-operator#301](https://github.com/osac-project/osac-operator/pull/301) but the umbrella chart was never updated.)
- Rename `storageController` to `storage` in `vmaas-ci` and `caas-ci` overlay values.
- Add TODO([OSAC-1957](https://redhat.atlassian.net/browse/OSAC-1957)) to the stub `vast-tenant-config-*` secrets in `prepare-tenant.sh`. These let the storage controller skip Backend Provisioning and reach StorageClass Resolution in environments where AAP is configured but no VAST backend is registered. They can be removed once the Backend API lets the controller detect the absence of a backend automatically.

## Testing

```bash
helm lint charts/osac/
helm template osac charts/osac/ --values values/vmaas-ci/values.yaml
helm template osac charts/osac/ --values values/caas-ci/values.yaml
```

## Related PRs

- [osac-operator#333](https://github.com/osac-project/osac-operator/pull/333) (merged)

## Ticket

[OSAC-1908](https://redhat.atlassian.net/browse/OSAC-1908)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration toggles for the Bare Metal Instance and Storage controllers, enabled by default.
  * Updated deployment configuration to use the streamlined Storage controller setting.

* **Documentation**
  * Clarified development and CI behavior for StorageClass resolution and backend-independent setup.
  * Documented the priority of tenant-specific versus shared default StorageClasses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->