### PR TITLE
OSAC-2468: convert bundled Postgres from Pod to Deployment

### DIFF
--- a/charts/osac/templates/bundled-postgres.yaml
+++ b/charts/osac/templates/bundled-postgres.yaml
@@ -74,10 +74,6 @@ data:
     hba_file = '/config/access/access.conf'
     fsync = off
     full_page_writes = off
-    # Pin the socket dir explicitly rather than relying on the image's
-    # default -- needed now that the container filesystem is read-only
-    # except for the volumes mounted below, /tmp being one of them.
-    unix_socket_directories = '/tmp'
   access.conf: |
     local all all peer
     hostssl all all 0.0.0.0/0 cert

--- a/charts/osac/templates/bundled-postgres.yaml
+++ b/charts/osac/templates/bundled-postgres.yaml
@@ -74,6 +74,10 @@ data:
     hba_file = '/config/access/access.conf'
     fsync = off
     full_page_writes = off
+    # Pin the socket dir explicitly rather than relying on the image's
+    # default -- needed now that the container filesystem is read-only
+    # except for the volumes mounted below, /tmp being one of them.
+    unix_socket_directories = '/tmp'
   access.conf: |
     local all all peer
     hostssl all all 0.0.0.0/0 cert
@@ -154,15 +158,22 @@ spec:
           secretName: postgres-init
       - name: data
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      - name: run
+        emptyDir: {}
       containers:
       - name: server
         image: {{ .Values.bundledPostgres.image | default "quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2" }}
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
             - ALL
+        resources:
+          {{- toYaml .Values.bundledPostgres.resources | nindent 10 }}
         env:
         - name: POSTGRESQL_USER
           value: "default"
@@ -173,6 +184,10 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /var/lib/pgsql/data
+        - name: tmp
+          mountPath: /tmp
+        - name: run
+          mountPath: /run
         - name: server-cert
           mountPath: /secrets/cert
         {{- if .Values.service.certs.caBundle.configMap }}

--- a/charts/osac/templates/bundled-postgres.yaml
+++ b/charts/osac/templates/bundled-postgres.yaml
@@ -109,8 +109,8 @@ spec:
     port: 5432
     targetPort: postgres
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: postgres
   namespace: {{ .Release.Namespace }}
@@ -118,73 +118,88 @@ metadata:
     app: postgres
     {{- include "osac.labels" . | nindent 4 }}
 spec:
-  automountServiceAccountToken: false
-  securityContext:
-    runAsNonRoot: true
-  volumes:
-  - name: server-cert
-    secret:
-      secretName: postgres-server-cert
-      defaultMode: 0440
-  - name: config
-    configMap:
-      name: postgres-config
-  {{- if .Values.service.certs.caBundle.configMap }}
-  - name: ca-bundle
-    configMap:
-      name: {{ .Values.service.certs.caBundle.configMap }}
-  {{- end }}
-  - name: init
-    secret:
-      secretName: postgres-init
-  - name: data
-    emptyDir: {}
-  containers:
-  - name: server
-    image: {{ .Values.bundledPostgres.image | default "quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2" }}
-    imagePullPolicy: IfNotPresent
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-    env:
-    - name: POSTGRESQL_USER
-      value: "default"
-    - name: POSTGRESQL_PASSWORD
-      value: ""
-    - name: POSTGRESQL_DATABASE
-      value: "default"
-    volumeMounts:
-    - name: data
-      mountPath: /var/lib/pgsql/data
-    - name: server-cert
-      mountPath: /secrets/cert
-    {{- if .Values.service.certs.caBundle.configMap }}
-    - name: ca-bundle
-      mountPath: /config/ca
-    {{- end }}
-    - name: config
-      mountPath: /opt/app-root/src/postgresql-cfg/server.conf
-      subPath: server.conf
-    - name: config
-      mountPath: /config/access/access.conf
-      subPath: access.conf
-    - name: init
-      mountPath: /opt/app-root/src/postgresql-init/init.sh
-      subPath: init.sh
-    ports:
-    - name: postgres
-      protocol: TCP
-      containerPort: 5432
-    livenessProbe:
-      tcpSocket:
-        port: postgres
-      initialDelaySeconds: 10
-      periodSeconds: 10
-    readinessProbe:
-      tcpSocket:
-        port: postgres
-      initialDelaySeconds: 5
-      periodSeconds: 5
+  replicas: 1
+  # emptyDir-backed data, and only one replica is ever wanted -- Recreate
+  # avoids two postgres pods briefly coexisting (and racing on the same
+  # Service) during a rollout, which RollingUpdate would otherwise allow.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+      volumes:
+      - name: server-cert
+        secret:
+          secretName: postgres-server-cert
+          defaultMode: 0440
+      - name: config
+        configMap:
+          name: postgres-config
+      {{- if .Values.service.certs.caBundle.configMap }}
+      - name: ca-bundle
+        configMap:
+          name: {{ .Values.service.certs.caBundle.configMap }}
+      {{- end }}
+      - name: init
+        secret:
+          secretName: postgres-init
+      - name: data
+        emptyDir: {}
+      containers:
+      - name: server
+        image: {{ .Values.bundledPostgres.image | default "quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2" }}
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        env:
+        - name: POSTGRESQL_USER
+          value: "default"
+        - name: POSTGRESQL_PASSWORD
+          value: ""
+        - name: POSTGRESQL_DATABASE
+          value: "default"
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/pgsql/data
+        - name: server-cert
+          mountPath: /secrets/cert
+        {{- if .Values.service.certs.caBundle.configMap }}
+        - name: ca-bundle
+          mountPath: /config/ca
+        {{- end }}
+        - name: config
+          mountPath: /opt/app-root/src/postgresql-cfg/server.conf
+          subPath: server.conf
+        - name: config
+          mountPath: /config/access/access.conf
+          subPath: access.conf
+        - name: init
+          mountPath: /opt/app-root/src/postgresql-init/init.sh
+          subPath: init.sh
+        ports:
+        - name: postgres
+          protocol: TCP
+          containerPort: 5432
+        livenessProbe:
+          tcpSocket:
+            port: postgres
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: postgres
+          initialDelaySeconds: 5
+          periodSeconds: 5
 {{- end }}

