### PR TITLE
OSAC-1964: fix(installer): extend LVMS CSV wait and add cluster stability gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,12 @@ teardown: ## Teardown OSAC deployment
 test-setup-lvms-timeouts: ## Regression test for OSAC-1964 LVMS wait timeouts
 	bash scripts/test/setup-lvms-timeouts.test.sh
 
+.PHONY: test-setup-cluster-stability
+test-setup-cluster-stability: ## Behavioral test for cluster stability gate env detection
+	bash scripts/test/setup-cluster-stability.test.sh
+
 .PHONY: test
-test: test-setup-lvms-timeouts ## Run installer regression tests
+test: test-setup-lvms-timeouts test-setup-cluster-stability ## Run installer regression tests
 
 ##@ Validation
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ setup: ## Run setup.sh
 teardown: ## Teardown OSAC deployment
 	./scripts/teardown.sh
 
+.PHONY: test-setup-lvms-timeouts
+test-setup-lvms-timeouts: ## Regression test for OSAC-1964 LVMS wait timeouts
+	bash scripts/test/setup-lvms-timeouts.test.sh
+
+.PHONY: test
+test: test-setup-lvms-timeouts ## Run installer regression tests
+
 ##@ Validation
 
 .PHONY: helm-validate

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -19,14 +19,23 @@ retry_until() {
     done
 }
 
