### PR TITLE
OSAC-1851: Use per-chart real release tags for nightly versions

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -23,10 +23,10 @@ env:
     osac-aap:osac-aap:base/osac-aap:inline:base/osac-aap/charts/aap
     bare-metal-fulfillment-operator:bare-metal-fulfillment-operator:base/bare-metal-fulfillment-operator:tag:base/bare-metal-fulfillment-operator/charts/operator
     osac-ui:osac-ui:base/osac-ui:inline:base/osac-ui/charts/ui
-  # CRD charts (no image, just chart paths)
+  # CRD charts: name, submodule path, chart path (no image, so no tag-mode field)
   CRD_CHARTS: >-
-    osac-operator-crds:base/osac-operator/charts/operator-crds
-    bare-metal-fulfillment-operator-crds:base/bare-metal-fulfillment-operator/charts/operator-crds
+    osac-operator-crds:base/osac-operator:base/osac-operator/charts/operator-crds
+    bare-metal-fulfillment-operator-crds:base/bare-metal-fulfillment-operator:base/bare-metal-fulfillment-operator/charts/operator-crds
 
 jobs:
   # -------------------------------------------------------------------
@@ -40,6 +40,8 @@ jobs:
       packages: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      base-version: ${{ steps.version.outputs.base-version }}
+      nightly-suffix: ${{ steps.version.outputs.nightly-suffix }}
       temp-branch: ${{ steps.push.outputs.branch }}
       temp-sha: ${{ steps.push.outputs.sha }}
 
@@ -122,11 +124,26 @@ jobs:
       env:
         COMMIT_SHA: ${{ steps.push.outputs.sha }}
       run: |
-        BASE_VERSION=$(yq '.version' charts/osac/Chart.yaml)
+        set -euo pipefail
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA="${COMMIT_SHA:0:7}"
-        VERSION="${BASE_VERSION}-nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}"
+        NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}"
+
+        # Use the umbrella chart's own latest real release tag (not the
+        # Chart.yaml placeholder, which is never bumped) so the nightly
+        # version reflects where this build actually sits relative to
+        # real releases. Fail loudly rather than silently guessing a
+        # version if no real tag is reachable.
+        if ! BASE_TAG=$(git describe --tags --abbrev=0 --exclude '*-nightly*' 2>/dev/null); then
+          echo "ERROR: no real (non-nightly) release tag reachable from HEAD — refusing to guess a version" >&2
+          exit 1
+        fi
+        BASE_VERSION="${BASE_TAG#v}"
+        VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
+
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "nightly-suffix=${NIGHTLY_SUFFIX}" >> "$GITHUB_OUTPUT"
         echo "Nightly version: ${VERSION} (base: ${BASE_VERSION})"
 
   # -------------------------------------------------------------------
@@ -159,6 +176,8 @@ jobs:
       packages: write
     env:
       VERSION: ${{ needs.prepare.outputs.version }}
+      BASE_VERSION: ${{ needs.prepare.outputs.base-version }}
+      NIGHTLY_SUFFIX: ${{ needs.prepare.outputs.nightly-suffix }}
 
     steps:
     - name: Checkout temporary branch
@@ -184,20 +203,33 @@ jobs:
         GHCR_USER: ${{ github.actor }}
       run: printf '%s' "${GHCR_TOKEN}" | helm registry login "${{ env.REGISTRY }}" -u "${GHCR_USER}" --password-stdin
 
+    - name: Compute per-chart versions
+      run: ./scripts/generate-chart-versions.sh
+
+    - name: Upload chart-versions.txt
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      with:
+        name: chart-versions-${{ needs.prepare.outputs.version }}
+        path: chart-versions.txt
+        retention-days: 1
+
     - name: Publish component charts
       env:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
       run: |
         set -euo pipefail
+        get_version() { ./scripts/get-chart-version.sh "$1"; }
         published=""
 
         for entry in ${CRD_CHARTS}; do
           chart_name="${entry%%:*}"
