### PR TITLE
OSAC-2183: only create GitHub Release after chart publish succeeds

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -208,7 +208,6 @@ jobs:
           oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
 
     - name: Create GitHub Release
-      if: always() && steps.versions.outcome == 'success'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VERSION: ${{ steps.versions.outputs.version }}


### PR DESCRIPTION
## Summary

- The `Create GitHub Release` step in `publish-charts.yaml` was gated by `if: always() && steps.versions.outcome == 'success'`
- This only checks that the early `Resolve versions` step succeeded — it does not check that `Package chart` or `Push chart to GHCR` actually succeeded
- Because of `always()`, the step ran even when a later step in the job failed, creating (or updating) a GitHub Release claiming a version was published even though the chart never reached the OCI registry
- This produces false-positive release records that could mislead consumers or downstream automation (e.g. the `/osac-release` skill) into believing a release succeeded when it didn't

## Change

Removed the `if:` condition entirely. With no `if:` specified, GitHub Actions defaults to `success()` semantics — the step now only runs when every prior step in the job (including `Package chart` and `Push chart to GHCR`) actually succeeded.

## Test plan

- [ ] Confirm a normal successful release still creates the GitHub Release as before
- [ ] Simulate a failure in `Package chart` or `Push chart to GHCR` (e.g. temporarily break the OCI push) and confirm no GitHub Release is created

Fixes [OSAC-2183](https://redhat.atlassian.net/browse/OSAC-2183).