### PR TITLE
OSAC-2402: update AGENTS.md/CLAUDE.md for Helm and deprecated Kustomize mode

### DIFF
--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -1,3 +1,5 @@
+# Feedback Workflow
+
 Read and execute .ai-workflows/bugfix/skills/feedback.md with
 the following repo-specific context.
 
@@ -9,10 +11,9 @@ to understand the prior session's decisions and changes.
 ## Feedback Handling Rules
 
 1. **Submodule boundaries**: If feedback asks you to change a file inside
-   `base/osac-operator/`, `base/osac-fulfillment-service/`, or
-   `base/osac-aap/`, explain that these are submodules and the change
-   belongs in the component repo. Suggest what the reviewer should do
-   instead.
+   any `base/*/` directory (discover submodules with: `git submodule status`),
+   explain that these are submodules and the change belongs in the component
+   repo. Suggest what the reviewer should do instead.
 
 2. **Values consistency**: If feedback applies to one values file, check
    whether other values files (development, vmaas-ci, caas-ci)
@@ -20,20 +21,13 @@ to understand the prior session's decisions and changes.
 
 ## Post-Change Validation
 
-After addressing all review comments, run the full validation suite:
+After addressing all review comments, run the full validation suite from the installer root:
 
+```bash
+yamllint --strict /path/to/osac-installer
+(cd /path/to/osac-installer && pre-commit run --all-files)
+make -C /path/to/osac-installer helm-lint
+make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
 ```
-yamllint --strict .
-pre-commit run --all-files
-helm lint charts/osac/
-for f in values/*/values.yaml; do helm template osac charts/osac/ --values "$f" > /dev/null; done
-bash scripts/sync-image-tags.sh
-```
 
-## Session Artifacts
-
-Update `.ai-bot/session-context.md` with a summary of this feedback
-round (what changed, what was kept, why).
-
-Write `.ai-bot/comment-responses.json` with per-comment response
-summaries matching the comment IDs from the task file.
+See `Makefile` for the underlying helm lint/template commands these targets execute.

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -31,3 +31,11 @@ make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/devel
 ```
 
 See `Makefile` for the underlying helm lint/template commands these targets execute.
+
+## Session Artifacts
+
+Update `.ai-bot/session-context.md` with a summary of this feedback
+round (what changed, what was kept, why).
+
+Write `.ai-bot/comment-responses.json` with per-comment response
+summaries matching the comment IDs from the task file.

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -24,10 +24,10 @@ to understand the prior session's decisions and changes.
 After addressing all review comments, run the full validation suite from the installer root:
 
 ```bash
-yamllint --strict /path/to/osac-installer
-(cd /path/to/osac-installer && pre-commit run --all-files)
-make -C /path/to/osac-installer helm-lint
-make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
+yamllint --strict .
+pre-commit run --all-files
+make helm-lint
+make helm-validate VALUES_FILE=values/development/values.yaml
 ```
 
 See `Makefile` for the underlying helm lint/template commands these targets execute.

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -27,7 +27,7 @@ After addressing all review comments, run the full validation suite from the ins
 yamllint --strict .
 pre-commit run --all-files
 make helm-lint
-make helm-validate VALUES_FILE=values/development/values.yaml
+make helm-validate
 ```
 
 See `Makefile` for the underlying helm lint/template commands these targets execute.

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -1,3 +1,5 @@
+# OSAC Installer Instructions
+
 This is a **Helm-based infrastructure/deployment repository**. It
 assembles component submodules (osac-operator, fulfillment-service,
 osac-aap, bare-metal-fulfillment-operator, osac-ui) and deploys them
@@ -10,80 +12,36 @@ After making changes, run the following commands in order. Every command
 must pass -- CI enforces all of them on every PR.
 
 1. **YAML lint** (strict mode, repo-level `.yamllint.yaml` config):
-   ```
-   yamllint --strict .
+
+   ```bash
+   yamllint --strict /path/to/osac-installer
    ```
 
 2. **Pre-commit hooks** (trailing whitespace, merge conflicts, large
    files, private key detection, YAML lint):
-   ```
-   pre-commit run --all-files
-   ```
 
-3. **Helm lint** (validates chart structure and templates):
    ```bash
-   helm lint charts/osac/
+   (cd /path/to/osac-installer && pre-commit run --all-files)
    ```
 
-4. **Helm template render** (renders chart against each values file):
+3. **Helm lint** (validates chart structure and templates -- see `Makefile` for full command):
+
    ```bash
-   for f in values/*/values.yaml; do helm template osac charts/osac/ --values "$f" > /dev/null; done
+   make -C /path/to/osac-installer helm-lint
    ```
 
-5. **Image tag sync** (verifies Helm values image tags match submodule
-   commit SHAs):
+4. **Helm template render** (validates against all values files -- see `Makefile` for full command):
+
    ```bash
