### PR TITLE
NO-ISSUE: skip CI for docs-only and metadata-only PRs

### DIFF
--- a/.github/workflows/check-image-tags.yaml
+++ b/.github/workflows/check-image-tags.yaml
@@ -2,6 +2,11 @@ name: Check image tags match submodules
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 concurrency:
   group: "check-image-tags-${{ github.head_ref || github.run_id }}"

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -4,6 +4,11 @@ name: E2E VMaaS Full Install
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   schedule:
     - cron: "0 */2 * * *"
   workflow_dispatch:

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -2,6 +2,11 @@ name: Helm Lint
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,11 @@ name: pre-commit
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 jobs:
   pre-commit:

--- a/.github/workflows/secret-scanning.yaml
+++ b/.github/workflows/secret-scanning.yaml
@@ -2,6 +2,11 @@ name: Secret scanning
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Add paths-ignore filters to all PR-triggered workflows so they don't run when only non-code files change (OWNERS, LICENSE, *.md, docs/**).

Affected workflows:
- `check-image-tags.yaml`
- `e2e-vmaas-full-install.yml`
- `helm-lint.yaml`
- `pre-commit.yaml`
- `secret-scanning.yaml`

Scheduled and workflow_dispatch triggers are unaffected.

Companion PR: https://github.com/osac-project/github-config/pull/131 (migrates required status checks to rulesets so skipped checks don't block merge)

Assisted-by: Claude Code <noreply@anthropic.com>