### PR TITLE
OSAC-2105: pin umbrella chart image tags at publish time

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -174,11 +174,23 @@ jobs:
 
     - name: Update image tags in values.yaml
       env:
-        VERSION: ${{ steps.versions.outputs.version }}
+        OPERATOR_VER: ${{ steps.versions.outputs.operator_ver }}
+        SERVICE_VER: ${{ steps.versions.outputs.service_ver }}
+        AAP_VER: ${{ steps.versions.outputs.aap_ver }}
+        BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
+        UI_VER: ${{ steps.versions.outputs.ui_ver }}
       run: |
-        sed -i \
-          -e "s|tag: latest|tag: v${VERSION}|g" \
-          charts/osac/values.yaml
+        yq -i "
+          .operator.image.tag = \"v${OPERATOR_VER}\" |
+          .bmf.image.tag = \"v${BMF_VER}\" |
+          .service.images.service = \"ghcr.io/osac-project/fulfillment-service:v${SERVICE_VER}\" |
+          .aap.bootstrap.image = \"ghcr.io/osac-project/osac-aap:v${AAP_VER}\" |
+          .ui.images.ui = \"ghcr.io/osac-project/osac-ui:v${UI_VER}\" |
+          .dbMigrate.image = \"ghcr.io/osac-project/fulfillment-service:v${SERVICE_VER}\"
+        " charts/osac/values.yaml
+
+        echo "--- Updated values.yaml image references ---"
+        grep -E "tag:|image:" charts/osac/values.yaml
 
     - name: Package chart
       env:


### PR DESCRIPTION
## Summary
- The umbrella chart's `publish-charts.yaml` only rewrote `tag: latest` via sed, which matches `operator.image.tag` and `bmf.image.tag` but misses images expressed as combined `repo:tag` strings (`service.images.service`, `aap.bootstrap.image`, `ui.images.ui`, `dbMigrate.image`), so those shipped `:latest` in every published OCI version (0.0.1-0.0.4).
- Replaced the sed with a `yq` expression that stamps each image using its already-resolved per-component version (`operator_ver`, `service_ver`, `aap_ver`, `bmf_ver`, `ui_ver`), matching the pattern already used for the `Chart.yaml` dependency rewrite step.
- Verified locally against the real `charts/osac/values.yaml` with fake version env vars — all previously-`:latest` fields resolve correctly, nothing else changes.

Fixes https://redhat.atlassian.net/browse/OSAC-2105

## Test plan
- [ ] CI passes
- [ ] Manually trigger `workflow_dispatch` on `Publish Helm Charts` (or dry-run the step) and confirm `helm template` output has no `:latest` images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to update each component’s image tag independently, keeping published chart values aligned with the correct component versions.
  * Updated the chart values output so the resulting image and tag settings are easier to verify after publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->