### PR TITLE
Increase E2E periodic schedule to 12x/day

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "0 */2 * * *"
   workflow_dispatch:
     inputs:
       test-suite:


### PR DESCRIPTION
## Summary
- Change E2E cron from `0 */3 * * *` (every 3h, 8x/day) to `0 */2 * * *` (every 2h, 12x/day)

## Test plan
- [ ] Verify cron triggers at the expected 2-hour intervals after merge