-          chart_path="${entry#*:}"
-          echo "--- Publishing ${chart_name} ---"
-          helm package "${chart_path}" --version "${VERSION}"
-          helm push "${chart_name}-${VERSION}.tgz" "${OCI_REPO}"
-          published="${published}\n${chart_name}:${VERSION}"
+          rest="${entry#*:}"
+          chart_path="${rest#*:}"
+          version=$(get_version "${chart_name}")
+          echo "--- Publishing ${chart_name} (${version}) ---"
+          helm package "${chart_path}" --version "${version}"
+          helm push "${chart_name}-${version}.tgz" "${OCI_REPO}"
+          published="${published}\n${chart_name}:${version}"
         done
 
         for entry in ${COMPONENTS}; do
@@ -206,10 +238,11 @@ jobs:
           rest="${rest#*:}"
           rest="${rest#*:}"
           chart_path="${rest#*:}"
-          echo "--- Publishing ${component} ---"
-          helm package "${chart_path}" --version "${VERSION}"
-          helm push "${component}-${VERSION}.tgz" "${OCI_REPO}"
-          published="${published}\n${component}:${VERSION}"
+          version=$(get_version "${component}")
+          echo "--- Publishing ${component} (${version}) ---"
+          helm package "${chart_path}" --version "${version}"
+          helm push "${component}-${version}.tgz" "${OCI_REPO}"
+          published="${published}\n${component}:${version}"
         done
 
         echo -e "Published charts:${published}"
@@ -219,15 +252,18 @@ jobs:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
       run: |
         set -euo pipefail
+        get_version() { ./scripts/get-chart-version.sh "$1"; }
         for entry in ${CRD_CHARTS}; do
           chart_name="${entry%%:*}"
-          echo "Verifying ${chart_name}..."
-          helm show chart "${OCI_REPO}/${chart_name}" --version "${VERSION}"
+          version=$(get_version "${chart_name}")
+          echo "Verifying ${chart_name} (${version})..."
+          helm show chart "${OCI_REPO}/${chart_name}" --version "${version}"
         done
         for entry in ${COMPONENTS}; do
           component="${entry%%:*}"
-          echo "Verifying ${component}..."
-          helm show chart "${OCI_REPO}/${component}" --version "${VERSION}"
+          version=$(get_version "${component}")
+          echo "Verifying ${component} (${version})..."
+          helm show chart "${OCI_REPO}/${component}" --version "${version}"
         done
 
     - name: Rewrite umbrella chart to use published components
@@ -235,17 +271,22 @@ jobs:
         OCI_REPO: oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
       run: |
         set -euo pipefail
+        GET_VERSION_SCRIPT="$(pwd)/scripts/get-chart-version.sh"
+        CHART_VERSIONS_FILE="$(pwd)/chart-versions.txt"
+        get_version() { "${GET_VERSION_SCRIPT}" "$1" 1 "${CHART_VERSIONS_FILE}"; }
         cd charts/osac
 
         for entry in ${CRD_CHARTS}; do
           chart_name="${entry%%:*}"
+          version=$(get_version "${chart_name}")
           yq -i "(.dependencies[] | select(.name == \"${chart_name}\")).repository = \"${OCI_REPO}\"" Chart.yaml
-          yq -i "(.dependencies[] | select(.name == \"${chart_name}\")).version = \"${VERSION}\"" Chart.yaml
+          yq -i "(.dependencies[] | select(.name == \"${chart_name}\")).version = \"${version}\"" Chart.yaml
         done
         for entry in ${COMPONENTS}; do
           component="${entry%%:*}"
+          version=$(get_version "${component}")
           yq -i "(.dependencies[] | select(.name == \"${component}\")).repository = \"${OCI_REPO}\"" Chart.yaml
-          yq -i "(.dependencies[] | select(.name == \"${component}\")).version = \"${VERSION}\"" Chart.yaml
+          yq -i "(.dependencies[] | select(.name == \"${component}\")).version = \"${version}\"" Chart.yaml
         done
 
         rm -f Chart.lock
