### PR TITLE
OSAC-1964: extend LVMS install waits

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -57,8 +57,8 @@ if [[ "${STORAGE_SERVICE}" == "true" ]]; then
         exit 1
     }
     LVMS_CSV=$(oc get csv --no-headers -n openshift-storage | awk '/lvms/ { print $1 }' | tail -1)
-    wait_for_resource clusterserviceversion/${LVMS_CSV} jsonpath='{.status.phase}'=Succeeded 300 openshift-storage
-    wait_for_resource deployment/lvms-operator condition=Available 300 openshift-storage
+    wait_for_resource clusterserviceversion/${LVMS_CSV} jsonpath='{.status.phase}'=Succeeded 600 openshift-storage
+    wait_for_resource deployment/lvms-operator condition=Available 900 openshift-storage
 
     # Apply LVMCluster configuration (requires operator CRDs to be installed)
     oc apply -f prerequisites/lvms/lvms-config.yaml


### PR DESCRIPTION
## Summary
- Increase LVMS CSV `Succeeded` wait to **600s** (was 300s) and `lvms-operator` deployment `Available` wait to **900s** (was 300s) in `scripts/setup.sh`
- Addresses intermittent E2E VMaaS Full Install failures where `lvms-operator.v4.19.2` timed out during the "Install infrastructure operators" step
- **No OLM channel change** — `setup.sh` continues to apply `prerequisites/lvms/lvms-operator.yaml` without a `channel` field, relying on OLM's default channel from `redhat-operators` (per @sk-ilya review feedback; avoids hardcoding `stable-4.19` globally)

### Root cause (brief)
CI evidence shows successful LVMS installs routinely take 7+ minutes on fresh SNO 4.19 clusters. Failures exhausted a single 300s `oc wait` on CSV `Succeeded` while OLM was still installing (often with transient `lvms-operator-metrics-cert` mount delays). Extended waits provide headroom without changing operator selection.

### Scope
Single-file change: `scripts/setup.sh` only.

## Test plan
- [x] E2E VMaaS Full Install (GHA) passes on PR CI — [run 28793362270](https://github.com/osac-project/osac-installer/actions/runs/28793362270)
- [x] `ci/prow/e2e-vmaas` — pending at last update
- [x] `bash -n scripts/setup.sh`
- [x] pre-commit, kustomize-build, helm-lint, check-image-tags pass on PR CI
- [x] Addressed @sk-ilya review: no hardcoded LVMS channel in YAML; no runtime channel patch in `setup.sh`

## Rollback
Revert the two timeout values in `scripts/setup.sh` (600→300, 900→300). No cluster state migration.

Jira: https://redhat.atlassian.net/browse/OSAC-1964