### PR TITLE
OSAC-2468: Add guard install-prereqs and install-osac with wait-for-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ wait-for-prereqs-namespaces: ## Wait for the keycloak namespace left Terminating
 	@bash -c 'source scripts/lib.sh && wait_for_namespace_cleanup keycloak'
 
 .PHONY: install-prereqs
-install-prereqs: wait-for-prereqs-namespaces ## Phase 2: Configure prerequisites (certificates, keycloak, operator CRs)
+install-prereqs: wait-for-api wait-for-prereqs-namespaces ## Phase 2: Configure prerequisites (certificates, keycloak, operator CRs)
 	$(eval OCP_VERSION := $(shell oc get clusterversion version -o jsonpath='{.status.desired.version}' | cut -d. -f1,2))
 	$(eval DOMAIN := $(shell oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'))
 	helm upgrade --install osac-prereqs charts/osac-prereqs/ \
@@ -80,7 +80,7 @@ check-postgres: ## Verify in-cluster PostgreSQL is reachable before installing O
 	@bash -c 'source scripts/lib.sh && check_postgres_prerequisites "$(INSTALLER_NAMESPACE)" "$(VALUES_FILE)"'
 
 .PHONY: install-osac
-install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
+install-osac: wait-for-api helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 	$(eval DOMAIN := $(shell oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'))
 	@[[ -n "$(DOMAIN)" ]] || { echo "ERROR: Could not determine cluster domain. Is oc logged in?"; exit 1; }
 	helm upgrade --install osac charts/osac/ \


### PR DESCRIPTION
## Summary

Stacked on #419 — this branch includes that PR's commit plus one more on top. Once #419 merges, this diff will shrink to just the new commit.

#419 added a `wait-for-api` Makefile target and wired it as a prerequisite of `install-operators` only, since that's the first phase to touch the cluster in the full `make install` chain. This PR extends the same guard to `install-prereqs` and `install-osac`, so standalone invocations of those phases (e.g. re-running just one phase during debugging, after some other transient API blip) get the same protection.

Verified via `make -n install` that this adds no extra cost to the full chain — Make's DAG dedup means `wait-for-api` still only runs once per `make install` invocation, since it's a shared `.PHONY` prerequisite of all three phase targets in the same build graph. It only actually runs an extra time when a phase is invoked standalone.

## Ticket

https://redhat.atlassian.net/browse/OSAC-2468

## Related

- #418 — bare Pod → Deployment for bundled Postgres (same regression wave from #404)
- #419 — original `wait-for-api` target, guarding `install-operators`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installation workflows now wait until the Kubernetes API is reachable before starting operator, prerequisite, and OSAC setup.
  * Added a bounded retry period with a clear failure if the API does not become available in time.
* **Chores**
  * Introduced a reusable API readiness check to improve reliability and prevent premature installation attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->