@@ -305,6 +346,8 @@ jobs:
         helm show chart "${OCI_REPO}/osac" --version "${VERSION}"
 
     - name: Generate images.txt
+      env:
+        REPO_OWNER: ${{ github.repository_owner }}
       run: |
         set -euo pipefail
         helm template osac "osac-${VERSION}.tgz" \
@@ -337,30 +380,28 @@ jobs:
         done
         grep -v -F -f images.txt images-raw.txt | sort >> images.txt || true
 
+        get_version() { ./scripts/get-chart-version.sh "$1" 1; }
+        get_source_tag() { ./scripts/get-chart-version.sh "$1" 2; }
+        get_source_sha() { ./scripts/get-chart-version.sh "$1" 3; }
+        OCI_BASE="${REGISTRY}/${REPO_OWNER}/charts"
         echo "" >> images.txt
-        echo "# Component versions" >> images.txt
-        for entry in ${COMPONENTS}; do
-          component="${entry%%:*}"
-          rest="${entry#*:}"
-          rest="${rest#*:}"
-          submodule_path="${rest%%:*}"
-          version=$(git -C "${submodule_path}" describe --tags --abbrev=0 2>/dev/null || echo "unknown")
-          sha=$(git -C "${submodule_path}" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
-          echo "# ${component}=${version} (${sha})" >> images.txt
-        done
-
-        OCI_BASE="${REGISTRY}/${{ github.repository_owner }}/charts"
-        echo "" >> images.txt
-        echo "# Chart versions (${VERSION})" >> images.txt
+        echo "# Chart source & versions" >> images.txt
         for entry in ${CRD_CHARTS}; do
           chart_name="${entry%%:*}"
-          echo "# oci://${OCI_BASE}/${chart_name}:${VERSION}" >> images.txt
+          chart_version=$(get_version "${chart_name}")
+          src_tag=$(get_source_tag "${chart_name}")
+          src_sha=$(get_source_sha "${chart_name}")
+          echo "# ${chart_name}: source=${src_tag} (${src_sha}), chart=oci://${OCI_BASE}/${chart_name}:${chart_version}" >> images.txt
         done
         for entry in ${COMPONENTS}; do
           component="${entry%%:*}"
-          echo "# oci://${OCI_BASE}/${component}:${VERSION}" >> images.txt
+          chart_version=$(get_version "${component}")
+          src_tag=$(get_source_tag "${component}")
+          src_sha=$(get_source_sha "${component}")
+          echo "# ${component}: source=${src_tag} (${src_sha}), chart=oci://${OCI_BASE}/${component}:${chart_version}" >> images.txt
         done
-        echo "# oci://${OCI_BASE}/osac:${VERSION}" >> images.txt
+        UMBRELLA_SHA=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+        echo "# osac: source=v${BASE_VERSION} (${UMBRELLA_SHA}), chart=oci://${OCI_BASE}/osac:${VERSION}" >> images.txt
 
         rm -f images-raw.txt
 
@@ -398,6 +439,11 @@ jobs:
         ref: ${{ needs.prepare.outputs.temp-branch }}
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Download chart-versions.txt
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      with:
+        name: chart-versions-${{ needs.prepare.outputs.version }}
 
     - name: Create nightly tag
       run: |
@@ -439,7 +485,53 @@ jobs:
         RUN_ID: ${{ github.run_id }}
         REPO_OWNER: ${{ github.repository_owner }}
       run: |
-        OCI_BASE="oci://ghcr.io/${REPO_OWNER}/charts"
+        set -euo pipefail
+        get_version() { ./scripts/get-chart-version.sh "$1"; }
+        OCI_BASE="oci://${REGISTRY}/${REPO_OWNER}/charts"
+
+        # Every chart shares the same OCI_BASE prefix, so state it once in
+        # the header instead of repeating the full path in every row (each
+        # chart's own version differs by more than just a shared suffix —
+        # e.g. the source commit SHA embedded per component — so the full
+        # version string is kept per row).
+        declare -a NAMES VERSIONS
+        for entry in ${CRD_CHARTS}; do
+          chart_name="${entry%%:*}"
+          NAMES+=("${chart_name}")
+          VERSIONS+=("$(get_version "${chart_name}")")
+        done
+        for entry in ${COMPONENTS}; do
+          component="${entry%%:*}"
+          NAMES+=("${component}")
+          VERSIONS+=("$(get_version "${component}")")
+        done
+        NAMES+=("osac (umbrella)")
+        VERSIONS+=("${VERSION}")
+
+        max_len() {
+          local max=${#1}
+          shift
+          for s in "$@"; do
+            (( ${#s} > max )) && max=${#s}
+          done
+          echo "${max}"
+        }
+        NAME_W=$(max_len "Chart" "${NAMES[@]}")
+        VERSION_W=$(max_len "Version" "${VERSIONS[@]}")
+
+        hline() { printf '─%.0s' $(seq 1 "$(($1 + 2))"); }
+        row() { printf '│ %-*s │ %-*s │' "${NAME_W}" "$1" "${VERSION_W}" "$2"; }
+
+        TABLE="┌$(hline "${NAME_W}")┬$(hline "${VERSION_W}")┐\n"
+        TABLE="${TABLE}$(row "Chart" "Version")\n"
+        TABLE="${TABLE}├$(hline "${NAME_W}")┼$(hline "${VERSION_W}")┤\n"
+        for i in "${!NAMES[@]}"; do
+          TABLE="${TABLE}$(row "${NAMES[$i]}" "${VERSIONS[$i]}")\n"
+        done
+        TABLE="${TABLE}└$(hline "${NAME_W}")┴$(hline "${VERSION_W}")┘"
+
+        SUMMARY_TEXT="*Charts published to* \`${OCI_BASE}/<chart>\`*:*\n\`\`\`\n${TABLE}\n\`\`\`\n*Tag:* \`v${VERSION}\`\n*Run:* <${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}|View workflow>"
+
         curl -sf --max-time 15 -X POST "${SLACK_WEBHOOK_URL}" \
           -H "Content-Type: application/json" \
           -d @- <<PAYLOAD
@@ -453,7 +545,7 @@ jobs:
               "type": "section",
               "text": {
                 "type": "mrkdwn",
-                "text": "*Charts published to GHCR:*\n\`\`\`\nosac-operator-crds            ${VERSION}  ${OCI_BASE}/osac-operator-crds\nosac-operator                 ${VERSION}  ${OCI_BASE}/osac-operator\nfulfillment-service           ${VERSION}  ${OCI_BASE}/fulfillment-service\nosac-aap                      ${VERSION}  ${OCI_BASE}/osac-aap\nbare-metal-fulfillment-operator-crds  ${VERSION}  ${OCI_BASE}/bare-metal-fulfillment-operator-crds\nbare-metal-fulfillment-operator       ${VERSION}  ${OCI_BASE}/bare-metal-fulfillment-operator\nosac-ui                       ${VERSION}  ${OCI_BASE}/osac-ui\nosac (umbrella)               ${VERSION}  ${OCI_BASE}/osac\n\`\`\`\n*Tag:* \`v${VERSION}\`\n*Run:* <${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}|View workflow>"
+                "text": "${SUMMARY_TEXT}"
               }
             }
           ]

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ kubeconfig.hub-access
 # Helm build artifacts
 charts/*/charts/*.tgz
 charts/*/Chart.lock
+chart-versions.txt
+images.txt
+images-raw.txt
 
 # Implementation artifacts
 .artifacts/

--- a/scripts/generate-chart-versions.sh
+++ b/scripts/generate-chart-versions.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Compute each component/CRD chart's own nightly version: its latest real
+# (non-nightly) release tag plus the shared nightly suffix. Used by the
+# nightly-build workflow so every chart's version reflects its actual
+# release history instead of inheriting one invented umbrella version.
+#
+# Requires the following environment variables to be set:
+#   NIGHTLY_SUFFIX  e.g. "nightly.20260709.0d44e56.3"
+#   CRD_CHARTS      e.g. "chart_name:submodule_path:chart_path ..."
+#   COMPONENTS      e.g. "component:image:submodule_path:mode:chart_path ..."
+#
+# Writes chart-versions.txt to the current working directory, one line per
+# chart: "<name>=<version>|<source_tag>|<source_sha>". The source tag/sha
+# are exposed (not just the final version) so callers like the images.txt
+# step can reuse the already-resolved, shallow-clone-safe values instead
+# of re-running `git describe` themselves.
+
+set -euo pipefail
+
+: "${NIGHTLY_SUFFIX:?NIGHTLY_SUFFIX must be set}"
+: "${CRD_CHARTS:?CRD_CHARTS must be set}"
+: "${COMPONENTS:?COMPONENTS must be set}"
+
+chart_info_for_path() {
+  local path=$1
+  local tag sha
+  # actions/checkout clones submodules shallow (depth 1) even when the
+  # superproject uses fetch-depth: 0. A shallow clone has no ancestor
+  # history for `describe` to walk, so fetching tag refs alone isn't
+  # enough — the submodule needs to be unshallowed too, or `describe`
+  # silently fails. `--unshallow` errors on an already-complete repo,
+  # so only use it when needed.
+  if [[ "$(git -C "${path}" rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]; then
+    git -C "${path}" fetch --unshallow --tags --quiet 2>/dev/null || true
+  else
+    git -C "${path}" fetch --tags --quiet 2>/dev/null || true
+  fi
+  # Fail loudly rather than silently guessing a version: publishing a
+  # chart under a made-up placeholder tag would be worse than failing
+  # the build, since it could get pushed to the registry unnoticed.
+  if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --exclude '*-nightly*' 2>/dev/null); then
+    echo "ERROR: no real (non-nightly) release tag reachable from ${path} — refusing to guess a version" >&2
+    exit 1
+  fi
+  sha=$(git -C "${path}" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
+  echo "${tag}|${sha}"
+}
+
+: > chart-versions.txt
+for entry in ${CRD_CHARTS}; do
+  chart_name="${entry%%:*}"
+  rest="${entry#*:}"
+  submodule_path="${rest%%:*}"
+  info=$(chart_info_for_path "${submodule_path}")
+  src_tag="${info%|*}"
+  src_sha="${info#*|}"
+  version="${src_tag#v}-${NIGHTLY_SUFFIX}"
+  echo "${chart_name}=${version}|${src_tag}|${src_sha}" >> chart-versions.txt
+done
+for entry in ${COMPONENTS}; do
+  component="${entry%%:*}"
+  rest="${entry#*:}"
+  rest="${rest#*:}"
+  submodule_path="${rest%%:*}"
+  info=$(chart_info_for_path "${submodule_path}")
+  src_tag="${info%|*}"
+  src_sha="${info#*|}"
+  version="${src_tag#v}-${NIGHTLY_SUFFIX}"
+  echo "${component}=${version}|${src_tag}|${src_sha}" >> chart-versions.txt
+done
+
+echo "--- Per-chart versions ---"
+cat chart-versions.txt

--- a/scripts/get-chart-version.sh
+++ b/scripts/get-chart-version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Look up a single field for a chart from chart-versions.txt, produced by
+# generate-chart-versions.sh (format: "<name>=<version>|<source_tag>|<source_sha>").
+#
+# Usage: get-chart-version.sh <name> [field] [file]
+#   field: 1=version (default), 2=source_tag, 3=source_sha
+#   file:  path to chart-versions.txt (default: ./chart-versions.txt)
+
+set -euo pipefail
+
+name="${1:?chart name required}"
+field="${2:-1}"
+file="${3:-chart-versions.txt}"
+
+grep "^${name}=" "${file}" | cut -d= -f2- | cut -d'|' -f"${field}"


### PR DESCRIPTION
## Summary

Follow-up to #374 (nightly build workflow), addressing eliorerz's concern raised after the first real nightly run: every published chart shared the same invented version derived from the umbrella `Chart.yaml`'s static placeholder (`0.0.1`), which doesn't reflect each component's actual release history and is confusing when compared against real releases.

## Changes

- **Umbrella version** now derives from `osac-installer`'s own latest real git tag (via `git describe --exclude '*-nightly*'`) instead of the `Chart.yaml` placeholder that's never bumped
- **Each component/CRD chart** now gets its OWN latest real release tag + the shared nightly suffix (e.g. `osac-operator-crds` gets its actual latest tag from the `osac-operator` repo, `fulfillment-service` gets its own, etc.), computed via a new "Compute per-chart versions" step
- **No more silent version guessing**: if no real (non-nightly) release tag is reachable, the build now fails loudly instead of falling back to a placeholder `v0.0.1`
- **Shallow submodule clone fix**: `actions/checkout` clones submodules at `--depth=1` regardless of the superproject's `fetch-depth: 0`, which silently broke `git describe --tags` inside submodules. Fixed by detecting shallow clones and unshallowing + fetching tags first
- The git tag, `images.txt`, and Slack notification table all reflect these per-chart versions consistently, without recomputing/duplicating logic across jobs:
  - `chart-versions.txt` is computed once in `publish` and passed to `tag-and-notify` via `upload-artifact`/`download-artifact` (avoids drift risk from two independent recomputations)
  - Version lookup logic (`get_version`/`get_source_tag`/`get_source_sha`) extracted into `scripts/get-chart-version.sh`, called from all 5 previous inline-definition sites
- `images.txt`'s "Component versions" and "Chart versions" sections merged into a single "Chart source & versions" section per chart (avoids duplicating the same base version + SHA across two separate blocks)
- Slack notification table redesigned to state the shared OCI base path once in the header instead of repeating it in every row — keeps the message well under Slack's 3000-char section limit as more charts are added (measured ~1167 chars with 8 charts, vs ~2002 chars in the original 3-column design)

## Before / After

**Before** (from the actual first nightly run):
```
osac-operator-crds  0.0.1-nightly.20260709.0d44e56.2  oci://ghcr.io/osac-project/charts/osac-operator-crds
osac-operator       0.0.1-nightly.20260709.0d44e56.2  oci://ghcr.io/osac-project/charts/osac-operator
...
osac (umbrella)     0.0.1-nightly.20260709.0d44e56.2  oci://ghcr.io/osac-project/charts/osac
```
Every chart shared the same invented `0.0.1` base, regardless of each component's real release history.

**After** (Slack notification, using each chart's actual latest real tag — matches what `/osac-release` would show):
```
*Charts published to* `oci://ghcr.io/osac-project/charts/<chart>`*:*
┌───────────────────────────────────────┬─────────────────────────────────────┐
│ Chart                                 │ Version                            │
├───────────────────────────────────────┼─────────────────────────────────────┤
│ osac-operator-crds                    │ 0.0.8-nightly.20260709.0d44e56.42  │
│ bare-metal-fulfillment-operator-crds  │ 0.0.8-nightly.20260709.c7d8e9f.42  │
│ osac-operator                         │ 0.0.8-nightly.20260709.0d44e56.42  │
│ fulfillment-service                   │ 0.0.75-nightly.20260709.a1b2c3d.42 │
│ osac-aap                              │ 0.0.9-nightly.20260709.e4f5a6b.42  │
│ bare-metal-fulfillment-operator       │ 0.0.8-nightly.20260709.c7d8e9f.42  │
│ osac-ui                               │ 0.0.3-nightly.20260709.1a2b3c4.42  │
│ osac (umbrella)                       │ 0.0.6-nightly.20260709.0d44e56.42  │
└───────────────────────────────────────┴─────────────────────────────────────┘
*Tag:* `v0.0.6-nightly.20260709.0d44e56.42`
*Run:* <View workflow>
```
This matches the real latest release tags confirmed via `gh api repos/osac-project/<repo>/tags` for each component (osac-operator v0.0.8, fulfillment-service v0.0.75, osac-aap v0.0.9, bare-metal-fulfillment-operator v0.0.8, osac-ui v0.0.3, osac-installer v0.0.6). The OCI base path is stated once in the header (`<chart>` placeholder) rather than repeated per row, since every chart shares the same registry prefix — only the chart name and its own version (which embeds a different source commit SHA per component) actually vary per row.

## Sample `images.txt` output

```
ghcr.io/osac-project/osac-operator:sha-0d44e56
ghcr.io/osac-project/fulfillment-service:sha-a1b2c3d
ghcr.io/osac-project/osac-aap:sha-e4f5a6b
ghcr.io/osac-project/bare-metal-fulfillment-operator:sha-c7d8e9f
ghcr.io/osac-project/osac-ui:sha-1a2b3c4
ghcr.io/osac-project/envoy:v1.33.0
quay.io/openshift/origin-cli:4.20.0

# Chart source & versions
# osac-operator-crds: source=v0.0.8 (0d44e56), chart=oci://ghcr.io/osac-project/charts/osac-operator-crds:0.0.8-nightly.20260709.0d44e56.3
# bare-metal-fulfillment-operator-crds: source=v0.0.8 (c7d8e9f), chart=oci://ghcr.io/osac-project/charts/bare-metal-fulfillment-operator-crds:0.0.8-nightly.20260709.c7d8e9f.3
# osac-operator: source=v0.0.8 (0d44e56), chart=oci://ghcr.io/osac-project/charts/osac-operator:0.0.8-nightly.20260709.0d44e56.3
# fulfillment-service: source=v0.0.75 (a1b2c3d), chart=oci://ghcr.io/osac-project/charts/fulfillment-service:0.0.75-nightly.20260709.a1b2c3d.3
# osac-aap: source=v0.0.9 (e4f5a6b), chart=oci://ghcr.io/osac-project/charts/osac-aap:0.0.9-nightly.20260709.e4f5a6b.3
# bare-metal-fulfillment-operator: source=v0.0.8 (c7d8e9f), chart=oci://ghcr.io/osac-project/charts/bare-metal-fulfillment-operator:0.0.8-nightly.20260709.c7d8e9f.3
# osac-ui: source=v0.0.3 (1a2b3c4), chart=oci://ghcr.io/osac-project/charts/osac-ui:0.0.3-nightly.20260709.1a2b3c4.3
# osac: source=v0.0.6 (0d44e56), chart=oci://ghcr.io/osac-project/charts/osac:0.0.6-nightly.20260709.0d44e56.3
```

Each line carries source traceability (real release tag + commit SHA the chart was built from) and a ready-to-pull OCI reference together.

## Test plan

- [x] YAML syntax validated locally
- [x] `git describe --exclude '*-nightly*'` behavior verified in an isolated test repo (correctly skips nightly tags, returns latest real release tag)
- [x] Shallow submodule clone bug reproduced with a real GitHub clone (matching `actions/checkout`'s `--depth=1` submodule behavior) and confirmed the `--unshallow` fix resolves it
- [x] Hard-fail behavior verified: no more silent `v0.0.1` fallback if no real tag is reachable
- [x] Per-chart version parsing/lookup logic (`CRD_CHARTS`/`COMPONENTS` field extraction, `get-chart-version.sh`) verified locally in bash
- [x] Box-drawing table generation (dynamic column widths) verified locally
- [x] Slack message size measured with realistic 8-chart data: ~1167 chars, comfortable margin under Slack's 3000-char limit
- [x] Cross-checked predicted per-chart versions against the actual `/osac-release` skill output — exact match
- [ ] Full nightly run on `osac-ci` (requires org context; will be validated on next scheduled/dispatched run after merge)