### PR TITLE
OSAC-1851: fix nightly-build tag-namespace collision and branch overwrite

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -104,13 +104,14 @@ jobs:
         set -euo pipefail
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA=$(git rev-parse --short=7 HEAD)
-        # Include the run ID so re-running the workflow against the same
-        # main commit on the same day (e.g. manual workflow_dispatch retries)
-        # never collides with an existing branch — a plain date+sha name
-        # is only unique if main has advanced since the last run, which
-        # isn't true for same-day manual re-runs and causes a
-        # non-fast-forward push rejection.
-        BRANCH="nightly/${DATE}-${SHORT_SHA}-${GITHUB_RUN_ID}"
+        # Include the run ID (unique per workflow run) and run attempt
+        # (increments on "Re-run failed jobs", where the run ID itself
+        # stays the same) so no combination of same-day manual re-run,
+        # whether a fresh dispatch or an in-place re-run, can ever collide
+        # with an existing branch — a plain date+sha name is only unique
+        # if main has advanced since the last run, which isn't true for
+        # either case and causes a non-fast-forward push rejection.
+        BRANCH="nightly/${DATE}-${SHORT_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -140,10 +141,18 @@ jobs:
         # version reflects where this build actually sits relative to
         # real releases. Fail loudly rather than silently guessing a
         # version if no real tag is reachable. --match restricts to plain
-        # "vX.Y.Z" tags in case an unrelated tag namespace (e.g. "api/vX.Y.Z"
-        # in a component repo) is ever introduced here too.
+        # "vX.Y.Z"-shaped tags in case an unrelated tag namespace (e.g.
+        # "api/vX.Y.Z" in a component repo) is ever introduced here too.
+        # --match is still a glob, not a real anchor (its trailing '*' is
+        # needed to allow multi-digit version segments, but that same '*'
+        # would also accept a stray "-rc1"/".4" suffix) so re-validate the
+        # result with a real regex before trusting it.
         if ! BASE_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
           echo "ERROR: no real (non-nightly) release tag reachable from HEAD — refusing to guess a version" >&2
