### PR TITLE
OSAC-2182: remove push:tags trigger from umbrella publish-charts workflow

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,9 +1,6 @@
 name: Publish Helm Charts
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       version:
@@ -86,7 +83,7 @@ jobs:
           exit 1
         fi
 
-        # Component versions: from inputs (workflow_dispatch) or default to umbrella version
+        # Component versions: always from workflow_dispatch inputs (all required)
         crds_ver="${INPUT_CRDS_VERSION}"
         operator_ver="${INPUT_OPERATOR_VERSION}"
         service_ver="${INPUT_SERVICE_VERSION}"
@@ -94,15 +91,6 @@ jobs:
         bmf_crds_ver="${INPUT_BMF_CRDS_VERSION}"
         bmf_ver="${INPUT_BMF_VERSION}"
         ui_ver="${INPUT_UI_VERSION}"
-
-        # When triggered by tag push (no inputs), use the umbrella version for all components
-        : "${crds_ver:=${version}}"
-        : "${operator_ver:=${version}}"
-        : "${service_ver:=${version}}"
-        : "${aap_ver:=${version}}"
-        : "${bmf_crds_ver:=${version}}"
-        : "${bmf_ver:=${version}}"
-        : "${ui_ver:=${version}}"
 
         # Validate all component versions
         for pair in "osac-operator-crds:${crds_ver}" "osac-operator:${operator_ver}" "fulfillment-service:${service_ver}" "osac-aap:${aap_ver}" "bare-metal-fulfillment-operator-crds:${bmf_crds_ver}" "bare-metal-fulfillment-operator:${bmf_ver}" "osac-ui:${ui_ver}"; do


### PR DESCRIPTION
## Summary

- `publish-charts.yaml` triggered on both `push: tags: ['v*']` and `workflow_dispatch`
- The umbrella chart is meant to be published only via `workflow_dispatch` with explicit per-component version inputs
- A bare tag push (e.g. tagging `osac-installer` for version tracking after a release, as the `/osac-release` skill does) independently retriggers the same workflow with no inputs — the "Resolve versions" step then defaults every component version to the umbrella version number
- This has already failed twice in production: runs `28554120530` (tag `v0.0.4`) and `28470564460` (tag `v0.0.3`), both failing with `could not download oci://.../fulfillment-service:0.0.4: not found` — because it tried to pull `fulfillment-service` at the umbrella's version instead of its real version
- Worse case: if a component version ever coincides with the umbrella version, the tag-push run would **succeed silently**, republishing the umbrella chart with wrong dependency pins and overwriting the correct release with no failed CI run to flag it

## Changes

- Removed the `push: tags: ['v*']` trigger — workflow is now `workflow_dispatch`-only
- Removed the now-unreachable tag-push version-defaulting logic in the "Resolve versions" step (all component version inputs are `required: true` for `workflow_dispatch`, so this branch could never execute safely anyway)

## Test plan

- [ ] Confirm `workflow_dispatch` runs with explicit component versions still work as before
- [ ] Confirm pushing a `v*` tag to `osac-installer` no longer triggers `publish-charts.yaml`

Fixes [OSAC-2182](https://redhat.atlassian.net/browse/OSAC-2182).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Publishing charts now runs only when started manually.
  * Component chart versions must be provided explicitly during the run, improving version consistency for published charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->