### PR TITLE
OSAC-2468: Restore setup.sh safety checks dropped by PR #404

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,26 @@ wait-for-api: ## Wait for the Kubernetes API server to be consistently reachable
 		sleep 10; \
 	done
 
+.PHONY: wait-for-operators-namespaces
+wait-for-operators-namespaces: ## Wait for operator namespaces left Terminating by a prior uninstall
+	@bash -c 'source scripts/lib.sh && \
+		for ns in ansible-aap cert-manager-operator cert-manager openshift-storage metallb-system multicluster-engine openshift-cnv; do \
+			wait_for_namespace_cleanup "$$ns"; \
+		done'
+
 .PHONY: install-operators
-install-operators: wait-for-api ## Phase 1: Install OLM operators (cert-manager, AAP, LVMS, etc.)
+install-operators: wait-for-api wait-for-operators-namespaces ## Phase 1: Install OLM operators (cert-manager, AAP, LVMS, etc.)
 	helm upgrade --install osac-operators charts/osac-operators/ \
 		--namespace osac-operators --create-namespace \
 		--values $(VALUES_FILE) \
 		--timeout 30m --wait
 
+.PHONY: wait-for-prereqs-namespaces
+wait-for-prereqs-namespaces: ## Wait for the keycloak namespace left Terminating by a prior uninstall
+	@bash -c 'source scripts/lib.sh && wait_for_namespace_cleanup keycloak'
+
 .PHONY: install-prereqs
-install-prereqs: ## Phase 2: Configure prerequisites (certificates, keycloak, operator CRs)
+install-prereqs: wait-for-prereqs-namespaces ## Phase 2: Configure prerequisites (certificates, keycloak, operator CRs)
 	helm upgrade --install osac-prereqs charts/osac-prereqs/ \
 		--namespace osac-prereqs --create-namespace \
 		--values $(VALUES_FILE) \
@@ -46,13 +57,23 @@ AAP_LICENSE_FILE ?= $(dir $(VALUES_FILE))license.zip
 .PHONY: install-secrets
 install-secrets: ## Create pre-install secrets (AAP license)
 	@[[ -f "$(AAP_LICENSE_FILE)" ]] || { echo "ERROR: AAP license not found at $(AAP_LICENSE_FILE)"; exit 1; }
