### PR TITLE
NO-ISSUE: Pin Keycloak image to 26.6.4

### DIFF
--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           done
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:latest
+        image: quay.io/keycloak/keycloak:26.6.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: realm


### PR DESCRIPTION
## Summary
- Pins the Keycloak container image from `latest` to `26.6.4` to avoid unexpected breaking changes from upstream (e.g., organization scope conflicts introduced in newer versions)

## Test plan
- [ ] Deploy from scratch and confirm Keycloak starts successfully with the pinned version
- [ ] Verify realm import completes without errors

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak deployment to use a pinned image version instead of `latest`, improving consistency and reducing unexpected version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->