### PR TITLE
OSAC-1455: Deploy network manager registration ConfigMaps for fabric and k8s managers

### DIFF
--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -104,6 +104,15 @@ clusterFulfillment:
   secret:
     NETRIS_PASSWORD: "test-password"
 
+networkManagers:
+  enabled: true
+  fabricManagers:
+    netris:
+      enabled: true
+      description: "Netris fabric manager for CI testing."
+      capabilities:
+        - ipv4
+
 networkFulfillment:
   enabled: true
   config:

--- a/charts/osac/templates/network-managers.yaml
+++ b/charts/osac/templates/network-managers.yaml
@@ -1,0 +1,25 @@
+{{- define "osac.networkManagerConfigMaps" -}}
+{{- range $name, $mgr := .managers }}
+{{- if or (not (hasKey $mgr "enabled")) $mgr.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osac-network-{{ $.kind }}-manager-{{ $name | replace "_" "-" }}
+  namespace: {{ $.root.Release.Namespace }}
+  labels:
+    {{- include "osac.labels" $.root | nindent 4 }}
+    osac.openshift.io/network-{{ $.kind }}-manager: "true"
+data:
+  name: {{ $name | quote }}
+  {{- if $mgr.description }}
+  description: {{ $mgr.description | quote }}
+  {{- end }}
+  capabilities: {{ $mgr.capabilities | join "," | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+{{- if .Values.networkManagers.enabled }}
+{{- include "osac.networkManagerConfigMaps" (dict "managers" .Values.networkManagers.fabricManagers "kind" "fabric" "root" $) }}
+{{- include "osac.networkManagerConfigMaps" (dict "managers" .Values.networkManagers.k8sManagers "kind" "k8s" "root" $) }}
+{{- end }}

--- a/charts/osac/templates/operator-rbac-supplement.yaml
+++ b/charts/osac/templates/operator-rbac-supplement.yaml
@@ -1,0 +1,38 @@
+{{/*
+Grants the osac-operator ServiceAccount namespaced access to ConfigMaps so it
+can discover network-manager registration ConfigMaps (see
+charts/osac/templates/network-managers.yaml) and read ca-bundle, without
+granting cluster-wide ConfigMap access.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osac-operator-configmaps-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osac-operator-configmaps-{{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osac-operator-configmaps-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: osac-operator
+  namespace: {{ .Release.Namespace }}

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -3,6 +3,33 @@
   "title": "OSAC Helm Chart Values",
   "description": "Configuration values for Open Sovereign AI Cloud deployment",
   "type": "object",
+  "$defs": {
+    "networkManagerEntry": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy this manager's ConfigMap",
+          "default": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the manager"
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "List of capabilities supported by this manager",
+          "items": {
+            "type": "string",
+            "enum": ["ipv4", "ipv6", "dualStack", "dpuSupport"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": ["capabilities"]
+    }
+  },
   "properties": {
     "operatorCrds": {
       "type": "object",
@@ -1184,6 +1211,37 @@
           "type": "boolean",
           "description": "Create hub-access resources and register local cluster as hub",
           "default": false
+        }
+      }
+    },
+    "networkManagers": {
+      "type": "object",
+      "description": "Network manager registration ConfigMaps for the two-manager model (fabric + k8s)",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy network manager registration ConfigMaps",
+          "default": false
+        },
+        "fabricManagers": {
+          "type": "object",
+          "description": "Fabric managers handle physical networking: segments, ACLs, IPs, NAT",
+          "propertyNames": {
+            "pattern": "^[a-z][a-z0-9_-]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/networkManagerEntry"
+          }
+        },
+        "k8sManagers": {
+          "type": "object",
+          "description": "K8s managers bridge the Kubernetes OVN overlay to the physical fabric",
+          "propertyNames": {
+            "pattern": "^[a-z][a-z0-9_-]*$"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/networkManagerEntry"
+          }
         }
       }
     },

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -233,6 +233,22 @@ bmf:
   env:
     aapInsecureSkipVerify: "true"
 
+# --- Network Manager Registration ---
+# ConfigMaps that register networking managers for the two-manager model.
+# The operator discovers managers by selecting ConfigMaps with labels
+# osac.openshift.io/network-fabric-manager or osac.openshift.io/network-k8s-manager.
+networkManagers:
+  enabled: false
+  fabricManagers:
+    netris:
+      enabled: true
+      description: >-
+        Netris SDN controller for physical fabric management.
+        Manages VLAN/VxLAN segments, ACLs, public IP allocation, and NAT gateways.
+      capabilities:
+        - ipv4
+  k8sManagers: {}
+
 # --- Validation hooks ---
 validation:
   enabled: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering network managers through chart values.
  * Introduced separate entries for fabric and Kubernetes network managers.
  * Generated manager configuration now includes names, capabilities, and optional descriptions.

* **Bug Fixes**
  * Enabled access needed for the application to read configuration maps at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->