-   bash scripts/sync-image-tags.sh
+   make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
    ```
-
-If image tags are out of sync, run `scripts/sync-image-tags.sh --fix`
-and verify the output before committing.
-
-## Submodule Rules (Critical)
-
-- Submodules live under `base/` (osac-operator, osac-fulfillment-service,
-  osac-aap, bare-metal-fulfillment-operator, osac-ui). They are pinned
-  snapshots of upstream repos.
-- **Never `cd` into a submodule directory and run git commands there.**
-  You will operate on the submodule repo, not the installer.
-- Always run git commands from the installer repo root.
-- After updating a submodule pointer, run `bash scripts/sync-image-tags.sh --fix`
-  to update the corresponding image tags in Helm values files.
-- Image tags use the format `sha-XXXXXXX` (first 7 chars of the
-  submodule commit).
-
-## Repository Structure
-
-```
-charts/osac/                     # Helm umbrella chart
-  Chart.yaml                     # Dependencies on subchart repos
-  values.yaml                    # Default values
-  values.schema.json             # JSON Schema for values validation
-  templates/                     # Deployment templates
-
-values/
-  development/values.yaml        # All controllers, latest images
-  vmaas-ci/values.yaml           # VMaaS CI: pinned images
-  caas-ci/values.yaml            # CaaS CI: pinned images
-
-base/                            # Git submodules (version tracking)
-  osac-operator/
-  osac-fulfillment-service/
-  osac-aap/
-  bare-metal-fulfillment-operator/
-  osac-ui/
-
-prerequisites/                   # Cluster-wide operator manifests
-scripts/                         # Automation scripts (setup, teardown, sync)
-```
 
 ## Coding Conventions
 
 - All YAML files must pass `yamllint --strict` with the repo's
   `.yamllint.yaml` config (line-length disabled, document-start disabled,
   indent-sequences: whatever).
-- Shell scripts must use `set -o nounset`, `set -o errexit`,
-  `set -o pipefail`. Source `scripts/lib.sh` for shared functions
+- Shell scripts must use `set -euo pipefail`. Source `scripts/lib.sh` for shared functions
   (`retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`).
 - Always use explicit `-n <namespace>` flags in `oc` commands -- never
   rely on the current context namespace.
@@ -92,6 +50,6 @@ scripts/                         # Automation scripts (setup, teardown, sync)
 
 ## What Not to Modify
 
-- Do not modify files inside `base/osac-operator/`, `base/osac-fulfillment-service/`,
-  `base/osac-aap/`, or `base/bare-metal-fulfillment-operator/` -- these are
-  submodules. Changes to component manifests belong in the component repos.
+- Do not modify files inside any `base/*/` directories (discover with:
+  `git submodule status`) -- these are submodules. Changes to component
+  manifests belong in the component repos.

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -36,6 +36,25 @@ must pass -- CI enforces all of them on every PR.
    make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
    ```
 
+## Repository Structure
+
+```text
+charts/osac/                     # Helm umbrella chart
+  Chart.yaml                     # Dependencies on subchart repos
+  values.yaml                    # Default values
+  values.schema.json             # JSON Schema for values validation
+  templates/                     # Deployment templates
+
+values/
+  development/values.yaml        # All controllers, latest images
+  vmaas-ci/values.yaml           # VMaaS CI: pinned images
+  caas-ci/values.yaml            # CaaS CI: pinned images
+
+base/                            # Git submodules (version tracking) -- discover with: git submodule status
+prerequisites/                   # Cluster-wide operator manifests
+scripts/                         # Automation scripts (setup, teardown, sync)
+```
+
 ## Coding Conventions
 
 - All YAML files must pass `yamllint --strict` with the repo's

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -8,32 +8,32 @@ and no unit tests in this repo. All validation is structural.
 
 ## Validation Commands
 
-After making changes, run the following commands in order. Every command
-must pass -- CI enforces all of them on every PR.
+After making changes, run the following commands from the installer root
+in order. Every command must pass -- CI enforces all of them on every PR.
 
 1. **YAML lint** (strict mode, repo-level `.yamllint.yaml` config):
 
    ```bash
-   yamllint --strict /path/to/osac-installer
+   yamllint --strict .
    ```
 
 2. **Pre-commit hooks** (trailing whitespace, merge conflicts, large
    files, private key detection, YAML lint):
 
    ```bash
-   (cd /path/to/osac-installer && pre-commit run --all-files)
+   pre-commit run --all-files
    ```
 
 3. **Helm lint** (validates chart structure and templates -- see `Makefile` for full command):
 
    ```bash
-   make -C /path/to/osac-installer helm-lint
+   make helm-lint
    ```
 
 4. **Helm template render** (validates against all values files -- see `Makefile` for full command):
 
    ```bash
-   make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
+   make helm-validate VALUES_FILE=values/development/values.yaml
    ```
 
 ## Repository Structure

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -33,7 +33,7 @@ in order. Every command must pass -- CI enforces all of them on every PR.
 4. **Helm template render** (validates against all values files -- see `Makefile` for full command):
 
    ```bash
-   make helm-validate VALUES_FILE=values/development/values.yaml
+   make helm-validate
    ```
 
 ## Repository Structure

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -1,6 +1,8 @@
+# New Ticket Workflow
+
 Execute the following workflow phases in order. This is an
 infrastructure/deployment repo -- there are no unit tests. Validation
-is structural (YAML lint, Helm lint, sync checks).
+is structural (YAML lint, pre-commit, Helm lint, Helm template render).
 
 1. **Read and execute .ai-workflows/bugfix/skills/assess.md**
    The bug report is in `.ai-bot/issue.md`. Identify which files are
@@ -12,31 +14,27 @@ is structural (YAML lint, Helm lint, sync checks).
 
 3. **Read and execute .ai-workflows/bugfix/skills/fix.md**
    Implement the minimal fix. Key constraints:
-   - Never modify files inside submodule directories (`base/osac-operator/`,
-     `base/osac-fulfillment-service/`, `base/osac-aap/`).
-   - If the fix involves submodule pointer updates, also run
-     `bash scripts/sync-image-tags.sh --fix`.
+   - Never modify files inside any `base/*/` submodule directories
+     (discover with: `git submodule status`).
+   - After submodule pointer changes, run
+     `/path/to/osac-installer/scripts/sync-image-tags.sh --fix` to update corresponding image tags.
 
 4. **Validate changes**
    Run all validation commands in sequence. If any fail, revise your
    fix and revalidate (up to 5 iterations):
-   ```
-   yamllint --strict .
-   pre-commit run --all-files
-   helm lint charts/osac/
-   for f in values/*/values.yaml; do helm template osac charts/osac/ --values "$f" > /dev/null; done
-   bash scripts/sync-image-tags.sh
+
+   ```bash
+   yamllint --strict /path/to/osac-installer
+   (cd /path/to/osac-installer && pre-commit run --all-files)
+   make -C /path/to/osac-installer helm-lint
+   make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
    ```
 
 5. **Read and execute .ai-workflows/bugfix/skills/review.md**
-   Self-review your changes. Pay special attention to:
-   - Values file consistency (if you changed one values file, check
-     whether other values files need the same change)
-   - Helm schema updates (new values must have matching schema entries)
-   If issues are found, correct them, revalidate, and re-review
+   Self-review for schema consistency, values file alignment, namespace
+   references. If issues found, correct them, revalidate, and re-review
    (up to 4 iterations).
 
-6. **Write PR description to `.ai-bot/pr.md`**
-   Use the `## Title` heading format. Include:
-   - A Root Cause section from `.ai-bot/diagnosis.md`
-   - Which values files are affected
+6. **Read and execute .ai-workflows/bugfix/skills/pr.md**
+   Write PR description to `.ai-bot/pr.md` with root cause and affected
+   components.

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -27,7 +27,7 @@ is structural (YAML lint, pre-commit, Helm lint, Helm template render).
    yamllint --strict .
    pre-commit run --all-files
    make helm-lint
-   make helm-validate VALUES_FILE=values/development/values.yaml
+   make helm-validate
    ```
 
 5. **Read and execute .ai-workflows/bugfix/skills/review.md**

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -17,17 +17,17 @@ is structural (YAML lint, pre-commit, Helm lint, Helm template render).
    - Never modify files inside any `base/*/` submodule directories
      (discover with: `git submodule status`).
    - After submodule pointer changes, run
-     `/path/to/osac-installer/scripts/sync-image-tags.sh --fix` to update corresponding image tags.
+     `./scripts/sync-image-tags.sh --fix` to update corresponding image tags.
 
 4. **Validate changes**
-   Run all validation commands in sequence. If any fail, revise your
-   fix and revalidate (up to 5 iterations):
+   Run all validation commands from the installer root in sequence. If any
+   fail, revise your fix and revalidate (up to 5 iterations):
 
    ```bash
