### PR TITLE
OSAC-2112: Enable bundledPostgres in caas-ci values

### DIFF
--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -1,6 +1,11 @@
 # OSAC CaaS (Cluster-as-a-Service) CI Environment Values
 # Replaces overlays/caas-ci/kustomization.yaml
 
+bundledPostgres:
+  enabled: true
+  database:
+    name: service
+
 # --- Operator ---
 operator:
   image:


### PR DESCRIPTION
Missed in 9a314ead which added it to vmaas-ci only. Without this, setup.sh fails at check_postgres_prerequisites when deploying CaaS.
https://redhat.atlassian.net/browse/OSAC-2112
https://redhat.atlassian.net/browse/OSAC-2113
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bundled Postgres configuration option.
  * Default database name is now set to `service` when using the bundled database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->