+	@bash -c 'source scripts/lib.sh && wait_for_namespace_cleanup "$(INSTALLER_NAMESPACE)"'
 	oc create namespace $(INSTALLER_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+	# Server-side apply avoids last-applied-configuration (256KiB limit on large
+	# license.zip) while remaining idempotent when the license file changes.
 	oc create secret generic config-as-code-manifest-ig \
 		--from-file=license.zip="$(AAP_LICENSE_FILE)" \
-		-n $(INSTALLER_NAMESPACE) --dry-run=client -o yaml | oc apply -f -
+		-n $(INSTALLER_NAMESPACE) --dry-run=client -o yaml | oc apply --server-side -f -
+	oc label secret config-as-code-manifest-ig \
+		osac.openshift.io/project=osac-aap \
+		-n $(INSTALLER_NAMESPACE) --overwrite
+
+.PHONY: check-postgres
+check-postgres: ## Verify in-cluster PostgreSQL is reachable before installing OSAC
+	@bash -c 'source scripts/lib.sh && check_postgres_prerequisites "$(INSTALLER_NAMESPACE)" "$(VALUES_FILE)"'
 
 .PHONY: install-osac
-install-osac: helm-deps install-secrets ## Phase 3: Install OSAC
+install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 	$(eval DOMAIN := $(shell oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'))
 	@[[ -n "$(DOMAIN)" ]] || { echo "ERROR: Could not determine cluster domain. Is oc logged in?"; exit 1; }
 	helm upgrade --install osac charts/osac/ \

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -281,9 +281,13 @@ check_postgres_prerequisites() {
     if [[ ${bundled_status} -eq 2 ]]; then
         _postgres_prereq_error "Values file ${values_file} not found or unreadable."
     elif [[ ${bundled_status} -eq 0 ]]; then
-        echo "Checking in-cluster PostgreSQL prerequisites (bundledPostgres)..."
-        service="postgres"
-        target_namespace="${namespace}"
+        # bundledPostgres's Deployment/Service are templated inside charts/osac
+        # itself and created by the very `helm upgrade --install osac --wait`
+        # this check runs ahead of -- nothing to verify yet, and checking now
+        # would always fail (the Service doesn't exist until that install
+        # creates it). The chart's own --wait covers Postgres readiness.
+        echo "bundledPostgres enabled -- readiness will be verified by the chart's own install --wait."
+        return 0
     else
         echo "Checking in-cluster PostgreSQL prerequisites..."
         oc get secret fulfillment-db -n "${namespace}" &>/dev/null || \

--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -500,8 +500,59 @@ def create_secrets(config: RefreshConfig) -> None:
 
 
 def ensure_ca_bundle(config: RefreshConfig) -> None:
-    """Ensure the cluster CA bundle ConfigMap exists in the install namespace."""
-    run([str(SCRIPT_DIR / "ensure-ca-bundle.sh"), config.namespace])
+    """Ensure the cluster CA bundle Bundle exists and covers the install namespace.
+
+    The Bundle is cluster-scoped and shared across deployments, but
+    osac-prereqs' own ca-issuer.yaml template only ever sets a single static
+    namespace (.Values.osacNamespace) at chart-install time -- it doesn't
+    additively cover a snapshot refresh into a differently-named namespace.
+    Reimplements the old scripts/ensure-ca-bundle.sh (deleted by PR #404,
+    which left this function's only caller pointed at a nonexistent file).
+    """
+    namespace = config.namespace
+    if oc_exists("bundle/ca-bundle"):
+        bundle = oc_json("get", "bundle", "ca-bundle")
+        values = bundle["spec"]["target"]["namespaceSelector"]["matchExpressions"][0]["values"]
+        if namespace not in values:
+            print(f"  Adding {namespace} to ca-bundle namespace selector...")
+            patch = [{
+                "op": "add",
+                "path": "/spec/target/namespaceSelector/matchExpressions/0/values/-",
+                "value": namespace,
+            }]
+            oc("patch", "bundle", "ca-bundle", "--type=json", "-p", json.dumps(patch))
+    else:
+        print(f"  Creating ca-bundle Bundle targeting {namespace}...")
+        manifest = f"""apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: ca-bundle
+spec:
+  sources:
+  - secret:
+      name: "default-ca"
+      key: "ca.crt"
+  target:
+    configMap:
+      key: bundle.pem
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - {namespace}
+"""
+        result = subprocess.run(
+            ["oc", "apply", "-f", "-"],
+            input=manifest, text=True, capture_output=True, cwd=str(REPO_ROOT),
+        )
+        if result.returncode != 0:
+            print("ERROR: oc apply bundle/ca-bundle failed", file=sys.stderr)
+            if result.stderr:
+                print(f"  stderr: {result.stderr.rstrip()}", file=sys.stderr)
+            raise subprocess.CalledProcessError(
+                result.returncode, ["oc", "apply", "-f", "-"],
+                output=result.stdout, stderr=result.stderr)
 
 
 def wait_tls_certs(config: RefreshConfig) -> None:


### PR DESCRIPTION
## Summary

PR #404 replaced `scripts/setup.sh` with the three-phase Helm install (`make install-operators install-prereqs install-osac`) but silently dropped several of its defensive checks along the way. Found while investigating the recent scheduled-job failures traced to PR #404 ([OSAC-2468](https://redhat.atlassian.net/browse/OSAC-2468)).

- **Crash fix**: `refresh-after-snapshot.py`'s `ensure_ca_bundle()` still called `scripts/ensure-ca-bundle.sh`, which PR #404 deleted — every snapshot refresh crashes at that step. Reimplemented the additive namespace-selector-patch logic natively in Python.
- **Missing pre-flight validation**: `check_postgres_prerequisites` (`scripts/lib.sh`) lost its only caller, so a production install with a broken/missing external Postgres now sails past validation and fails much later, deep into a 40-minute `helm --wait`, with a far less actionable error. Restored via a new `make check-postgres` prerequisite of `install-osac`. Its `bundledPostgres` branch now skips instead of fail-fast, since that Postgres is chart-managed now and created by the very install this check used to run ahead of — checking before would always fail.
- **Missing `--server-side` apply**: `install-secrets` dropped `--server-side` for the AAP license secret, previously used specifically to avoid the 256KiB `last-applied-configuration` annotation limit for large `license.zip` files.
- **Missing namespace-cleanup wait**: no phase waited for a Terminating namespace to finish deleting before reinstalling into it (a fast reinstall-after-uninstall race). Restored via `wait_for_namespace_cleanup`, run ahead of `install-operators`/`install-prereqs`/`install-secrets`.

## Test plan

- [x] `bash -n scripts/lib.sh` / `python3 -m py_compile scripts/refresh-after-snapshot.py`
- [x] `make -n` dry-run expansion of all touched targets
- [x] `check_postgres_prerequisites` exercised directly for both `bundledPostgres: true` (returns 0, no cluster calls) and `false` (fails fast with the expected error, no cluster) values files
- [x] `wait_for_namespace_cleanup` exercised directly for every namespace now wired in — correct no-op when absent
- [x] `make helm-lint` / `helm template` for all three charts unaffected (pre-existing unrelated schema-validation failure confirmed present on `main` too, not introduced by this change)