-   yamllint --strict /path/to/osac-installer
-   (cd /path/to/osac-installer && pre-commit run --all-files)
-   make -C /path/to/osac-installer helm-lint
-   make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
+   yamllint --strict .
+   pre-commit run --all-files
+   make helm-lint
+   make helm-validate VALUES_FILE=values/development/values.yaml
    ```
 
 5. **Read and execute .ai-workflows/bugfix/skills/review.md**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,81 +1,99 @@
-# AGENTS.md
+# OSAC Installer
 
-## Overview
+Helm-based deployment orchestrator for OSAC components. No Go code, no builds, no unit tests — only structural validation.
 
-Helm-based deployment system for the OSAC platform. Component repos (fulfillment-service, osac-operator, osac-aap, bare-metal-fulfillment-operator) are aggregated as Git submodules under `base/` for version tracking. Deployment uses Helm charts under `charts/osac/`.
-
-## Common Commands
+## Quick Start
 
 ```bash
-# Initialize submodules (required before sync-image-tags)
-git submodule update --init --recursive
+# Initialize submodules
+git -C /path/to/osac-installer submodule update --init --recursive
 
-# Helm lint
-helm lint charts/osac/
+# Validate changes
+yamllint --strict /path/to/osac-installer
+(cd /path/to/osac-installer && pre-commit run --all-files)
+make -C /path/to/osac-installer helm-lint
+make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
 
