### PR TITLE
OSAC-1960: Add GitHub Release creation to publish-charts workflow

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -44,7 +44,7 @@ jobs:
     name: Publish osac umbrella chart
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
     - name: Checkout repository
@@ -194,3 +194,48 @@ jobs:
       run: |
         helm push "osac-${VERSION}.tgz" \
           oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+    - name: Create GitHub Release
+      if: always() && steps.versions.outcome == 'success'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.versions.outputs.version }}
+        OPERATOR_VER: ${{ steps.versions.outputs.operator_ver }}
+        CRDS_VER: ${{ steps.versions.outputs.crds_ver }}
+        SERVICE_VER: ${{ steps.versions.outputs.service_ver }}
+        AAP_VER: ${{ steps.versions.outputs.aap_ver }}
+        BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
+        BMF_CRDS_VER: ${{ steps.versions.outputs.bmf_crds_ver }}
+        UI_VER: ${{ steps.versions.outputs.ui_ver }}
+      run: |
+        BODY=$(mktemp)
+        cat > "$BODY" <<EOF
+        ## Component versions
+
+        | Component | Version | Chart |
+        |-----------|---------|-------|
+        | fulfillment-service | ${SERVICE_VER} | oci://ghcr.io/osac-project/charts/fulfillment-service |
+        | osac-operator | ${OPERATOR_VER} | oci://ghcr.io/osac-project/charts/osac-operator |
+        | osac-operator-crds | ${CRDS_VER} | oci://ghcr.io/osac-project/charts/osac-operator-crds |
+        | osac-aap | ${AAP_VER} | oci://ghcr.io/osac-project/charts/osac-aap |
+        | bare-metal-fulfillment-operator | ${BMF_VER} | oci://ghcr.io/osac-project/charts/bare-metal-fulfillment-operator |
+        | bare-metal-fulfillment-operator-crds | ${BMF_CRDS_VER} | oci://ghcr.io/osac-project/charts/bare-metal-fulfillment-operator-crds |
+        | osac-ui | ${UI_VER} | oci://ghcr.io/osac-project/charts/osac-ui |
+
+        ## Install
+
+        \`\`\`bash
+        helm install osac oci://ghcr.io/osac-project/charts/osac --version ${VERSION}
+        \`\`\`
+        EOF
+        # Strip leading whitespace from heredoc (indented for YAML readability)
+        sed -i 's/^        //' "$BODY"
+
+        gh release create "v${VERSION}" \
+          --repo "${{ github.repository }}" \
+          --title "OSAC v${VERSION}" \
+          --notes-file "$BODY" \
+        || gh release edit "v${VERSION}" \
+          --repo "${{ github.repository }}" \
+          --notes-file "$BODY"
+        rm -f "$BODY"


### PR DESCRIPTION
## Summary
- Add a release step after chart push that creates a GitHub Release with a component version table
- Lists all sub-chart versions and install instructions in the release body
- Change `contents` permission from `read` to `write` for `gh release create`
- Uses `gh release edit` fallback for idempotent re-runs

## Test plan
- [ ] Push a test tag (or dispatch workflow) and verify GitHub Release is created with version table
- [ ] Verify component versions are correctly listed in the release body
- [ ] Re-run the workflow and verify `gh release edit` fallback works
- [ ] Verify chart publishing still works as before