### PR TITLE
OSAC-2214: Add per-PR secret scanning with gitleaks

### DIFF
--- a/.github/workflows/secret-scanning.yaml
+++ b/.github/workflows/secret-scanning.yaml
@@ -1,0 +1,91 @@
+name: Secret scanning
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Scan PR diff for leaked secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # createComment/updateComment below use the Issues API even though this
+      # targets a PR (PRs and issues share that endpoint), so issues: write
+      # is needed — pull-requests: write grants no additional capability
+      # here since no pulls.* endpoint is called. Fork PRs still get a
+      # read-only GITHUB_TOKEN regardless, per GitHub's fork security model,
+      # so the comment step will fail there — that's an accepted gap; the
+      # gitleaks scan itself (contents: read) still runs and blocks the PR.
+      issues: write
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Run gitleaks on the PR diff
+      id: gitleaks
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+        # ghcr.io/gitleaks/gitleaks:v8.30.1, pinned by digest for reproducibility
+        docker run --rm -v "${PWD}:/repo" ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f git \
+          --config=/repo/.gitleaks.toml \
+          --log-opts="${BASE_SHA}..${HEAD_SHA}" \
+          --redact \
+          --verbose \
+          --exit-code 1 \
+          /repo
+
+    # Detection alone doesn't fix anything — leave a clear, hard-to-miss
+    # reminder so a real finding gets rotated instead of just removed from
+    # the diff or silently allowlisted.
+    - name: Comment on PR with rotation reminder
+      if: failure() && steps.gitleaks.outcome == 'failure'
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+      with:
+        script: |
+          const marker = '<!-- secret-scanning-rotation-reminder -->';
+          const body = [
+            marker,
+            '**gitleaks detected a potential secret in this PR diff.**',
+            '',
+            'If this is a real credential, rotate it immediately at its source (e.g. regenerate it via ' +
+              'the issuing system\'s admin API/console) — detection is not remediation. A leaked secret ' +
+              'must be treated as compromised even if this PR never merges, since removing it from the ' +
+              'diff or history does not invalidate the value itself.',
+            '',
+            'Red Hat employees: if this involves a Red Hat corporate account or credential, also contact ' +
+              'the Red Hat Information Security team immediately.',
+            '',
+            "If this is a false positive, add a narrowly-scoped entry to `.gitleaks.toml`'s allowlist with a comment explaining why.",
+          ].join('\n');
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+          });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+          }

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+[extend]
+  # Layer our allowlist on top of gitleaks' bundled default rules instead of
+  # replacing them (a config file without this is a full ruleset override).
+  useDefault = true
+
+# Add an entry below for each confirmed false positive, so gitleaks stops
+# flagging it on every PR instead of it being ignored out of alert fatigue.
+# Keep entries narrowly scoped (a specific regex/path, not a broad pattern)
+# and always fill in `description` explaining *why* it's safe to ignore, so
+# it's auditable in review instead of a silent, unexplained suppression.
+#
+# If a finding is a real secret instead of a false positive, rotate it at
+# its source immediately — do not allowlist it.
+#
+# [[allowlists]]
+#   description = "Why this specific value/pattern is a false positive"
+#   regexes = [
+#     '''the-false-positive-value-or-pattern''',
+#   ]


### PR DESCRIPTION
## Summary

Adds a GitHub Actions job that runs `gitleaks` against each PR's diff (`base.sha..head.sha`) so newly introduced secrets are caught before merge, without failing on pre-existing history.

* On a finding, the check fails and a PR comment is posted (or updated on re-runs) reminding the author that a real finding must be rotated at its source, not just removed from the diff or silently allowlisted — detection alone doesn't undo an exposure.
* `.gitleaks.toml` documents the allowlist convention with a commented template, so a future false positive gets a narrowly-scoped, explained entry instead of being ignored out of alert fatigue.

This complements local `rh-pre-commit` hooks (already wired into `bootstrap.sh` for known repos) as a CI-level backstop for cases where hooks aren't installed, get skipped, or a new repo hasn't yet been added to `bootstrap.sh`'s repo list.

Remediating the currently-hardcoded Keycloak secrets themselves is tracked in a separate PR/branch (`keycloak-secret-rotation`), since it's a credential-security fix to the installer, not a CI-hardening change.

Fixes [OSAC-2214](https://redhat.atlassian.net/browse/OSAC-2214)

## Test plan

- [ ] CI itself exercises this job on this PR's own diff
- [ ] Confirm the PR comment appears if a test commit intentionally introduces a fake secret pattern (and disappears/updates correctly on a follow-up push), then drop that test commit before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated secret scanning for pull requests via a dedicated CI workflow.
  * Pull requests with detected potential credentials now fail the check.
  * A PR comment is posted or updated with a rotation reminder and guidance to narrowly allowlist confirmed false positives.
* **Documentation**
  * Added a `.gitleaks.toml` configuration that builds on default rules and includes auditable instructions for targeted allowlisting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->