-# Helm template render (dry-run validation)
-helm template osac charts/osac/ --values values/development/values.yaml
-
-# Deploy to OpenShift (three-phase Helm install)
-make install VALUES_FILE=values/<env>/values.yaml
+# Deploy (three-phase Helm install)
+make -C /path/to/osac-installer install VALUES_FILE=/path/to/osac-installer/values/development/values.yaml
 
 # Uninstall
-make uninstall
-
-# Run pre-commit hooks
-pre-commit run --all-files
-
-# YAML lint only
-yamllint --strict .
+make -C /path/to/osac-installer uninstall
 ```
+
+## Critical Rules
+
+**Submodules (READ ONLY):**
+- Never modify any `base/*/` directories (discover submodules with: `git submodule status`)
+- Changes belong in component repos
+- All git commands must run from installer root — never `cd` into submodule directories or use `git -C base/...`
+
+**Helm Schema:**
+- Every value in `charts/osac/values.yaml` **must** have matching `values.schema.json` entry
+- Use `enum` for fields with known valid values
+
+**Shell Scripts:**
+- Use `set -euo pipefail` in all `scripts/*.sh`
+- Source `scripts/lib.sh` for: `retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`
+
+**Git Workflow:**
+- Push to `fork` remote, never `origin`
+- PRs: `fork/<branch>` → `origin/main`
+- Commits: DCO (`-s`) + `Assisted-by: Claude Code <noreply@anthropic.com>`
+
+**Shared Clusters:**
+- Always use `-n <namespace>` in `oc`/`kubectl` — never rely on context
 
 ## Architecture
 
-### Helm Chart
+See `docs/helm-deployment-guide.md` for complete architecture details, including:
+- Helm chart structure and dependencies
+- Submodule organization and version tracking
+- Prerequisites and operator deployment patterns
+- Values file organization per environment
 
 ```text
-charts/osac/                         # Umbrella chart
-  Chart.yaml                         # Dependencies on subchart repos
-  values.yaml                        # Default values
-  values.schema.json                 # JSON Schema for values validation
-  templates/                         # Deployment templates
-
-values/
-  development/values.yaml            # All controllers, latest images
-  vmaas-ci/values.yaml               # VMaaS CI: computeInstance + tenant + networking, pinned images
-  caas-ci/values.yaml                # CaaS CI: clusterOrder + tenant + networking, pinned images
+charts/osac/           # Helm umbrella chart (Chart.yaml, values.yaml, values.schema.json)
+charts/osac-operators/ # Phase 1: OLM operator subscriptions
+charts/osac-prereqs/   # Phase 2: CRD instances, certs, Keycloak
+values/<env>/          # Environment values (development, vmaas-ci, caas-ci)
+base/                  # Git submodules — discover with: git submodule status
+prerequisites/         # Reference manifests for manual prerequisite installation
+scripts/               # Automation scripts (see README.md for full list)
 ```
 
-### Submodules
+Submodules are pinned snapshots for version tracking. Image tags in `values/*/values.yaml`
+must match submodule commits — CI enforces this via `scripts/sync-image-tags.sh`.
+After updating a submodule pointer, run `./scripts/sync-image-tags.sh --fix`.
 
-Submodules under `base/` (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are pinned snapshots used for version tracking. Image tags in `values/*/values.yaml` must match submodule commit SHAs. CI enforces this via `scripts/sync-image-tags.sh`.
+Prerequisites are installed via Phase 1 (`make install-operators`) and Phase 2
+(`make install-prereqs`), each gated by values toggles. See `Makefile` for
+underlying commands and `docs/helm-deployment-guide.md` for phase details.
 
-### Prerequisites
+## Key Scripts
 
-Prerequisites are installed automatically by Phase 1 (`make install-operators`) and configured by Phase 2 (`make install-prereqs`). Each prerequisite is gated by a values toggle. `prerequisites/` contains reference manifests for manual installation if needed.
+See `README.md` for complete script documentation. Most commonly used:
 
-### Scripts
+- `teardown.sh` — Full teardown: uninstalls Helm releases, removes operators and CRDs
+- `sync-image-tags.sh` — Syncs Helm values image tags to match submodule commits
+- `refresh-after-snapshot.py` — Refresh after snapshot boot
 
-- **teardown.sh** -- Full teardown: uninstalls Helm release, removes operators and CRDs.
-- **sync-image-tags.sh** -- Syncs image tags in Helm values files to match submodule commits.
-- **setup-remote-cluster.sh** -- CI-only script for preparing a remote cluster (LVMS, CNV, service accounts).
-- **create-hub-access-kubeconfig.sh** -- Generates `kubeconfig.hub-access` from the hub-access ServiceAccount token.
-- **lib.sh** -- Shared shell functions: `retry_until` (retry with timeout) and `wait_for_resource` (wait for k8s resource condition).
+## Workflows
 
-## Submodules and Local Development
+AI-assisted workflows reference detailed phase instructions:
 
-Submodules under `base/` are pinned snapshots of the real working repos. They do not auto-sync -- to test local changes, synchronize modified files from the working repo into the submodule directory, without committing. During active development the submodule pointers are often dirty; this is expected.
+- **Bugfix workflow:** `.ai-bot/new-ticket-workflow.md` → phases in `.ai-workflows/bugfix/skills/`
+- **Review feedback:** `.ai-bot/feedback-workflow.md` → phases in `.ai-workflows/bugfix/skills/feedback.md`
 
-Do not `cd` into submodule directories and run git commands there -- you will operate on the submodule repo, not the installer. Always run git commands from the installer root.
+## Documentation
 
-After updating a submodule pointer, update the corresponding image tag via `./scripts/sync-image-tags.sh --fix`.
+Detailed information moved from this file to specialized docs:
 
-## Helm Chart Conventions
-
-- **Every new value must have a matching schema entry** -- when adding or modifying keys in `charts/osac/values.yaml`, always add the corresponding property definition to `charts/osac/values.schema.json`. Use `enum` constraints for fields with a known set of valid values (e.g., network/DNS backend classes). The schema is both validation and documentation -- incomplete schemas allow silent misconfiguration.
-
-## Key Conventions
-
-- Values files are organized per environment under `values/<env>/values.yaml`.
-- Pull secrets and AAP license files are stored alongside values files (e.g., `values/<env>/pull-secret.json`, `values/<env>/license.zip`).
-- `ca-bundle` Bundle is cluster-scoped and managed by the `osac-prereqs` chart via trust-manager.
+- **Bugfix workflow orchestrator:** `.ai-bot/new-ticket-workflow.md` (phases: assess → diagnose → fix → validate → review → pr)
+- **Review feedback workflow:** `.ai-bot/feedback-workflow.md`
+- **Validation commands & conventions:** `.ai-bot/instructions.md`
+- **Architecture & deployment:** `docs/helm-deployment-guide.md`
+- **Script reference:** `README.md`
+- **CLI usage:** `OSAC-CLI-HOWTO.md`
+- **Component repos:** `base/*/AGENTS.md` (discover with: `git submodule status`)
+- **Design docs:** [osac-project/docs/architecture](https://github.com/osac-project/docs/tree/main/architecture)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,23 @@ values/
   bmaas-ci/values.yaml                 # BM-as-a-Service CI: bmf + storage + bareMetalInstance
 ```
 
