### PR TITLE
Rename Helm Integration Test workflow to Integration Tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: Helm Integration Test
+name: Integration Tests
 
 on:
   schedule:


### PR DESCRIPTION
## What

Renamed `helm-integration.yaml` -> `integration-tests.yml`, workflow name `Helm Integration Test` -> `Integration Tests`. No trigger/content change — already runs on a daily schedule (06:00 UTC) + `workflow_dispatch`.

## Why

Part of [OSAC-2377](https://redhat.atlassian.net/browse/OSAC-2377): aligning integration-test workflow naming across OSAC repos so the CI monitoring dashboard's cross-repo merge actually groups them.

Confirmed this repo's branch protection required status check (`e2e-vmaas-full-install / e2e`) doesn't reference this workflow's name.