### PR TITLE
OSAC-2310: pin prerequisite container images to specific versions

### DIFF
--- a/prerequisites/keycloak/database/statefulset.yaml
+++ b/prerequisites/keycloak/database/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
           claimName: keycloak-database
       initContainers:
       - name: password-generator
-        image: quay.io/openshift/origin-cli:latest
+        image: quay.io/openshift/origin-cli:4.21
         command:
         - /bin/bash
         - -c
@@ -56,7 +56,7 @@ spec:
           fi
       containers:
       - name: server
-        image: quay.io/sclorg/postgresql-18-c10s:latest
+        image: quay.io/sclorg/postgresql-18-c10s:c10s
         imagePullPolicy: IfNotPresent
         env:
         - name: POSTGRESQL_USER

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           secretName: keycloak-tls-cert
       initContainers:
       - name: wait-for-database
-        image: quay.io/sclorg/postgresql-18-c10s:latest
+        image: quay.io/sclorg/postgresql-18-c10s:c10s
         imagePullPolicy: IfNotPresent
         command:
         - /bin/bash
@@ -49,7 +49,7 @@ spec:
           done
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:latest
+        image: quay.io/keycloak/keycloak:26.6.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: realm

--- a/prerequisites/keycloak/service/password-setup-job.yaml
+++ b/prerequisites/keycloak/service/password-setup-job.yaml
@@ -85,7 +85,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: set-passwords
-        image: quay.io/openshift/origin-cli:latest
+        image: quay.io/openshift/origin-cli:4.21
         command:
         - /bin/bash
         - /scripts/set-passwords.sh


### PR DESCRIPTION
## Summary

- Pin all 5 external `:latest` image tags in `prerequisites/keycloak/` to specific versions
- Fixes full-install E2E breakage caused by Keycloak 26.7.0 being pushed to `:latest` at 07:01 UTC today

## Root Cause

PR #398 replaced kustomize image placeholders with full image refs but used `:latest`. Keycloak 26.7.0 landed on the `latest` tag today, breaking the `scope=openid organization` token request — all JWT auth smoke tests fail (31 passed, 29 errors on every run).

## Changes

| Image | Was | Now |
|-------|-----|-----|
| `quay.io/keycloak/keycloak` | `:latest` | `:26.6.4` |
| `quay.io/sclorg/postgresql-18-c10s` (×2) | `:latest` | `:c10s` |
| `quay.io/openshift/origin-cli` (×2) | `:latest` | `:4.21` |

## Test plan

- [ ] E2E full-install passes (JWT auth smoke tests no longer error)
- [ ] Keycloak boots and imports realm correctly with pinned 26.6.4 image

Jira: [OSAC-2310](https://redhat.atlassian.net/browse/OSAC-2310)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several container images to fixed versions in Keycloak-related deployments and jobs.
  * Replaced `latest` tags with pinned releases for the database, Keycloak service, and password setup components.
  * These updates help keep environments more consistent and reduce unexpected changes during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->