-Submodules are pinned snapshots for version tracking. Image tags in `values/*/values.yaml`
-must match submodule commits — CI enforces this via `scripts/sync-image-tags.sh`.
-Image tags follow the `sha-XXXXXXX` format (first 7 characters of the submodule
-commit SHA). After updating a submodule pointer, run `./scripts/sync-image-tags.sh --fix`.
+Pull secrets and AAP license files are stored alongside values files (e.g.,
+`values/<env>/pull-secret.json`, `values/<env>/license.zip`).
+
+Submodules are pinned snapshots for version tracking. They do not auto-sync --
+to test local changes, synchronize modified files from the working repo into
+the submodule directory, without committing. During active development the
+submodule pointers are often dirty; this is expected. Image tags in
+`values/*/values.yaml` must match submodule commits — CI enforces this via
+`scripts/sync-image-tags.sh`. Image tags follow the `sha-XXXXXXX` format
+(first 7 characters of the submodule commit SHA). After updating a submodule
+pointer, run `./scripts/sync-image-tags.sh --fix`.
 
 Prerequisites are installed via Phase 1 (`make install-operators`) and Phase 2
-(`make install-prereqs`), each gated by values toggles. See `Makefile` for
-underlying commands and `docs/helm-deployment-guide.md` for phase details.
+(`make install-prereqs`), each gated by values toggles. `ca-bundle` Bundle is
+cluster-scoped and managed by the `osac-prereqs` chart via trust-manager. See
+`Makefile` for underlying commands and `docs/helm-deployment-guide.md` for
+phase details.
 
 ## Key Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ git submodule update --init --recursive
 yamllint --strict .
 pre-commit run --all-files
 make helm-lint
