### PR TITLE
OSAC-2390: Add NATGateway RBAC entries to hub-access Role

### DIFF
--- a/charts/osac/templates/hub-access.yaml
+++ b/charts/osac/templates/hub-access.yaml
@@ -240,6 +240,24 @@ rules:
   - apiGroups:
       - osac.openshift.io
     resources:
+      - natgateways
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - osac.openshift.io
+    resources:
+      - natgateways/status
+    verbs:
+      - get
+  - apiGroups:
+      - osac.openshift.io
+    resources:
       - baremetalinstances
     verbs:
       - create


### PR DESCRIPTION
Grant the fulfillment-service controller RBAC access to NATGateway CRD resources on the hub cluster. The NATGateway reconciler ([OSAC-1490](https://redhat.atlassian.net/browse/OSAC-1490)) creates and manages NATGateway CRs on hub clusters via the hub-access ServiceAccount, which needs natgateways and natgateways/status permissions.

Follows the same pattern as the ExternalIP entries added in PR #337.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions for enabled hub access to manage NAT gateway resources, including viewing their status.
  * Supports creating, updating, deleting, listing, watching, and retrieving NAT gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->