### PR TITLE
OSAC-2115: generate osac-controller/osac-admin Keycloak secrets at boot

### DIFF
--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -448,15 +448,18 @@ oc wait certificate/postgres-client-service -n ${NAMESPACE} \
 
 ### 2.3 Fulfillment Controller Credentials
 
-OAuth client credentials for the fulfillment controller, extracted from the
-Keycloak realm configuration. The Keycloak client is named `osac-controller`
-and the OPA authorization policy expects JWT username
-`service-account-osac-controller`:
+OAuth client credentials for the fulfillment controller. The Keycloak client
+is named `osac-controller` and the OPA authorization policy expects JWT
+username `service-account-osac-controller`.
+
+`realm.json` no longer ships a static secret for this client — the
+`keycloak-service` init container generates one on first boot and stores it
+in the `keycloak-client-secrets` Secret in the `keycloak` namespace (see
+OSAC-2115). Read it from there:
 
 ```bash
-FC_CLIENT_SECRET=$(jq -r \
-  '.clients[] | select(.clientId == "osac-controller") | .secret' \
-  prerequisites/keycloak/service/files/realm.json)
+FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n keycloak \
+  -o jsonpath='{.data.osac-controller}' | base64 -d)
 
 oc create secret generic fulfillment-controller-credentials \
   --from-literal=client-id=osac-controller \
@@ -995,9 +998,8 @@ oc get secret fulfillment-controller-credentials -n ${NAMESPACE} \
 If it shows a different value, recreate the secret:
 
 ```bash
-FC_CLIENT_SECRET=$(jq -r \
-  '.clients[] | select(.clientId == "osac-controller") | .secret' \
-  prerequisites/keycloak/service/files/realm.json)
+FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n keycloak \
+  -o jsonpath='{.data.osac-controller}' | base64 -d)
 
 oc create secret generic fulfillment-controller-credentials \
   --from-literal=client-id=osac-controller \