-make helm-validate VALUES_FILE=values/development/values.yaml
+make helm-validate
 ```
 
 ## Common Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,20 @@
 
 Helm-based deployment orchestrator for OSAC components. No Go code, no builds, no unit tests — only structural validation.
 
+Helm-based deployment system for the OSAC platform. Component repos (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-operators/` (Phase 1), `charts/osac-prereqs/` (Phase 2), `charts/osac/` (Phase 3).
+
 ## Quick Start
 
 ```bash
 # Initialize submodules
-git -C /path/to/osac-installer submodule update --init --recursive
+git submodule update --init --recursive
 
 # Validate changes
-yamllint --strict /path/to/osac-installer
-(cd /path/to/osac-installer && pre-commit run --all-files)
-make -C /path/to/osac-installer helm-lint
-make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
-Helm-based deployment system for the OSAC platform. Component repos (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-operators/` (Phase 1), `charts/osac-prereqs/` (Phase 2), `charts/osac/` (Phase 3).
+yamllint --strict .
+pre-commit run --all-files
+make helm-lint
+make helm-validate VALUES_FILE=values/development/values.yaml
+```
 
 ## Common Commands
 
@@ -27,19 +29,19 @@ make helm-lint
 # Helm template render (dry-run validation against all values files)
 make helm-validate
 
-# Sync submodules and rebuild chart dependencies
-make sync-charts
-
 # Deploy (three-phase Helm install)
-make -C /path/to/osac-installer install VALUES_FILE=/path/to/osac-installer/values/development/values.yaml
+make install VALUES_FILE=values/development/values.yaml
 
 # Individual install phases
 make install-operators VALUES_FILE=values/<env>/values.yaml
 make install-prereqs VALUES_FILE=values/<env>/values.yaml
 make install-osac VALUES_FILE=values/<env>/values.yaml
 
+# Sync submodules and rebuild chart dependencies
+make sync-charts
+
 # Uninstall
-make -C /path/to/osac-installer uninstall
+make uninstall
 ```
 
 ## Critical Rules
@@ -64,6 +66,25 @@ make -C /path/to/osac-installer uninstall
 
 **Shared Clusters:**
 - Always use `-n <namespace>` in `oc`/`kubectl` — never rely on context
+
+## Architecture
+
+See `docs/helm-deployment-guide.md` for complete architecture details, including:
+- Helm chart structure and dependencies
+- Submodule organization and version tracking
+- Prerequisites and operator deployment patterns
+- Values file organization per environment
+
+```text
+charts/osac/           # Helm umbrella chart (Chart.yaml, values.yaml, values.schema.json)
+charts/osac-operators/ # Phase 1: OLM operator subscriptions
+charts/osac-prereqs/   # Phase 2: CRD instances, certs, Keycloak
+values/<env>/          # Environment values (development, vmaas-ci, caas-ci)
+base/                  # Git submodules — discover with: git submodule status
+prerequisites/         # Reference manifests for manual prerequisite installation
+scripts/               # Automation scripts (see README.md for full list)
+```
+
 ### Helm Charts (Three-Phase Deployment)
 
 ```text
@@ -97,33 +118,19 @@ values/
   bmaas-ci/values.yaml                 # BM-as-a-Service CI: bmf + storage + bareMetalInstance
 ```
 