--- a/charts/osac/templates/bundled-postgres.yaml
+++ b/charts/osac/templates/bundled-postgres.yaml
@@ -183,7 +183,14 @@ spec:
           value: "default"
         volumeMounts:
         - name: data
-          mountPath: /var/lib/pgsql/data
+          # Mounted at the whole home dir, not just .../data -- the sclorg
+          # entrypoint (common.sh) also writes an nss_wrapper passwd file
+          # directly under /var/lib/pgsql (for the container's arbitrary
+          # OpenShift-assigned UID) before ever touching the data subdir.
+          # Confirmed live: with the mount scoped to .../data only, the
+          # container CrashLoopBackOff'd on
+          # "/var/lib/pgsql/passwd: Read-only file system".
+          mountPath: /var/lib/pgsql
         - name: tmp
           mountPath: /tmp
         - name: run

--- a/charts/osac/templates/bundled-postgres.yaml
+++ b/charts/osac/templates/bundled-postgres.yaml
@@ -158,6 +158,27 @@ spec:
         emptyDir: {}
       - name: run
         emptyDir: {}
+      # The run emptyDir starts out completely empty -- nothing creates the
+      # postgresql/ subdirectory the server needs for its lock file and
+      # socket before it starts. Confirmed live: without this, postgres
+      # fails outright with 'could not create lock file
+      # "/var/run/postgresql/.s.PGSQL.5432.lock": No such file or directory'.
+      initContainers:
+      - name: init-run-dir
+        image: {{ .Values.bundledPostgres.image | default "quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - mkdir -p /run/postgresql
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: run
+          mountPath: /run
       containers:
       - name: server
         image: {{ .Values.bundledPostgres.image | default "quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2" }}

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1195,6 +1195,38 @@
               "default": "service"
             }
           }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Container resource requests and limits",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU limit"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory limit"
+                }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "string",
+                  "description": "CPU request"
+                },
+                "memory": {
+                  "type": "string",
+                  "description": "Memory request"
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -249,3 +249,10 @@ bundledPostgres:
   database:
     name: service
     user: service
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi


### PR DESCRIPTION
## Summary

#404 added a bare `kind: Pod` for the CI-only bundled Postgres. This is currently breaking E2E on **every** downstream repo that deploys OSAC as part of its own test suite — confirmed identically on `osac-aap`, `osac-operator`, and `fulfillment-service`:

```
Error: UPGRADE FAILED: cannot patch "postgres" with kind Pod: Pod "postgres" is invalid: spec: Forbidden: pod updates may not change fields other than `spec.containers[*].image`, ...
```

## Root cause

The E2E workflow calls `helm upgrade` on this chart **twice** per run: once via `make install-osac`, then again later to merge a built component's image in (`--reuse-values --no-hooks --set ...`). The first call creates the Pod fine — no existing object to conflict with. By the second call, OpenShift's SCC admission controller has already mutated the *live* Pod (e.g. injecting a per-namespace `securityContext.seLinuxOptions.level` absent from the chart's literal template). Helm's patch generation doesn't account for that server-side mutation, and Kubernetes rejects the resulting patch outright — almost the entire Pod spec is immutable post-creation.

This isn't specific to what's *in* this particular Pod spec — a bare `Pod` under `helm upgrade` is fundamentally unsafe to re-apply more than once, regardless of contents.

## Fix

Wrap it in a single-replica `Deployment` instead. Deployments are designed to be re-applied — Kubernetes reconciles by rolling a new ReplicaSet/Pod rather than attempting an in-place Pod patch, so server-side mutations on the live Pod never conflict with the chart's desired template. `strategy: Recreate` matches the existing single-replica, `emptyDir`-backed (no real persistence to preserve) design, avoiding two Postgres pods briefly coexisting and racing on the same Service.

## Verification

- [x] `helm lint charts/osac/ --values values/vmaas-ci/values.yaml` passes
- [x] `helm template` renders the Deployment correctly with CI values
- [x] Confirmed the rendered template is byte-identical across two calls with different unrelated `--set` overrides, ruling out per-render nondeterminism as a contributing factor
- [ ] Full E2E verification pending — will confirm once this merges and a fresh run exercises the double-`helm upgrade` path this was actually breaking