### PR TITLE
OSAC-2468: Retry-wait for API server before the first install phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,24 @@ help: ## Display this help
 .PHONY: install
 install: install-operators install-prereqs install-osac ## Full install (operators + prereqs + OSAC)
 
+.PHONY: wait-for-api
+wait-for-api: ## Wait for the Kubernetes API server to be consistently reachable
+	@echo "Waiting for API server to be reachable..."
+	@for i in $$(seq 1 30); do \
+		if oc get --raw /version >/dev/null 2>&1; then \
+			echo "API server is reachable."; \
+			exit 0; \
+		fi; \
+		if [ "$$i" -eq 30 ]; then \
+			echo "ERROR: API server still unreachable after 5 minutes." >&2; \
+			exit 1; \
+		fi; \
+		echo "  Not yet reachable (attempt $$i/30), retrying in 10s..."; \
+		sleep 10; \
+	done
+
 .PHONY: install-operators
-install-operators: ## Phase 1: Install OLM operators (cert-manager, AAP, LVMS, etc.)
+install-operators: wait-for-api ## Phase 1: Install OLM operators (cert-manager, AAP, LVMS, etc.)
 	helm upgrade --install osac-operators charts/osac-operators/ \
 		--namespace osac-operators --create-namespace \
 		--values $(VALUES_FILE) \


### PR DESCRIPTION
## Summary

`install-operators` is the first thing that talks to the cluster in the three-phase install (`install-operators` -> `install-prereqs` -> `install-osac`). The now-deleted `setup.sh`'s first API call used to be wrapped in a `retry_until`, silently absorbing a transient connection blip (e.g. right after a node reboots for an unrelated reason, or any other momentary apiserver hiccup). A bare `helm upgrade --install ... --wait` has no such resilience — one unlucky EOF and the whole install fails outright:

```
Error: Kubernetes cluster unreachable: Get "https://...:6443/version": EOF
```

Confirmed via timeline: this signature only started appearing in E2E runs after #404/#183 merged, never before.

## Fix

Add a `wait-for-api` target (up to 5 minutes, retried every 10s) as a prerequisite of `install-operators`. Scoped to the installer itself rather than any specific caller's workflow, since anything invoking `make install`/`make install-operators` against a cluster that just had a node reboot (or any other transient network blip) benefits — not just one CI pipeline.

## Verification

- [x] `make -n install-operators` confirms correct target expansion
- [x] Tested the retry loop's success and failure paths directly with a stubbed `oc` binary
- [ ] Full E2E verification pending on this branch

## Related

Companion fix to #418 (bare `Pod` → `Deployment` for bundled Postgres — a separate bug from the same PR). Together these should resolve the current wave of scheduled-run failures without needing to revert the #404 chart restructuring.