-## Architecture
-
-See `docs/helm-deployment-guide.md` for complete architecture details, including:
-- Helm chart structure and dependencies
-- Submodule organization and version tracking
-- Prerequisites and operator deployment patterns
-- Values file organization per environment
-
-```text
-charts/osac/           # Helm umbrella chart (Chart.yaml, values.yaml, values.schema.json)
-charts/osac-operators/ # Phase 1: OLM operator subscriptions
-charts/osac-prereqs/   # Phase 2: CRD instances, certs, Keycloak
-values/<env>/          # Environment values (development, vmaas-ci, caas-ci)
-base/                  # Git submodules — discover with: git submodule status
-prerequisites/         # Reference manifests for manual prerequisite installation
-scripts/               # Automation scripts (see README.md for full list)
-```
-
 Submodules are pinned snapshots for version tracking. Image tags in `values/*/values.yaml`
 must match submodule commits — CI enforces this via `scripts/sync-image-tags.sh`.
-After updating a submodule pointer, run `./scripts/sync-image-tags.sh --fix`.
+Image tags follow the `sha-XXXXXXX` format (first 7 characters of the submodule
+commit SHA). After updating a submodule pointer, run `./scripts/sync-image-tags.sh --fix`.
 
 Prerequisites are installed via Phase 1 (`make install-operators`) and Phase 2
 (`make install-prereqs`), each gated by values toggles. See `Makefile` for
 underlying commands and `docs/helm-deployment-guide.md` for phase details.
 
 ## Key Scripts
+
+See `README.md` for complete script documentation. Most commonly used:
+
 - **teardown.sh** -- Full teardown: uninstalls Helm releases, removes operators and CRDs
 - **sync-image-tags.sh** -- Syncs image tags in Helm values files to match submodule commits
 - **setup-remote-cluster.sh** -- CI-only: prepares a fresh remote cluster (LVMS, CNV, service accounts)
@@ -153,12 +160,6 @@ underlying commands and `docs/helm-deployment-guide.md` for phase details.
 | `publish-charts.yaml` | Publishes Helm charts on release |
 | `secret-scanning.yaml` | Scans for leaked secrets |
 | `slash-command.yml` | Handles PR slash commands |
-
-See `README.md` for complete script documentation. Most commonly used:
-
-- `teardown.sh` — Full teardown: uninstalls Helm releases, removes operators and CRDs
-- `sync-image-tags.sh` — Syncs Helm values image tags to match submodule commits
-- `refresh-after-snapshot.py` — Refresh after snapshot boot
 
 ## Workflows
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ make helm-validate
 # Sync submodules and rebuild chart dependencies
 make sync-charts
 
-# Deploy (three-phase Helm install)
-make install VALUES_FILE=values/development/values.yaml
+# Deploy to OpenShift (three-phase Helm install)
+make install VALUES_FILE=values/<env>/values.yaml
 
 # Individual install phases
 make install-operators VALUES_FILE=values/<env>/values.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ make helm-lint
 # Helm template render (dry-run validation against all values files)
 make helm-validate
 
+# Sync submodules and rebuild chart dependencies
+make sync-charts
+
 # Deploy (three-phase Helm install)
 make install VALUES_FILE=values/development/values.yaml
 
@@ -36,9 +39,6 @@ make install VALUES_FILE=values/development/values.yaml
 make install-operators VALUES_FILE=values/<env>/values.yaml
 make install-prereqs VALUES_FILE=values/<env>/values.yaml
 make install-osac VALUES_FILE=values/<env>/values.yaml
-
-# Sync submodules and rebuild chart dependencies
-make sync-charts
 
 # Uninstall
 make uninstall

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,55 @@
 @AGENTS.md
