### PR TITLE
OSAC-2115: generate osac-controller/osac-admin Keycloak secrets at boot

### DIFF
--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -459,15 +459,18 @@ oc wait certificate/postgres-client-service -n ${NAMESPACE} \
 
 ### 2.3 Fulfillment Controller Credentials
 
-OAuth client credentials for the fulfillment controller, extracted from the
-Keycloak realm configuration. The Keycloak client is named `osac-controller`
-and the OPA authorization policy expects JWT username
-`service-account-osac-controller`:
+OAuth client credentials for the fulfillment controller. The Keycloak client
+is named `osac-controller` and the OPA authorization policy expects JWT
+username `service-account-osac-controller`.
+
+`realm.json` no longer ships a static secret for this client — the
+`keycloak-service` init container generates one on first boot and stores it
+in the `keycloak-client-secrets` Secret in the `keycloak` namespace (see
+OSAC-2115). Read it from there:
 
 ```bash
-FC_CLIENT_SECRET=$(jq -r \
-  '.clients[] | select(.clientId == "osac-controller") | .secret' \
-  prerequisites/keycloak/service/files/realm.json)
+FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n keycloak \
+  -o jsonpath='{.data.osac-controller}' | base64 -d)
 
 oc create secret generic fulfillment-controller-credentials \
   --from-literal=client-id=osac-controller \
@@ -1002,9 +1005,8 @@ oc get secret fulfillment-controller-credentials -n ${NAMESPACE} \
 If it shows a different value, recreate the secret:
 
 ```bash
-FC_CLIENT_SECRET=$(jq -r \
-  '.clients[] | select(.clientId == "osac-controller") | .secret' \
-  prerequisites/keycloak/service/files/realm.json)
+FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n keycloak \
+  -o jsonpath='{.data.osac-controller}' | base64 -d)
 
 oc create secret generic fulfillment-controller-credentials \
   --from-literal=client-id=osac-controller \

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -66,6 +66,7 @@ spec:
           fi
           CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-controller}' | base64 -d)
           ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
+          [[ -n "${CONTROLLER_SECRET}" && -n "${ADMIN_SECRET}" ]] || { echo "ERROR: keycloak-client-secrets is missing osac-controller or osac-admin" >&2; exit 1; }
           sed \
             -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
             -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \

--- a/prerequisites/keycloak/service/deployment.yaml
+++ b/prerequisites/keycloak/service/deployment.yaml
@@ -25,10 +25,13 @@ spec:
       labels:
         app: keycloak-service
     spec:
+      serviceAccountName: keycloak-service
       volumes:
-      - name: realm
+      - name: realm-raw
         configMap:
           name: keycloak-realm
+      - name: realm
+        emptyDir: {}
       - name: database-client-cert
         secret:
           secretName: keycloak-database-client-cert
@@ -47,6 +50,32 @@ spec:
           until pg_isready --host keycloak-database --timeout 1; do
             sleep 1
           done
+      - name: resolve-realm-secrets
+        image: quay.io/openshift/origin-cli:4.21
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+          if ! oc get secret keycloak-client-secrets > /dev/null 2>&1; then
+            echo "generating osac-controller/osac-admin client secrets"
+            oc create secret generic keycloak-client-secrets \
+              --from-literal=osac-controller="$(openssl rand -base64 18)" \
+              --from-literal=osac-admin="$(openssl rand -base64 18)"
+          fi
+          CONTROLLER_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-controller}' | base64 -d)
+          ADMIN_SECRET=$(oc get secret keycloak-client-secrets -o jsonpath='{.data.osac-admin}' | base64 -d)
+          sed \
+            -e "s#__OSAC_CONTROLLER_CLIENT_SECRET__#${CONTROLLER_SECRET}#" \
+            -e "s#__OSAC_ADMIN_CLIENT_SECRET__#${ADMIN_SECRET}#" \
+            /realm-raw/realm.json > /realm/realm.json
+        volumeMounts:
+        - name: realm-raw
+          mountPath: /realm-raw
+          readOnly: true
+        - name: realm
+          mountPath: /realm
       containers:
       - name: keycloak
         image: quay.io/keycloak/keycloak:26.6.4

