### PR TITLE
NO-ISSUE: fix OOMKilled in wait-cert-manager hook

### DIFF
--- a/charts/osac-operators/templates/hooks/wait-cert-manager.yaml
+++ b/charts/osac-operators/templates/hooks/wait-cert-manager.yaml
@@ -103,10 +103,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 128Mi
+              memory: 256Mi
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 512Mi
           command:
             - /bin/bash
             - /scripts/wait-cert-manager.sh


### PR DESCRIPTION
## Summary
- Increase memory limits for the `wait-cert-manager` post-install hook job
- Requests: 128Mi → 256Mi, Limits: 256Mi → 512Mi
- The `oc` commands in the hook can exceed 256Mi, causing OOMKilled followed by BackoffLimitExceeded which fails `make install-operators`

## Test plan
- [x] Reproduced OOMKilled on OCP 4.22 cluster during `make install-operators`
- [x] Verified the hook completes successfully with the increased limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased memory allocation for the certificate manager readiness check to improve reliability during deployment.
  * CPU allocation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->