--- a/overlays/osac-integration/README.md
+++ b/overlays/osac-integration/README.md
@@ -31,7 +31,13 @@ oc create secret generic fulfillment-controller-credentials \
   --from-literal=client-secret=<client-secret>
 ```
 
-`client-secret` must match the secret configured for the `osac-controller` client in the Keycloak realm ([prerequisites/keycloak/service/files/realm.json](../../prerequisites/keycloak/service/files/realm.json)).
+`client-secret` must match the `osac-controller` value generated at first boot by the
+`keycloak-service` init container, stored in the `keycloak-client-secrets` Secret in the
+`keycloak` namespace:
+
+```sh
+oc get secret keycloak-client-secrets -n keycloak -o jsonpath='{.data.osac-controller}' | base64 -d
+```
 
 ## Deployment
 

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -66,6 +66,7 @@ spec:
           fi
           CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-controller}' | base64 -d)
           ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
+          [[ -n "${CONTROLLER_SECRET}" && -n "${ADMIN_SECRET}" ]] || { echo "ERROR: keycloak-client-secrets is missing osac-controller or osac-admin" >&2; exit 1; }
           sed \
             -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
             -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -25,10 +25,13 @@ spec:
       labels:
         app: keycloak-service
     spec:
+      serviceAccountName: keycloak-service
       volumes:
-      - name: realm
+      - name: realm-raw
         configMap:
           name: keycloak-realm
+      - name: realm
+        emptyDir: {}
       - name: database-client-cert
         secret:
           secretName: keycloak-database-client-cert
@@ -47,6 +50,32 @@ spec:
           until pg_isready --host keycloak-database --timeout 1; do
             sleep 1
           done
+      - name: resolve-realm-secrets
+        image: quay.io/openshift/origin-cli:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if ! oc get secret keycloak-client-secrets > /dev/null 2>&1; then
+            echo "generating osac-controller/osac-admin client secrets"
+            oc create secret generic keycloak-client-secrets \
+              --from-literal=osac-controller="$(openssl rand -base64 18)" \
+              --from-literal=osac-admin="$(openssl rand -base64 18)"
+          fi
+          CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-controller}' | base64 -d)
+          ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
+          sed \
+            -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
+            -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \
+            /realm-raw/realm.json > /realm/realm.json
+        volumeMounts:
+        - name: realm-raw
+          mountPath: /realm-raw
+          readOnly: true
+        - name: realm
+          mountPath: /realm
       containers:
       - name: keycloak
         image: keycloak

--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -1035,7 +1035,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "t2N7qNiOYZzt6InsHOVsV5AzcZZbA7Sg",
+      "secret": "__OSAC_CONTROLLER_CLIENT_SECRET__",
       "redirectUris": [
         "/*"
       ],
@@ -1093,7 +1093,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "kP9xRmNvQw3hYjL8sT5uA2dF7gB0cE4i",
+      "secret": "__OSAC_ADMIN_CLIENT_SECRET__",
       "redirectUris": [
         "/*"
       ],

--- a/prerequisites/keycloak/service/rbac.yaml
+++ b/prerequisites/keycloak/service/rbac.yaml
@@ -21,8 +21,15 @@ rules:
   resources:
   - secrets
   verbs:
-  - get
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - keycloak-client-secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/prerequisites/keycloak/service/rbac.yaml
+++ b/prerequisites/keycloak/service/rbac.yaml
@@ -11,22 +11,27 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- certificate.yaml
-- service.yaml
-- route.yaml
-- sa.yaml
-- rbac.yaml
-- deployment.yaml
-- password-setup-job.yaml
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-configMapGenerator:
-- name: keycloak-realm
-  files:
-  - realm.json=files/realm.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-service
+subjects:
+- kind: ServiceAccount
+  name: keycloak-service

--- a/prerequisites/keycloak/service/sa.yaml
+++ b/prerequisites/keycloak/service/sa.yaml
@@ -11,22 +11,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- certificate.yaml
-- service.yaml
-- route.yaml
-- sa.yaml
-- rbac.yaml
-- deployment.yaml
-- password-setup-job.yaml
-
-generatorOptions:
-  disableNameSuffixHash: true
-
-configMapGenerator:
-- name: keycloak-realm
-  files:
-  - realm.json=files/realm.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-service

--- a/scripts/refresh-after-snapshot.sh
+++ b/scripts/refresh-after-snapshot.sh
@@ -79,6 +79,19 @@ fi
 # Keycloak sync and fulfillment credentials run in parallel.
 # Credentials read from realm.json (local file) — no dependency on Keycloak being up.
 # Kustomize apply needs the credentials secret, so we wait for it before proceeding.
+#
+# realm.json ships with __OSAC_CONTROLLER_CLIENT_SECRET__/__OSAC_ADMIN_CLIENT_SECRET__
+# placeholders (see OSAC-2115) resolved at pod startup by the keycloak-service init
+# container. Anything that talks to Keycloak directly (admin API sync, credential
+# extraction) needs the same real values, read back from the keycloak-client-secrets
+# Secret that init container generates/persists.
+RESOLVED_REALM_JSON=$(mktemp)
+CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -n "${KEYCLOAK_NS}" -o jsonpath='{.data.osac-controller}' | base64 -d)
+ADMIN_SECRET=$(oc get secret keycloak-client-secrets -n "${KEYCLOAK_NS}" -o jsonpath='{.data.osac-admin}' | base64 -d)
+sed \
+    -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
+    -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \
+    "${REALM_JSON}" > "${RESOLVED_REALM_JSON}"
 
 keycloak_sync() {
     echo "[1/9] Syncing Keycloak realm..."
@@ -105,7 +118,7 @@ keycloak_sync() {
     [[ -n "${KC_ADMIN_TOKEN}" && "${KC_ADMIN_TOKEN}" != "null" ]] || { echo "ERROR: Could not get Keycloak admin token" >&2; exit 1; }
 
     echo "  Syncing clients and users via admin API..."
-    jq -c '.clients[] | select(.protocol == "openid-connect" and .publicClient != true and .bearerOnly != true)' "${REALM_JSON}" | while IFS= read -r CLIENT_JSON; do
+    jq -c '.clients[] | select(.protocol == "openid-connect" and .publicClient != true and .bearerOnly != true)' "${RESOLVED_REALM_JSON}" | while IFS= read -r CLIENT_JSON; do
         CID=$(echo "${CLIENT_JSON}" | jq -r '.clientId')
         CLIENT_UUID=$(echo "${CLIENT_JSON}" | jq -r '.id')
         HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" "${KC_URL}/admin/realms/osac/clients/${CLIENT_UUID}")
@@ -120,7 +133,7 @@ keycloak_sync() {
         fi
     done
 
-    jq -c '.users[]?' "${REALM_JSON}" | while IFS= read -r USER_JSON; do
+    jq -c '.users[]?' "${RESOLVED_REALM_JSON}" | while IFS= read -r USER_JSON; do
         USERNAME=$(echo "${USER_JSON}" | jq -r '.username')
         USER_UUID=$(echo "${USER_JSON}" | jq -r '.id')
         HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" "${KC_URL}/admin/realms/osac/users/${USER_UUID}")
@@ -145,8 +158,8 @@ keycloak_sync() {
 
 create_fulfillment_credentials() {
     echo "[2/9] Recreating fulfillment controller credentials..."
-    FC_CLIENT_ID=${FC_CLIENT:-$(jq -er 'first(.clients[] | select(.serviceAccountsEnabled==true)) | .clientId' "${REALM_JSON}")}
-    FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${REALM_JSON}")
+    FC_CLIENT_ID=${FC_CLIENT:-$(jq -er 'first(.clients[] | select(.serviceAccountsEnabled==true)) | .clientId' "${RESOLVED_REALM_JSON}")}
+    FC_CLIENT_SECRET=$(jq -er ".clients[] | select(.clientId == \"${FC_CLIENT_ID}\") | .secret // empty" "${RESOLVED_REALM_JSON}")
     [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for ${FC_CLIENT_ID} in realm.json" >&2; exit 1; }
     oc delete secret fulfillment-controller-credentials -n "${INSTALLER_NAMESPACE}" --ignore-not-found
     oc create secret generic fulfillment-controller-credentials \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -283,8 +283,8 @@ if [[ "${DEPLOY_MODE}" == "helm" ]]; then
     retry_until 120 3 'oc get configmap ca-bundle -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.data.bundle\.pem}'"'"' 2>/dev/null | grep -q "BEGIN CERTIFICATE"'
 
     # Create controller OAuth credentials from the Keycloak realm config.
-    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
-    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+    FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n "${KEYCLOAK_NS}" -o jsonpath='{.data.osac-controller}' | base64 -d)
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller from keycloak-client-secrets" >&2; exit 1; }
     oc create secret generic fulfillment-controller-credentials \
         --from-literal=client-id=osac-controller \
         --from-literal=client-secret="${FC_CLIENT_SECRET}" \
@@ -373,8 +373,8 @@ else
     "${SCRIPT_DIR}/ensure-ca-bundle.sh" "${INSTALLER_NAMESPACE}"
 
     # Create controller OAuth credentials from the Keycloak realm config
-    FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json)
-    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+    FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n "${KEYCLOAK_NS}" -o jsonpath='{.data.osac-controller}' | base64 -d)
+    [[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller from keycloak-client-secrets" >&2; exit 1; }
     oc create secret generic fulfillment-controller-credentials \
         --from-literal=client-id=osac-controller \
         --from-literal=client-secret="${FC_CLIENT_SECRET}" \


### PR DESCRIPTION
## Summary
- `realm.json` shipped real, static Keycloak client secrets for `osac-controller`/`osac-admin`, publicly exposed in git history and flagged by secret scanning. Both service accounts are hardcoded as admin in fulfillment-service's OPA policy.
- Replaces the static secrets with placeholders, resolved in-cluster at first boot by a new `resolve-realm-secrets` init container (mirrors the existing `keycloak-database` password-generator pattern), persisted in a `keycloak-client-secrets` Secret.
- Updates `setup.sh`, `refresh-after-snapshot.sh`, and the manual deployment docs to read the generated secret from that Secret instead of parsing the static file.

No live deployment used the leaked value, so there was nothing to rotate in place — this closes the hole so future installs never ship a static admin-level secret again.

## Test plan
- [x] `./scripts/kustomize-build-all.sh` — all overlays/prerequisites build clean
- [x] `bash -n scripts/setup.sh scripts/refresh-after-snapshot.sh` — syntax OK
- [ ] Manual: run `setup.sh` against a real cluster and confirm `keycloak-client-secrets` is created and `fulfillment-controller-credentials` authenticates successfully