+
+## Claude Code Tooling
+
+This is an infrastructure/deployment repository (Helm-based) with no Go code, container builds, or unit tests. All validation is structural (YAML lint, Helm lint/template). Legacy overlay directories under `overlays/` store environment-specific secret files (no kustomization.yaml).
+
+### Read Tool
+
+Use for reading YAML manifests, Helm chart files, scripts, submodule metadata. Primary targets:
+
+- `charts/osac/values.yaml`, `charts/osac/values.schema.json` -- Helm default values and schema
+- `values/<env>/values.yaml` -- Helm environment-specific values
+- `scripts/*.sh`, `scripts/*.py` -- Automation scripts
+- `prerequisites/` -- Operator manifests
+
+### Edit Tool
+
+Use for updating Helm chart files, YAML manifests, shell scripts. Common edits:
+
+- New/changed keys in `charts/osac/values.yaml` -- always add a matching property in `charts/osac/values.schema.json`
+- Script logic in `scripts/*.sh` (follow `set -euo pipefail`)
+
+Never use Edit for files in submodule directories (`base/*/` -- discover with: `git submodule status`).
+
+### Write Tool
+
+Use sparingly. Most work is editing existing files. Valid use cases:
+
+- New prerequisite manifests in `prerequisites/`
+- New Helm values files in `values/<env>/`
+- Session artifacts (`.ai-bot/diagnosis.md`, `.ai-bot/pr.md`)
+
+Never use Write for files in submodule directories (`base/*/` -- discover with: `git submodule status`).
+
+### Bash Tool
+
+Use for validation commands, Helm operations, git operations. Always use absolute paths since the thread cwd resets between calls. Always specify `-n <namespace>` explicitly in `oc` commands on shared clusters.
+
+Example commands (replace placeholders with absolute paths):
+
+```bash
+# Validation suite (run in order, all must pass)
+yamllint --strict /path/to/osac-installer
+(cd /path/to/osac-installer && pre-commit run --all-files)
+make -C /path/to/osac-installer helm-lint
+make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
+
+# Git operations (always from installer root, never inside submodules)
+git -C /path/to/osac-installer status
+git -C /path/to/osac-installer add /path/to/file1 /path/to/file2
+git -C /path/to/osac-installer commit -s -m "OSAC-XXXX: description
+
+Assisted-by: Claude Code <noreply@anthropic.com>"
+git -C /path/to/osac-installer push fork <branch>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Example commands (run from the installer repo root):
 yamllint --strict .
 pre-commit run --all-files
 make helm-lint
-make helm-validate VALUES_FILE=values/development/values.yaml
+make helm-validate
 
 # Git operations (always from installer root, never inside submodules)
 git status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,22 +34,22 @@ Never use Write for files in submodule directories (`base/*/` -- discover with: 
 
 ### Bash Tool
 
-Use for validation commands, Helm operations, git operations. Always use absolute paths since the thread cwd resets between calls. Always specify `-n <namespace>` explicitly in `oc` commands on shared clusters.
+Use for validation commands, Helm operations, git operations. Commands run relative to the installer repo root (cwd). Always specify `-n <namespace>` explicitly in `oc` commands on shared clusters.
 
-Example commands (replace placeholders with absolute paths):
+Example commands (run from the installer repo root):
 
 ```bash
 # Validation suite (run in order, all must pass)
-yamllint --strict /path/to/osac-installer
-(cd /path/to/osac-installer && pre-commit run --all-files)
-make -C /path/to/osac-installer helm-lint
-make -C /path/to/osac-installer VALUES_FILE=/path/to/osac-installer/values/development/values.yaml helm-validate
+yamllint --strict .
+pre-commit run --all-files
+make helm-lint
+make helm-validate VALUES_FILE=values/development/values.yaml
 
 # Git operations (always from installer root, never inside submodules)
-git -C /path/to/osac-installer status
-git -C /path/to/osac-installer add /path/to/file1 /path/to/file2
-git -C /path/to/osac-installer commit -s -m "OSAC-XXXX: description
+git status
+git add file1 file2
+git commit -s -m "OSAC-XXXX: description
 
 Assisted-by: Claude Code <noreply@anthropic.com>"
-git -C /path/to/osac-installer push fork <branch>
+git push fork <branch>
 ```


### PR DESCRIPTION
## Summary
- Rewrite AGENTS.md to reflect Helm-first deployment model: updated quick start, dynamic submodule discovery, simplified validation suite (`make helm-lint`, `make helm-validate`)
- Add Claude Code tooling section to CLAUDE.md with submodule protections and cwd-relative command patterns
- Update `.ai-bot/` workflow docs (feedback, instructions, new-ticket) for Helm validation
- Remove stale Kustomize references and non-existent script paths (post-OSAC-1677 CI cleanup)
- Fix AGENTS.md structural issues (garbled Quick Start/Common Commands boundary, missing Architecture heading, duplicate Key Scripts list) introduced by prior merge rounds
- Address eranco74's review feedback: replaced `/path/to/osac-installer` placeholders with cwd-relative commands, documented the `sha-XXXXXXX` image tag format, moved `make sync-charts` before the deploy commands (it's a pre-deploy step, not teardown)

## Jira
https://redhat.atlassian.net/browse/OSAC-2402

## Test plan
- [x] Every script/workflow referenced in AGENTS.md verified against live repo
- [x] Validation commands are runnable (`yamllint --strict .`, `pre-commit run --all-files`, `make helm-lint`, `make helm-validate`)
- [x] No references to non-existent files or commands
- [x] All command examples are cwd-relative (run from the installer repo root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)