-# Returns 0 when every present MachineConfigPool is Updated with matching configuration.
+# Returns 0 when every MCP with machines has Updated=True.
 _machineconfigpools_updated() {
-    local mcp status config desired
+    local mcp status machine_count
     for mcp in $(oc get mcp --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+        machine_count=$(oc get mcp "${mcp}" -o jsonpath='{.status.machineCount}' 2>/dev/null || echo 0)
+        (( machine_count > 0 )) || continue
         status=$(oc get mcp "${mcp}" -o jsonpath='{.status.conditions[?(@.type=="Updated")].status}' 2>/dev/null || true)
-        config=$(oc get mcp "${mcp}" -o jsonpath='{.status.configuration.name}' 2>/dev/null || true)
-        desired=$(oc get mcp "${mcp}" -o jsonpath='{.status.desiredConfiguration.name}' 2>/dev/null || true)
-        [[ "${status}" == "True" && "${config}" == "${desired}" ]] || return 1
+        [[ "${status}" == "True" ]] || return 1
+    done
+}
+
+# Dump MCP state to aid CI triage when the stability gate times out.
+_dump_machineconfigpool_diagnostics() {
+    echo "=== MachineConfigPool diagnostics ==="
+    oc get mcp -o wide || true
+    for mcp in $(oc get mcp --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+        oc describe mcp "${mcp}" || true
     done
 }
 
@@ -45,6 +54,7 @@ wait_for_machineconfigpools_stable() {
     echo "Waiting for MachineConfigPools to be Updated..."
     retry_until "${timeout}" 10 '_machineconfigpools_updated' || {
         echo "Timed out waiting for MachineConfigPools to reach Updated state"
+        _dump_machineconfigpool_diagnostics
         return 1
     }
 }
@@ -61,13 +71,34 @@ wait_for_api_connectivity() {
     }
 }
 
+# Returns 0 when MCP stability wait should be skipped.
+# CI E2E runs "Prepare cluster prerequisites" (mcp/master wait + settle) before
+# SETUP_PHASE=prerequisites setup.sh. Manual installs (SETUP_PHASE=all, no CI) still
+# need the MCP gate when KubeletConfig or other MCO changes may be in flight.
+# Override with SKIP_MCP_STABILITY_CHECK=true if needed.
+_should_skip_mcp_stability_check() {
+    if [[ "${SKIP_MCP_STABILITY_CHECK:-}" == "true" ]]; then
+        return 0
+    fi
+    if [[ "${CI:-}" == "true" || "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        [[ "${SETUP_PHASE:-all}" == "prerequisites" ]]
+        return $?
+    fi
+    return 1
+}
+
 # Combined gate before operator installs that need a responsive API after MCP rollouts.
+# Skips MCP wait only in CI prerequisites phase (workflow already gated MCP).
 # Usage: wait_for_cluster_stability [mcp_timeout_seconds] [api_timeout_seconds]
 wait_for_cluster_stability() {
     local mcp_timeout="${1:-600}"
     local api_timeout="${2:-120}"
 
-    wait_for_machineconfigpools_stable "${mcp_timeout}" || return 1
+    if _should_skip_mcp_stability_check; then
+        echo "Skipping MCP stability check (CI prerequisites phase; workflow already gated MCP rollout)"
+    else
+        wait_for_machineconfigpools_stable "${mcp_timeout}" || return 1
+    fi
     wait_for_api_connectivity "${api_timeout}" || return 1
 }
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -19,6 +19,58 @@ retry_until() {
     done
 }
 
+# Returns 0 when every present MachineConfigPool is Updated with matching configuration.
+_machineconfigpools_updated() {
+    local mcp status config desired
+    for mcp in $(oc get mcp --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
+        status=$(oc get mcp "${mcp}" -o jsonpath='{.status.conditions[?(@.type=="Updated")].status}' 2>/dev/null || true)
+        config=$(oc get mcp "${mcp}" -o jsonpath='{.status.configuration.name}' 2>/dev/null || true)
+        desired=$(oc get mcp "${mcp}" -o jsonpath='{.status.desiredConfiguration.name}' 2>/dev/null || true)
+        [[ "${status}" == "True" && "${config}" == "${desired}" ]] || return 1
+    done
+}
+
+# Wait for MachineConfigPools to finish applying pending changes.
+# On HyperShift or custom control-plane topologies, mcp/master may be absent or
+# non-representative; wait for all present MCPs, or skip when none exist.
+# Usage: wait_for_machineconfigpools_stable [timeout_seconds]
+wait_for_machineconfigpools_stable() {
+    local timeout="${1:-600}"
+
+    if ! oc get mcp &>/dev/null || [[ -z "$(oc get mcp --no-headers 2>/dev/null)" ]]; then
+        echo "No MachineConfigPools found; skipping MCP stability check (typical for HyperShift or custom CP topologies)"
+        return 0
+    fi
+
+    echo "Waiting for MachineConfigPools to be Updated..."
+    retry_until "${timeout}" 10 '_machineconfigpools_updated' || {
+        echo "Timed out waiting for MachineConfigPools to reach Updated state"
+        return 1
+    }
+}
+
+# Wait for stable API server connectivity (healthz + namespace list).
+# Usage: wait_for_api_connectivity [timeout_seconds]
+wait_for_api_connectivity() {
+    local timeout="${1:-120}"
+
+    echo "Waiting for API server connectivity..."
+    retry_until "${timeout}" 5 'oc get --raw /healthz &>/dev/null && oc get ns default &>/dev/null' || {
+        echo "Timed out waiting for API server connectivity"
+        return 1
+    }
+}
+
+# Combined gate before operator installs that need a responsive API after MCP rollouts.
+# Usage: wait_for_cluster_stability [mcp_timeout_seconds] [api_timeout_seconds]
+wait_for_cluster_stability() {
+    local mcp_timeout="${1:-600}"
+    local api_timeout="${2:-120}"
+
+    wait_for_machineconfigpools_stable "${mcp_timeout}" || return 1
+    wait_for_api_connectivity "${api_timeout}" || return 1
+}
+
 # Wait for a namespace to finish terminating if it exists in Terminating state
 # Usage: wait_for_namespace_cleanup <namespace> [timeout_seconds]
 wait_for_namespace_cleanup() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -48,10 +48,12 @@ _dump_machineconfigpool_diagnostics() {
 # Usage: wait_for_machineconfigpools_stable [timeout_seconds]
 wait_for_machineconfigpools_stable() {
     local timeout="${1:-600}"
+    local mcp_list
 
     # Skip only when the MCP API is reachable but no pools exist (HyperShift/custom CP).
+    # Single oc get call avoids TOCTOU between reachability and emptiness checks.
     # API failures fall through to retry_until so transient EOF does not bypass the gate.
-    if oc get mcp &>/dev/null && [[ -z "$(oc get mcp --no-headers 2>/dev/null)" ]]; then
+    if mcp_list=$(oc get mcp --no-headers 2>/dev/null) && [[ -z "${mcp_list}" ]]; then
         echo "No MachineConfigPools found; skipping MCP stability check (typical for HyperShift or custom CP topologies)"
         return 0
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -20,12 +20,15 @@ retry_until() {
 }
 
 # Returns 0 when every MCP with machines has Updated=True.
+# Fails closed on API errors so retry_until keeps polling during transient EOF.
 _machineconfigpools_updated() {
-    local mcp status machine_count
-    for mcp in $(oc get mcp --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null); do
-        machine_count=$(oc get mcp "${mcp}" -o jsonpath='{.status.machineCount}' 2>/dev/null || echo 0)
+    local mcp status machine_count mcp_list
+    mcp_list=$(oc get mcp --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null) || return 1
+    [[ -n "${mcp_list}" ]] || return 1
+    for mcp in ${mcp_list}; do
+        machine_count=$(oc get mcp "${mcp}" -o jsonpath='{.status.machineCount}' 2>/dev/null) || return 1
         (( machine_count > 0 )) || continue
-        status=$(oc get mcp "${mcp}" -o jsonpath='{.status.conditions[?(@.type=="Updated")].status}' 2>/dev/null || true)
+        status=$(oc get mcp "${mcp}" -o jsonpath='{.status.conditions[?(@.type=="Updated")].status}' 2>/dev/null) || return 1
         [[ "${status}" == "True" ]] || return 1
     done
 }
@@ -46,7 +49,9 @@ _dump_machineconfigpool_diagnostics() {
 wait_for_machineconfigpools_stable() {
     local timeout="${1:-600}"
 
-    if ! oc get mcp &>/dev/null || [[ -z "$(oc get mcp --no-headers 2>/dev/null)" ]]; then
+    # Skip only when the MCP API is reachable but no pools exist (HyperShift/custom CP).
+    # API failures fall through to retry_until so transient EOF does not bypass the gate.
+    if oc get mcp &>/dev/null && [[ -z "$(oc get mcp --no-headers 2>/dev/null)" ]]; then
         echo "No MachineConfigPools found; skipping MCP stability check (typical for HyperShift or custom CP topologies)"
         return 0
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,8 +32,8 @@ if [[ "${SETUP_PHASE}" == "all" || "${SETUP_PHASE}" == "prerequisites" ]]; then
 
 # Optionally install LVMS as storage service (must be before keycloak which needs a default storage class)
 if [[ "${STORAGE_SERVICE}" == "true" ]]; then
-    # OSAC-1964-csv-exist: defer LVMS until MCP rollout and API are stable (KubeletConfig
-    # in CI can leave the master pool updating while the API returns EOF).
+    # OSAC-1964-csv-exist: defer LVMS until the API is stable (KubeletConfig in CI can
+    # leave the API returning EOF). CI prerequisites already wait for mcp/master Updated.
     wait_for_cluster_stability || exit 1
 
     wait_for_namespace_cleanup openshift-storage

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,10 +32,27 @@ if [[ "${SETUP_PHASE}" == "all" || "${SETUP_PHASE}" == "prerequisites" ]]; then
 
 # Optionally install LVMS as storage service (must be before keycloak which needs a default storage class)
 if [[ "${STORAGE_SERVICE}" == "true" ]]; then
+    # OSAC-1964-csv-exist: defer LVMS until MCP rollout and API are stable (KubeletConfig
+    # in CI can leave the master pool updating while the API returns EOF).
+    wait_for_cluster_stability || exit 1
+
     wait_for_namespace_cleanup openshift-storage
     echo "Installing LVMS storage service..."
-    retry_until 300 3 '[[ -n "$(oc get csv --no-headers -n openshift-storage | grep lvms)" ]]' 'oc apply -f prerequisites/lvms/lvms-operator.yaml || true' || {
+
+    # Apply manifest once with a dedicated retry budget so API EOF during apply does not
+    # consume the OLM CSV-existence wait (OLM typically needs 5-7+ minutes on VMaaS SNO).
+    retry_command 600 5 oc apply -f prerequisites/lvms/lvms-operator.yaml || {
+        echo "Failed to apply LVMS operator manifest"
+        exit 1
+    }
+
+    retry_until 900 3 '[[ -n "$(oc get csv --no-headers -n openshift-storage | grep lvms)" ]]' || {
         echo "Timed out waiting for LVMS CSV to exist"
+        echo "=== LVMS OLM diagnostics ==="
+        oc get subscription,installplan,csv -n openshift-storage || true
+        oc get packagemanifest lvms-operator -n openshift-marketplace || true
+        oc describe subscription lvms-operator -n openshift-storage || true
+        oc get events -n openshift-storage --sort-by='.lastTimestamp' || true
         exit 1
     }
     LVMS_CSV=$(oc get csv --no-headers -n openshift-storage | awk '/lvms/ { print $1 }' | tail -1)

--- a/scripts/test/setup-cluster-stability.test.sh
+++ b/scripts/test/setup-cluster-stability.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Behavioral tests for cluster stability gate environment detection.
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "${SCRIPT_DIR}/../lib.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "PASS: $*"
+}
+
+assert_skip() {
+    local label="$1"
+    if _should_skip_mcp_stability_check; then
+        pass "${label} skips MCP stability check"
+    else
+        fail "${label} should skip MCP stability check"
+    fi
+}
+
+assert_no_skip() {
+    local label="$1"
+    if _should_skip_mcp_stability_check; then
+        fail "${label} should not skip MCP stability check"
+    else
+        pass "${label} runs MCP stability check"
+    fi
+}
+
+# CI E2E: prerequisites step after workflow MCP gate
+(
+    CI=true GITHUB_ACTIONS=true SETUP_PHASE=prerequisites SKIP_MCP_STABILITY_CHECK=
+    assert_skip "CI prerequisites phase"
+)
+
+# CI hypothetical full install: still run MCP gate
+(
+    CI=true GITHUB_ACTIONS=true SETUP_PHASE=all SKIP_MCP_STABILITY_CHECK=
+    assert_no_skip "CI full install (SETUP_PHASE=all)"
+)
+
+# Manual production / developer install via setup.sh
+(
+    unset CI GITHUB_ACTIONS
+    SETUP_PHASE=all SKIP_MCP_STABILITY_CHECK=
+    assert_no_skip "manual SETUP_PHASE=all"
+)
+
+(
+    unset CI GITHUB_ACTIONS
+    SETUP_PHASE=prerequisites SKIP_MCP_STABILITY_CHECK=
+    assert_no_skip "manual SETUP_PHASE=prerequisites only"
+)
+
+# Explicit override for custom automation
+(
+    unset CI GITHUB_ACTIONS
+    SETUP_PHASE=all SKIP_MCP_STABILITY_CHECK=true
+    assert_skip "SKIP_MCP_STABILITY_CHECK override"
+)
+
+echo "All cluster stability environment checks passed."

--- a/scripts/test/setup-lvms-timeouts.test.sh
+++ b/scripts/test/setup-lvms-timeouts.test.sh
@@ -37,6 +37,26 @@ grep -q 'wait_for_cluster_stability()' "${LIB_SH}" || \
     fail "lib.sh must define wait_for_cluster_stability (OSAC-1964-csv-exist)"
 pass "lib.sh defines wait_for_cluster_stability"
 
+grep -q '_should_skip_mcp_stability_check()' "${LIB_SH}" || \
+    fail "lib.sh must define _should_skip_mcp_stability_check for CI MCP skip"
+pass "lib.sh defines _should_skip_mcp_stability_check"
+
+grep -q 'SETUP_PHASE:-all' "${LIB_SH}" || \
+    fail "MCP skip logic must consider SETUP_PHASE (CI prerequisites vs full install)"
+pass "lib.sh gates MCP skip on SETUP_PHASE"
+
+grep -q 'Skipping MCP stability check (CI prerequisites phase' "${LIB_SH}" || \
+    fail "wait_for_cluster_stability must skip MCP wait only in CI prerequisites phase"
+pass "lib.sh skips MCP stability check in CI prerequisites phase"
+
+grep -q 'machine_count' "${LIB_SH}" || \
+    fail "lib.sh must skip empty MachineConfigPools when checking MCP stability"
+pass "lib.sh skips empty MachineConfigPools in MCP check"
+
+grep -q 'MachineConfigPool diagnostics' "${LIB_SH}" || \
+    fail "lib.sh should dump MCP diagnostics on stability timeout"
+pass "lib.sh dumps MCP diagnostics on stability timeout"
+
 grep -q 'wait_for_machineconfigpools_stable()' "${LIB_SH}" || \
     fail "lib.sh must define wait_for_machineconfigpools_stable for portable MCP checks"
 pass "lib.sh defines wait_for_machineconfigpools_stable"

--- a/scripts/test/setup-lvms-timeouts.test.sh
+++ b/scripts/test/setup-lvms-timeouts.test.sh
@@ -78,6 +78,10 @@ if grep -F 'machine_count=$(oc get mcp' "${LIB_SH}" | grep -q '|| echo 0'; then
 fi
 pass "lib.sh does not mask machineCount API failures"
 
+grep -q 'mcp_list=$(oc get mcp --no-headers 2>/dev/null) && \[\[ -z "${mcp_list}" \]\]' "${LIB_SH}" || \
+    fail "wait_for_machineconfigpools_stable must use single oc get mcp call for skip check (avoid TOCTOU)"
+pass "lib.sh uses single-call MCP skip check"
+
 if grep -E 'oc get mcp/master|mcp/master -o' "${LIB_SH}"; then
     fail "lib.sh must not hardcode mcp/master; use wait_for_machineconfigpools_stable for HyperShift/custom CP topologies"
 fi

--- a/scripts/test/setup-lvms-timeouts.test.sh
+++ b/scripts/test/setup-lvms-timeouts.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Regression tests for OSAC-1964 LVMS install wait timeouts in setup.sh.
+#
+# OSAC-1964: CSV Succeeded and deployment Available waits (300s -> 600s/900s).
+# OSAC-1964-csv-exist: CSV-existence retry_until (300s -> 900s), split apply vs wait,
+# and cluster stability gate before LVMS when MCP/API may still be settling.
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SH="${SCRIPT_DIR}/../setup.sh"
+LIB_SH="${SCRIPT_DIR}/../lib.sh"
+
+readonly MIN_CSV_EXISTENCE_TIMEOUT=900
+readonly MIN_CSV_SUCCEEDED_TIMEOUT=600
+readonly MIN_DEPLOYMENT_AVAILABLE_TIMEOUT=900
+readonly LEGACY_TIMEOUT=300
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "PASS: $*"
+}
+
+[[ -f "${SETUP_SH}" ]] || fail "setup.sh not found at ${SETUP_SH}"
+[[ -f "${LIB_SH}" ]] || fail "lib.sh not found at ${LIB_SH}"
+
+grep -q 'wait_for_cluster_stability' "${SETUP_SH}" || \
+    fail "setup.sh must call wait_for_cluster_stability before LVMS install (OSAC-1964-csv-exist)"
+pass "setup.sh calls wait_for_cluster_stability before LVMS install"
+
+grep -q 'wait_for_cluster_stability()' "${LIB_SH}" || \
+    fail "lib.sh must define wait_for_cluster_stability (OSAC-1964-csv-exist)"
+pass "lib.sh defines wait_for_cluster_stability"
+
+grep -q 'wait_for_machineconfigpools_stable()' "${LIB_SH}" || \
+    fail "lib.sh must define wait_for_machineconfigpools_stable for portable MCP checks"
+pass "lib.sh defines wait_for_machineconfigpools_stable"
+
+grep -q '_machineconfigpools_updated()' "${LIB_SH}" || \
+    fail "lib.sh must define _machineconfigpools_updated helper"
+pass "lib.sh defines _machineconfigpools_updated helper"
+
+if grep -E 'oc get mcp/master|mcp/master -o' "${LIB_SH}"; then
+    fail "lib.sh must not hardcode mcp/master; use wait_for_machineconfigpools_stable for HyperShift/custom CP topologies"
+fi
+pass "lib.sh does not hardcode mcp/master"
+
+grep -q 'retry_command 600 5 oc apply -f prerequisites/lvms/lvms-operator.yaml' "${SETUP_SH}" || \
+    fail "setup.sh must apply lvms-operator.yaml via retry_command, separate from CSV wait (OSAC-1964-csv-exist)"
+pass "setup.sh applies LVMS manifest via dedicated retry_command"
+
+csv_exist_line=$(grep -F "retry_until ${MIN_CSV_EXISTENCE_TIMEOUT} 3" "${SETUP_SH}" | \
+    grep -F 'oc get csv --no-headers -n openshift-storage | grep lvms' | head -1 || true)
+[[ -n "${csv_exist_line}" ]] || fail "LVMS CSV-existence retry_until ${MIN_CSV_EXISTENCE_TIMEOUT}s line not found in setup.sh"
+
+csv_exist_timeout=$(echo "${csv_exist_line}" | grep -oE 'retry_until [0-9]+' | awk '{print $2}')
+[[ -n "${csv_exist_timeout}" ]] || fail "Could not parse LVMS CSV-existence timeout from: ${csv_exist_line}"
+
+if (( csv_exist_timeout < MIN_CSV_EXISTENCE_TIMEOUT )); then
+    fail "LVMS CSV-existence timeout is ${csv_exist_timeout}s; expected >= ${MIN_CSV_EXISTENCE_TIMEOUT}s (OSAC-1964-csv-exist)"
+fi
+pass "LVMS CSV-existence timeout is ${csv_exist_timeout}s (>= ${MIN_CSV_EXISTENCE_TIMEOUT}s)"
+
+if echo "${csv_exist_line}" | grep -q 'oc apply -f prerequisites/lvms/lvms-operator.yaml'; then
+    fail "LVMS CSV-existence retry_until must not re-apply manifest in the wait loop (OSAC-1964-csv-exist)"
+fi
+pass "LVMS CSV-existence wait does not re-apply manifest in loop"
+
+csv_line=$(grep -F 'clusterserviceversion/${LVMS_CSV}' "${SETUP_SH}" || true)
+deploy_line=$(grep -F 'deployment/lvms-operator condition=Available' "${SETUP_SH}" || true)
+
+[[ -n "${csv_line}" ]] || fail "LVMS CSV wait_for_resource line not found in setup.sh"
+[[ -n "${deploy_line}" ]] || fail "LVMS deployment wait_for_resource line not found in setup.sh"
+
+csv_timeout=$(echo "${csv_line}" | grep -oE '[0-9]+ openshift-storage' | awk '{print $1}')
+deploy_timeout=$(echo "${deploy_line}" | grep -oE '[0-9]+ openshift-storage' | awk '{print $1}')
+
+[[ -n "${csv_timeout}" ]] || fail "Could not parse LVMS CSV timeout from: ${csv_line}"
+[[ -n "${deploy_timeout}" ]] || fail "Could not parse LVMS deployment timeout from: ${deploy_line}"
+
+if (( csv_timeout < MIN_CSV_SUCCEEDED_TIMEOUT )); then
+    fail "LVMS CSV Succeeded timeout is ${csv_timeout}s; expected >= ${MIN_CSV_SUCCEEDED_TIMEOUT}s (OSAC-1964)"
+fi
+pass "LVMS CSV Succeeded timeout is ${csv_timeout}s (>= ${MIN_CSV_SUCCEEDED_TIMEOUT}s)"
+
+if (( deploy_timeout < MIN_DEPLOYMENT_AVAILABLE_TIMEOUT )); then
+    fail "LVMS deployment Available timeout is ${deploy_timeout}s; expected >= ${MIN_DEPLOYMENT_AVAILABLE_TIMEOUT}s (OSAC-1964)"
+fi
+pass "LVMS deployment Available timeout is ${deploy_timeout}s (>= ${MIN_DEPLOYMENT_AVAILABLE_TIMEOUT}s)"
+
+if (( csv_exist_timeout == LEGACY_TIMEOUT || csv_timeout == LEGACY_TIMEOUT || deploy_timeout == LEGACY_TIMEOUT )); then
+    fail "LVMS waits still use legacy ${LEGACY_TIMEOUT}s timeout that caused CI flakes"
+fi
+pass "LVMS waits no longer use legacy ${LEGACY_TIMEOUT}s timeout"
+
+grep -q 'LVMS OLM diagnostics' "${SETUP_SH}" || \
+    fail "setup.sh should dump OLM diagnostics on CSV-existence timeout (OSAC-1964-csv-exist)"
+pass "setup.sh dumps OLM diagnostics on CSV-existence timeout"
+
+echo "All LVMS timeout regression checks passed."

--- a/scripts/test/setup-lvms-timeouts.test.sh
+++ b/scripts/test/setup-lvms-timeouts.test.sh
@@ -65,6 +65,19 @@ grep -q '_machineconfigpools_updated()' "${LIB_SH}" || \
     fail "lib.sh must define _machineconfigpools_updated helper"
 pass "lib.sh defines _machineconfigpools_updated helper"
 
+grep -q 'mcp_list=$(oc get mcp' "${LIB_SH}" || \
+    fail "lib.sh must capture MCP list before iterating _machineconfigpools_updated"
+pass "lib.sh captures MCP list before iterating"
+
+grep -q 'mcp_list=$(oc get mcp.*) || return 1' "${LIB_SH}" || \
+    fail "_machineconfigpools_updated must fail closed when MCP list retrieval fails"
+pass "lib.sh fails closed on MCP list API errors"
+
+if grep -F 'machine_count=$(oc get mcp' "${LIB_SH}" | grep -q '|| echo 0'; then
+    fail "_machineconfigpools_updated must not silently skip pools on machineCount API failure"
+fi
+pass "lib.sh does not mask machineCount API failures"
+
 if grep -E 'oc get mcp/master|mcp/master -o' "${LIB_SH}"; then
     fail "lib.sh must not hardcode mcp/master; use wait_for_machineconfigpools_stable for HyperShift/custom CP topologies"
 fi


### PR DESCRIPTION
Address intermittent E2E failure where LVMS install timed out waiting for the CSV to exist because API EOF during KubeletConfig/MCP rollout consumed the retry budget before OLM could create the subscription.

- Gate LVMS install on MCP and API stability before applying the operator
- Use portable MCP checks for all present pools; skip when absent (HyperShift/custom CP)
- Split manifest apply (retry_command 600s) from CSV-existence poll (900s)
- Dump OLM diagnostics when the CSV-existence wait times out
- Add static regression test and `make test` target

Assisted-by: cursor

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installer regression tests for LVMS timeouts and cluster-stability, wired into a single `make test` runner.
  * Introduced cluster-stability and API-connectivity gating before LVMS installation, with conditional skip behavior for certain setup phases.

* **Bug Fixes**
  * Improved LVMS operator manifest installation resilience with dedicated retry logic.
  * Extended LVMS CSV/rollout wait timeouts and added richer LVMS on-timeout diagnostics for faster triage.

* **Tests**
  * Added validation for MCP stability-skip gating and updated LVMS timeout expectations, including diagnostics on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->