### PR TITLE
fix: remove dead ensure_ca_bundle call from refresh-after-snapshot

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -499,11 +499,6 @@ def create_secrets(config: RefreshConfig) -> None:
     print("  Secrets created")
 
 
-def ensure_ca_bundle(config: RefreshConfig) -> None:
-    """Ensure the cluster CA bundle ConfigMap exists in the install namespace."""
-    run([str(SCRIPT_DIR / "ensure-ca-bundle.sh"), config.namespace])
-
-
 def wait_tls_certs(config: RefreshConfig) -> None:
     """Wait for all cert-manager Certificates in the namespace to become Ready."""
     print("  Waiting for TLS certificates...")
@@ -873,7 +868,6 @@ def main() -> None:
     run_parallel([
         ("Keycloak sync", lambda: keycloak_sync(config)),
         ("create secrets", lambda: create_secrets(config)),
-        ("ensure CA bundle", lambda: ensure_ca_bundle(config)),
         ("wait TLS certs", lambda: wait_tls_certs(config)),
         ("upgrade fulfillment-db", lambda: maybe_upgrade_fulfillment_db(config)),
     ])


### PR DESCRIPTION
## Summary
- `d604478` ([OSAC-1928](https://redhat.atlassian.net/browse/OSAC-1928)) deleted `scripts/ensure-ca-bundle.sh` when moving CA bundle management into the `osac-prereqs` Helm chart, but didn't remove the `ensure_ca_bundle` function and its `run_parallel` entry in `refresh-after-snapshot.py`
- This causes snapshot refresh to fail with `[Errno 2] No such file or directory: '.../ensure-ca-bundle.sh'`
- The `ca-bundle` Bundle is now managed by the `osac-prereqs` chart and persists in the snapshot — the refresh-time call is dead code

## Test plan
- [x] Verified `ensure-ca-bundle.sh` was deleted in `d604478` but `refresh-after-snapshot.py` still referenced it
- [x] Verified `ca-bundle` Bundle is created by `charts/osac-prereqs/templates/ca-issuer.yaml` and persists in the snapshot
- [ ] Run `make deploy-ocp-snapshot` end-to-end with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot refresh workflow reliability by waiting for TLS certificates to become ready before continuing with preparation tasks.
  * Preserved the existing Keycloak synchronization, secret creation, and database upgrade checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->