### PR TITLE
OSAC-2189: Pin committed Chart.yaml dependency versions exactly

### DIFF
--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -6,32 +6,32 @@ version: 0.0.1
 
 dependencies:
   - name: osac-operator-crds
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/osac-operator/charts/operator-crds"
     alias: operatorCrds
   - name: osac-operator
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/osac-operator/charts/operator"
     alias: operator
   - name: fulfillment-service
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/osac-fulfillment-service/charts/service"
     alias: service
   - name: osac-aap
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/osac-aap/charts/aap"
     alias: aap
   - name: bare-metal-fulfillment-operator-crds
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator-crds"
     alias: bmfCrds
   - name: bare-metal-fulfillment-operator
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/bare-metal-fulfillment-operator/charts/operator"
     alias: bmf
     condition: bmf.enabled
   - name: osac-ui
-    version: ">=0.0.0"
+    version: "0.0.0"
     repository: "file://../../base/osac-ui/charts/ui"
     alias: ui
     condition: ui.enabled


### PR DESCRIPTION
## Summary

`charts/osac/Chart.yaml` declared all 7 sub-chart dependencies with `version: ">=0.0.0"` -- an intentional placeholder that `publish-charts.yaml` overwrites with the exact release version via `yq` before packaging. But `">=0.0.0"` is a real, permissive semver range: if the `repository` field were ever pointed at the actual OCI registry outside the release workflow (e.g. during a refactor), `helm dependency update`/`helm package` would silently resolve every dependency to the **newest available** chart version, with no error or warning.

Changed the placeholder to an exact `"0.0.0"` match instead of an open-ended range.

### Verification (done locally, not just by inspection)

- All 7 local submodule sub-charts (`base/*/charts/*/Chart.yaml`) pin their own committed version to exactly `0.0.0`, so `helm dependency build` / `helm lint` / `helm template` against the local `file://` dependencies (as run by `helm-lint.yaml` on every PR and `helm-integration.yaml` on schedule) continue to work unchanged -- confirmed by running the full `helm-lint.yaml` sequence (dependency build, lint, template with all `ci/*-values.yaml` and `values/*/values.yaml`) locally against this change.
- Against the real OCI registry, simulated both constraints against `oci://ghcr.io/osac-project/charts/osac-aap`:
  - `>=0.0.0` **silently resolved to the newest published version** (`0.0.9`) with no warning -- reproducing the exact hazard described in the ticket.
  - Exact `"0.0.0"` **fails loudly** (`not found`) instead, since no real release is tagged `0.0.0`.
- The `publish-charts.yaml` "Rewrite dependencies to OCI references" step unconditionally overwrites both `.version` and `.repository` by dependency `name` via `yq`, regardless of the prior placeholder value -- confirmed by simulating that rewrite step against the modified `Chart.yaml`, which produces an identical result to before.

### Rejected alternative

The ticket (and automated triage) also suggested an obviously-invalid placeholder string like `"0.0.0-placeholder"`. Tested this locally first and rejected it: it breaks `helm dependency build` against the local `file://` submodule charts, because those are pinned to exactly `0.0.0`, not `0.0.0-placeholder` -- this would have broken the `helm-lint` PR check and the scheduled integration test.

## Test plan

- [x] `helm dependency build charts/osac/` succeeds locally with this change.
- [x] `helm lint` / `helm template` with all CI and environment values files succeed locally (pre-existing, unrelated schema warnings excluded).
- [x] Simulated the `publish-charts.yaml` release-time `yq` rewrite against the modified file; output unchanged.
- [ ] CI (`helm-lint.yaml`) passes on this PR.

Fixes [OSAC-2189](https://redhat.atlassian.net/browse/OSAC-2189).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart dependency version declarations to use fixed versions for more predictable deployments.
  * Preserved existing dependency repositories, aliases, and conditional settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->