--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -1035,7 +1035,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "t2N7qNiOYZzt6InsHOVsV5AzcZZbA7Sg",
+      "secret": "__OSAC_CONTROLLER_CLIENT_SECRET__",
       "redirectUris": [
         "/*"
       ],
@@ -1093,7 +1093,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "secret": "kP9xRmNvQw3hYjL8sT5uA2dF7gB0cE4i",
+      "secret": "__OSAC_ADMIN_CLIENT_SECRET__",
       "redirectUris": [
         "/*"
       ],

--- a/prerequisites/keycloak/service/rbac.yaml
+++ b/prerequisites/keycloak/service/rbac.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keycloak-service
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keycloak-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keycloak-service
+subjects:
+- kind: ServiceAccount
+  name: keycloak-service

--- a/prerequisites/keycloak/service/rbac.yaml
+++ b/prerequisites/keycloak/service/rbac.yaml
@@ -21,8 +21,15 @@ rules:
   resources:
   - secrets
   verbs:
-  - get
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - keycloak-client-secrets
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/prerequisites/keycloak/service/sa.yaml
+++ b/prerequisites/keycloak/service/sa.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-service

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -265,9 +265,10 @@ oc create namespace "${INSTALLER_NAMESPACE}" --dry-run=client -o yaml | oc apply
 echo "Waiting for ca-bundle ConfigMap..."
 retry_until 120 3 'oc get configmap ca-bundle -n '"${INSTALLER_NAMESPACE}"' -o jsonpath='"'"'{.data.bundle\.pem}'"'"' 2>/dev/null | grep -q "BEGIN CERTIFICATE"'
 
-# Create controller OAuth credentials from the Keycloak realm config.
-FC_CLIENT_SECRET=$(jq -er '.clients[] | select(.clientId == "osac-controller") | .secret // empty' prerequisites/keycloak/service/files/realm.json || true)
-[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller in realm.json" >&2; exit 1; }
+# Create controller OAuth credentials. The init container generates the secret
+# at first boot and persists it in keycloak-client-secrets (OSAC-2115).
+FC_CLIENT_SECRET=$(oc get secret keycloak-client-secrets -n "${KEYCLOAK_NS}" -o jsonpath='{.data.osac-controller}' | base64 -d)
+[[ -n "${FC_CLIENT_SECRET}" ]] || { echo "ERROR: Could not resolve secret for osac-controller from keycloak-client-secrets" >&2; exit 1; }
 oc create secret generic fulfillment-controller-credentials \
     --from-literal=client-id=osac-controller \
     --from-literal=client-secret="${FC_CLIENT_SECRET}" \


### PR DESCRIPTION
## Summary
- `realm.json` shipped real, static Keycloak client secrets for `osac-controller`/`osac-admin`, publicly exposed in git history and flagged by secret scanning. Both service accounts are hardcoded as admin in fulfillment-service's OPA policy.
- Replaces the static secrets with placeholders, resolved in-cluster at first boot by a new `resolve-realm-secrets` init container (mirrors the existing `keycloak-database` password-generator pattern), persisted in a `keycloak-client-secrets` Secret.
- Updates `setup.sh` and the manual deployment docs to read the generated secret from that Secret instead of parsing the static file.

No live deployment used the leaked value, so there was nothing to rotate in place — this closes the hole so future installs never ship a static admin-level secret again.

Rebased onto current main (post kustomize removal).

## Test plan
- [x] `bash -n scripts/setup.sh` — syntax OK
- [x] YAML validation on all new/modified manifests
- [ ] Manual: run `setup.sh` against a real cluster and confirm `keycloak-client-secrets` is created and `fulfillment-controller-credentials` authenticates successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak setup now generates and stores client secrets automatically during first startup, removing the need for a prebuilt static secret.
  * A dedicated service account and access rules were added to support this automated secret handling.

* **Documentation**
  * Updated the deployment guide and troubleshooting steps to show the new way to retrieve the fulfillment controller secret.

* **Bug Fixes**
  * Setup scripts now read the live secret from the cluster, improving reliability and reducing manual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->