### PR TITLE
OSAC-2365: pass BMF aapInsecureSkipVerify through umbrella chart

### DIFF
--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1130,6 +1130,17 @@
               "default": "osac-profiles"
             }
           }
+        },
+        "env": {
+          "type": "object",
+          "description": "Environment variable overrides for the BMF operator pod",
+          "properties": {
+            "aapInsecureSkipVerify": {
+              "type": "string",
+              "description": "Skip TLS certificate verification for AAP API calls (set to 'true' for self-signed certs)",
+              "default": ""
+            }
+          }
         }
       }
     },

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -230,6 +230,8 @@ bmf:
     osClouds: "osac-os-clouds"
   configMaps:
     profiles: "osac-profiles"
+  env:
+    aapInsecureSkipVerify: "true"
 
 # --- Validation hooks ---
 validation:

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -144,7 +144,7 @@ bmf:
   enabled: false
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
-    tag: sha-0a06955
+    tag: sha-d28b3ca
     pullPolicy: Always
 
 # --- CI/dev only ---


### PR DESCRIPTION
## Problem

The osac-installer umbrella chart has no way to pass `OSAC_AAP_INSECURE_SKIP_VERIFY` to the BMF operator subchart, so clusters with self-signed certificates cannot reach AAP for bare metal provisioning.

## Fix

- **`charts/osac/values.yaml`** — Added `bmf.env.aapInsecureSkipVerify: "true"` to pass through to the BMF subchart
- **`charts/osac/values.schema.json`** — Added `env.aapInsecureSkipVerify` schema entry under the `bmf` properties

Defaults to `"true"` to match the osac-operator chart behavior.

## Dependencies

Depends on osac-project/bare-metal-fulfillment-operator#66 — the BMF subchart must include the `env.aapInsecureSkipVerify` value before this PR takes effect. After that PR merges, the `base/bare-metal-fulfillment-operator` submodule pointer should be bumped in this PR.

## Testing

- JSON schema validates correctly
- Pre-existing `helm lint` failures are unrelated (`service.externalHostname` minLength)

## Confidence

High — two-line values addition with matching schema entry.

## Risk Assessment

Low — adds a new passthrough value with no behavior change until the BMF subchart is updated.

Fixes https://redhat.atlassian.net/browse/OSAC-2365