+          exit 1
+        fi
+        if [[ ! "${BASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "ERROR: nearest release tag '${BASE_TAG}' is not a plain vX.Y.Z tag — refusing to guess a version" >&2
           exit 1
         fi
         BASE_VERSION="${BASE_TAG#v}"

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -104,7 +104,13 @@ jobs:
         set -euo pipefail
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA=$(git rev-parse --short=7 HEAD)
-        BRANCH="nightly/${DATE}-${SHORT_SHA}"
+        # Include the run ID so re-running the workflow against the same
+        # main commit on the same day (e.g. manual workflow_dispatch retries)
+        # never collides with an existing branch — a plain date+sha name
+        # is only unique if main has advanced since the last run, which
+        # isn't true for same-day manual re-runs and causes a
+        # non-fast-forward push rejection.
+        BRANCH="nightly/${DATE}-${SHORT_SHA}-${GITHUB_RUN_ID}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -133,8 +139,10 @@ jobs:
         # Chart.yaml placeholder, which is never bumped) so the nightly
         # version reflects where this build actually sits relative to
         # real releases. Fail loudly rather than silently guessing a
-        # version if no real tag is reachable.
-        if ! BASE_TAG=$(git describe --tags --abbrev=0 --exclude '*-nightly*' 2>/dev/null); then
+        # version if no real tag is reachable. --match restricts to plain
+        # "vX.Y.Z" tags in case an unrelated tag namespace (e.g. "api/vX.Y.Z"
+        # in a component repo) is ever introduced here too.
+        if ! BASE_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
           echo "ERROR: no real (non-nightly) release tag reachable from HEAD — refusing to guess a version" >&2
           exit 1
         fi

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -135,7 +135,12 @@ jobs:
         source ./scripts/lib.sh
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA="${COMMIT_SHA:0:7}"
-        NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}"
+        # GITHUB_RUN_NUMBER, like GITHUB_RUN_ID, stays constant across a
+        # "Re-run failed jobs" of the same run — only GITHUB_RUN_ATTEMPT
+        # increments there. Without it, re-running the same failed run
+        # would produce the identical chart version string, matching the
+        # temp-branch collision fixed above.
+        NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
 
         # Use the umbrella chart's own latest real release tag (not the
         # Chart.yaml placeholder, which is never bumped) so the nightly

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -132,6 +132,7 @@ jobs:
         COMMIT_SHA: ${{ steps.push.outputs.sha }}
       run: |
         set -euo pipefail
+        source ./scripts/lib.sh
         DATE=$(date -u +%Y%m%d)
         SHORT_SHA="${COMMIT_SHA:0:7}"
         NIGHTLY_SUFFIX="nightly.${DATE}.${SHORT_SHA}.${GITHUB_RUN_NUMBER}"
@@ -139,22 +140,8 @@ jobs:
         # Use the umbrella chart's own latest real release tag (not the
         # Chart.yaml placeholder, which is never bumped) so the nightly
         # version reflects where this build actually sits relative to
-        # real releases. Fail loudly rather than silently guessing a
-        # version if no real tag is reachable. --match restricts to plain
-        # "vX.Y.Z"-shaped tags in case an unrelated tag namespace (e.g.
-        # "api/vX.Y.Z" in a component repo) is ever introduced here too.
-        # --match is still a glob, not a real anchor (its trailing '*' is
-        # needed to allow multi-digit version segments, but that same '*'
-        # would also accept a stray "-rc1"/".4" suffix) so re-validate the
-        # result with a real regex before trusting it.
-        if ! BASE_TAG=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
-          echo "ERROR: no real (non-nightly) release tag reachable from HEAD — refusing to guess a version" >&2
-          exit 1
-        fi
-        if [[ ! "${BASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "ERROR: nearest release tag '${BASE_TAG}' is not a plain vX.Y.Z tag — refusing to guess a version" >&2
-          exit 1
-        fi
+        # real releases.
+        BASE_TAG=$(resolve_release_tag .)
         BASE_VERSION="${BASE_TAG#v}"
         VERSION="${BASE_VERSION}-${NIGHTLY_SUFFIX}"
 

--- a/scripts/generate-chart-versions.sh
+++ b/scripts/generate-chart-versions.sh
@@ -38,12 +38,19 @@ chart_info_for_path() {
   # Fail loudly rather than silently guessing a version: publishing a
   # chart under a made-up placeholder tag would be worse than failing
   # the build, since it could get pushed to the registry unnoticed.
-  # --match restricts to plain "vX.Y.Z" tags: some component repos (e.g.
-  # osac-operator) also carry a separate "api/vX.Y.Z" tag namespace (Go
-  # API module versioning) that `describe` would otherwise pick up if
-  # it happens to be nearer HEAD than the real chart-release tag.
+  # --match restricts to plain "vX.Y.Z"-shaped tags: some component repos
+  # (e.g. osac-operator) also carry a separate "api/vX.Y.Z" tag namespace
+  # (Go API module versioning) that `describe` would otherwise pick up if
+  # it happens to be nearer HEAD than the real chart-release tag. --match
+  # is still a glob, not a real anchor (its trailing '*' is needed to
+  # allow multi-digit version segments, but that same '*' would also
+  # accept a stray "-rc1"/".4" suffix) so re-validate with a real regex.
   if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
     echo "ERROR: no real (non-nightly) release tag reachable from ${path} — refusing to guess a version" >&2
+    exit 1
+  fi
+  if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: nearest release tag '${tag}' reachable from ${path} is not a plain vX.Y.Z tag — refusing to guess a version" >&2
     exit 1
   fi
   sha=$(git -C "${path}" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")

--- a/scripts/generate-chart-versions.sh
+++ b/scripts/generate-chart-versions.sh
@@ -24,6 +24,8 @@ source "${SCRIPT_DIR}/lib.sh"
 : "${CRD_CHARTS:?CRD_CHARTS must be set}"
 : "${COMPONENTS:?COMPONENTS must be set}"
 
+# Resolve a submodule's release tag and current SHA for chart-versions.txt.
+# Usage: chart_info_for_path <submodule_path>; prints "<tag>|<sha>".
 chart_info_for_path() {
   local path=$1
   local tag sha

--- a/scripts/generate-chart-versions.sh
+++ b/scripts/generate-chart-versions.sh
@@ -38,7 +38,11 @@ chart_info_for_path() {
   # Fail loudly rather than silently guessing a version: publishing a
   # chart under a made-up placeholder tag would be worse than failing
   # the build, since it could get pushed to the registry unnoticed.
-  if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --exclude '*-nightly*' 2>/dev/null); then
+  # --match restricts to plain "vX.Y.Z" tags: some component repos (e.g.
+  # osac-operator) also carry a separate "api/vX.Y.Z" tag namespace (Go
+  # API module versioning) that `describe` would otherwise pick up if
+  # it happens to be nearer HEAD than the real chart-release tag.
+  if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
     echo "ERROR: no real (non-nightly) release tag reachable from ${path} — refusing to guess a version" >&2
     exit 1
   fi

--- a/scripts/generate-chart-versions.sh
+++ b/scripts/generate-chart-versions.sh
@@ -17,6 +17,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
 : "${NIGHTLY_SUFFIX:?NIGHTLY_SUFFIX must be set}"
 : "${CRD_CHARTS:?CRD_CHARTS must be set}"
 : "${COMPONENTS:?COMPONENTS must be set}"
@@ -35,24 +38,7 @@ chart_info_for_path() {
   else
     git -C "${path}" fetch --tags --quiet 2>/dev/null || true
   fi
-  # Fail loudly rather than silently guessing a version: publishing a
-  # chart under a made-up placeholder tag would be worse than failing
-  # the build, since it could get pushed to the registry unnoticed.
-  # --match restricts to plain "vX.Y.Z"-shaped tags: some component repos
-  # (e.g. osac-operator) also carry a separate "api/vX.Y.Z" tag namespace
-  # (Go API module versioning) that `describe` would otherwise pick up if
-  # it happens to be nearer HEAD than the real chart-release tag. --match
-  # is still a glob, not a real anchor (its trailing '*' is needed to
-  # allow multi-digit version segments, but that same '*' would also
-  # accept a stray "-rc1"/".4" suffix) so re-validate with a real regex.
-  if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
-    echo "ERROR: no real (non-nightly) release tag reachable from ${path} — refusing to guess a version" >&2
-    exit 1
-  fi
-  if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "ERROR: nearest release tag '${tag}' reachable from ${path} is not a plain vX.Y.Z tag — refusing to guess a version" >&2
-    exit 1
-  fi
+  tag=$(resolve_release_tag "${path}") || exit 1
   sha=$(git -C "${path}" rev-parse --short=7 HEAD 2>/dev/null || echo "unknown")
   echo "${tag}|${sha}"
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -127,6 +127,32 @@ http_json() {
     return 1
 }
 
+# Resolve the nearest real (non-nightly) plain vX.Y.Z release tag reachable
+# from a repo path's HEAD. --match narrows git describe's glob search to
+# tags shaped like "vX.Y.Z" so an unrelated tag namespace (e.g. a component
+# repo's "api/vX.Y.Z" Go module tags) isn't picked up if it happens to be
+# nearer HEAD than the real release tag. --match is still a glob, not a
+# real anchor (its trailing '*' is needed to allow multi-digit version
+# segments, but that same '*' would also accept a stray "-rc1"/".4"
+# suffix), so the result is re-validated with a real regex before being
+# trusted. Fails loudly rather than silently guessing a version: publishing
+# a chart under a made-up placeholder tag would be worse than failing the
+# build outright, since it could get pushed to the registry unnoticed.
+# Usage: resolve_release_tag <repo_path>
+resolve_release_tag() {
+    local path="$1"
+    local tag
+    if ! tag=$(git -C "${path}" describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude '*-nightly*' 2>/dev/null); then
+        echo "ERROR: no real (non-nightly) release tag reachable from ${path} — refusing to guess a version" >&2
+        return 1
+    fi
+    if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "ERROR: nearest release tag '${tag}' reachable from ${path} is not a plain vX.Y.Z tag — refusing to guess a version" >&2
+        return 1
+    fi
+    echo "${tag}"
+}
+
 readonly POSTGRES_INSTALL_DOC="base/osac-fulfillment-service/docs/INSTALL.md"
 
 # PostgreSQL prerequisite helpers (production install via setup.sh).


### PR DESCRIPTION
## Summary

Follow-up to #408. Root-caused two of the recent nightly-build.yaml failure runs, plus follow-up hardening/cleanup from CodeRabbit review:

- **`git describe --tags` picked up the wrong tag namespace.** `osac-operator` carries both a plain `vX.Y.Z` release-tag namespace and a separate `api/vX.Y.Z` namespace (Go API module versioning). `git describe --tags --abbrev=0 --exclude '*-nightly*'` has no way to distinguish them and returned `api/v0.0.7` on a run where it happened to be nearer HEAD than the real `v0.0.8` release tag, producing an invalid semver string (`api/v0.0.7-nightly...`) and failing the publish job (`Error: Invalid Semantic Version`). Fix: add `--match 'v[0-9]*.[0-9]*.[0-9]*'` to both `git describe` call sites (`scripts/generate-chart-versions.sh` and the umbrella `BASE_TAG` computation) so only real release tags are ever considered.
- **Temp branch name collision on same-day re-runs.** The branch name `nightly/${DATE}-${SHORT_SHA}` is only unique if `main` has advanced since the previous run. Manually re-running `workflow_dispatch` multiple times against an unchanged `main` commit on the same day pushes to the exact same branch name every time, and the push is rejected as non-fast-forward. Fix: include `${GITHUB_RUN_ID}` in the branch name to guarantee uniqueness per run.
- **(CodeRabbit) `GITHUB_RUN_ID` alone doesn't cover "Re-run failed jobs".** `RUN_ID` stays constant across re-run attempts of the *same* run — only `GITHUB_RUN_ATTEMPT` increments there. Added `GITHUB_RUN_ATTEMPT` alongside `GITHUB_RUN_ID` so both a fresh dispatch and an in-place re-run are covered.
- **(CodeRabbit) `--match` glob is not a real anchor.** `--match 'v[0-9]*.[0-9]*.[0-9]*'` still accepts malformed tags like `v1.2.3-rc1` or `v1.2.3.4`, since the trailing `*` needed to allow multi-digit version segments also swallows any suffix. Glob (fnmatch) has no repetition quantifier to express "digits only" precisely, so added a real regex check (`^v[0-9]+\.[0-9]+\.[0-9]+$`) on the resolved tag after `describe`, failing loudly if it doesn't match exactly.
- **(CodeRabbit) Duplicated tag-resolution logic across two files.** The `git describe --match`/`--exclude`/regex-validation block above had already needed two rounds of coordinated fixes across `scripts/generate-chart-versions.sh` and `nightly-build.yaml`. Extracted it into a `resolve_release_tag()` helper in `scripts/lib.sh` (this repo's existing convention for shared shell functions) so both call sites share one implementation.
- **(CodeRabbit) `NIGHTLY_SUFFIX` had the same rerun-collision bug as the branch name.** `GITHUB_RUN_NUMBER`, like `GITHUB_RUN_ID`, stays constant across "Re-run failed jobs" of the same run — only `GITHUB_RUN_ATTEMPT` increments there. The actual published chart version string (`NIGHTLY_SUFFIX`) was missed when the branch-name fix above was applied. Added `GITHUB_RUN_ATTEMPT` there too, for consistency.

## Test plan

- Reproduced the tag-namespace bug directly against `osac-operator`'s live history: `git describe --tags --abbrev=0 --exclude '*-nightly*'` returns `api/v0.0.7`, while adding `--match 'v[0-9]*.[0-9]*.[0-9]*'` correctly returns `v0.0.8`.
- Confirmed via `gh run view --log-failed` on the actual failed runs that this matches the exact error seen in production (`--- Publishing osac-operator-crds (api/v0.0.7-nightly...) --- Error: Invalid Semantic Version`) and the exact branch-push rejection (`! [rejected] nightly/20260710-091c6f0 -> nightly/20260710-091c6f0 (non-fast-forward)`).
- Verified the new regex against the edge cases CodeRabbit flagged: `v1.2.3` and `v0.0.10` accepted; `v1.2.3-rc1`, `v1.2.3.4`, and `api/v0.0.7` rejected.
- Re-verified the same edge cases against the extracted `resolve_release_tag()` helper after the consolidation to confirm identical behavior.
- Confirmed `NIGHTLY_SUFFIX`/`VERSION` are only ever consumed as opaque strings downstream (never parsed with an assumed segment count), so appending `GITHUB_RUN_ATTEMPT` is safe.
- Will be validated end-to-end on the next scheduled/dispatched nightly run after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved nightly end-to-end reruns with more collision-resistant temporary branch names using run identifiers.
  - Tightened release-tag selection to only accept standard `vX.Y.Z` releases (excluding nightly-tagged versions).
  - Fail fast when a valid release tag can’t be resolved to avoid incorrect downstream versioning.

- **Chores**
  - Refined release automation by centralizing release-tag resolution logic.
  - Updated nightly/chart version suffixing to include run attempt for clearer run-level uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->