### PR TITLE
OSAC-2173: update installer chart schema for BMC credentials

### DIFF
--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -279,15 +279,15 @@ aap:
     # servers:
     #   - name: node001
     #     bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
-    #     bmc_username: "admin"
-    #     bmc_password: "password"
+    #     bmc_username: "<BMC_USERNAME>"
+    #     bmc_password: "<BMC_PASSWORD>"
     #     boot_mac: "AA:BB:CC:DD:EE:01"
     #     netris_server_name: "server-01"
     #     resource_class: "fc430"
     #   - name: node002
     #     bmc_url: "redfish-virtualmedia+https://192.168.1.22:8000/redfish/v1/Systems/<uuid>"
-    #     bmc_username: "admin"
-    #     bmc_password: "password"
+    #     bmc_username: "<BMC_USERNAME>"
+    #     bmc_password: "<BMC_PASSWORD>"
     #     boot_mac: "AA:BB:CC:DD:EE:02"
     #     netris_server_name: "server-02"
     #     resource_class: "fc430"

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -271,6 +271,7 @@ aap:
 
   # Server inventory for bare metal agent import.
   # Each entry provisions a BareMetalHost CR via the import-agents playbook.
+  # The playbook auto-creates a BMC Secret named {name}-bmc-secret for each server.
   # See osac-aap/docs/import-agents.md for the server inventory format.
   importAgents:
     servers: []
@@ -278,13 +279,15 @@ aap:
     # servers:
     #   - name: node001
     #     bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
-    #     bmc_secret: "node001-bmc-secret"
+    #     bmc_username: "admin"
+    #     bmc_password: "password"
     #     boot_mac: "AA:BB:CC:DD:EE:01"
     #     netris_server_name: "server-01"
     #     resource_class: "fc430"
     #   - name: node002
     #     bmc_url: "redfish-virtualmedia+https://192.168.1.22:8000/redfish/v1/Systems/<uuid>"
-    #     bmc_secret: "node002-bmc-secret"
+    #     bmc_username: "admin"
+    #     bmc_password: "password"
     #     boot_mac: "AA:BB:CC:DD:EE:02"
     #     netris_server_name: "server-02"
     #     resource_class: "fc430"

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -514,7 +514,7 @@
               "description": "Server inventory for bare metal agent import. Each entry provisions a BareMetalHost CR.",
               "items": {
                 "type": "object",
-                "required": ["name", "bmc_url", "bmc_secret", "boot_mac", "netris_server_name", "resource_class"],
+                "required": ["name", "bmc_url", "bmc_username", "bmc_password", "boot_mac", "netris_server_name", "resource_class"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -524,9 +524,13 @@
                     "type": "string",
                     "description": "Redfish BMC address for virtual media boot"
                   },
-                  "bmc_secret": {
+                  "bmc_username": {
                     "type": "string",
-                    "description": "Name of the Kubernetes Secret with BMC credentials"
+                    "description": "BMC username. The playbook creates a Kubernetes Secret named {name}-bmc-secret with these credentials."
+                  },
+                  "bmc_password": {
+                    "type": "string",
+                    "description": "BMC password. The playbook creates a Kubernetes Secret named {name}-bmc-secret with these credentials."
                   },
                   "boot_mac": {
                     "type": "string",


### PR DESCRIPTION
## Summary

Updates the osac-installer umbrella chart schema to match the osac-aap playbook changes from https://github.com/osac-project/osac-aap/pull/403 (merged).

Replaces `bmc_secret` with `bmc_username`/`bmc_password` in the import-agents server inventory schema. The import-agents playbook now creates BMC Secrets at runtime from these credentials — no manual Secret creation required.

## Changes

- **`values.schema.json`**: Replace `bmc_secret` with `bmc_username` and `bmc_password` as required fields in the server item schema
- **`values-example.yaml`**: Update example to use the new credential fields

## Depends on

- https://github.com/osac-project/osac-aap/pull/403 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the server inventory example to show BMC connection details without a pre-created secret.
  * Clarified that a BMC secret is created automatically for each server using the provided credentials.

* **Bug Fixes**
  * Changed the required server fields so BMC username and password are now captured explicitly instead of a single secret reference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->