### PR TITLE
[WIP] OSAC-2529 OSAC-2791: Fix helm adoption missing label and Certificate scope

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -703,14 +703,43 @@ def maybe_upgrade_fulfillment_db(config: RefreshConfig) -> None:
 
 
 def adopt_resources_for_helm(config: RefreshConfig) -> None:
-    """Annotate existing namespace resources so Helm can manage them."""
+    """Label and annotate existing namespace resources so Helm can manage them."""
     print("  Adopting existing resources for Helm...")
+    # "all" doesn't cover "route" (an OpenShift-specific resource), so it's
+    # listed explicitly alongside it.
     result = oc("get", "all,configmap,secret,route", "-n", config.namespace,
                 "-o", "name", capture=True, check=False)
     resources = [r for r in result.stdout.strip().splitlines() if r]
 
+    # Queried separately, not folded into the call above: cert-manager's
+    # Certificate CRD isn't part of "all" either, but unlike the core types
+    # above it isn't guaranteed to exist in every cluster this script runs
+    # against. An isolated call means a missing/unavailable CRD here can't
+    # affect the core resource types' own results. Confirmed live: a
+    # pre-existing "postgres-server" Certificate (created by a different
+    # Helm release earlier in this same refresh) was previously skipped by
+    # this sweep entirely and broke the osac release's own helm upgrade with
+    # "invalid ownership metadata" once it tried to manage that same-named
+    # Certificate.
+    cert_result = oc("get", "certificate.cert-manager.io", "-n", config.namespace,
+                      "-o", "name", capture=True, check=False)
+    if cert_result.returncode == 0:
+        resources += [r for r in cert_result.stdout.strip().splitlines() if r]
+    else:
+        print(f"  WARN: could not list certificate.cert-manager.io resources: "
+              f"{cert_result.stderr or cert_result.stdout}", file=sys.stderr)
+
     def _adopt(resource: str) -> None:
-        """Add Helm release metadata annotations to a single resource."""
+        """Add Helm release ownership label + metadata annotations to a single resource."""
+        # Helm's adoption check requires BOTH this label AND the two
+        # meta.helm.sh/* annotations below -- annotations alone (the
+        # previous behavior here) still fail with "missing key
+        # app.kubernetes.io/managed-by: must be set to Helm", confirmed live.
+        r = oc("label", resource, "-n", config.namespace,
+               "app.kubernetes.io/managed-by=Helm",
+               "--overwrite", check=False, capture=True)
+        if r.returncode != 0:
+            print(f"  WARN: failed to label {resource}: {r.stderr or r.stdout}", file=sys.stderr)
         r = oc("annotate", resource, "-n", config.namespace,
                "meta.helm.sh/release-name=osac",
                f"meta.helm.sh/release-namespace={config.namespace}",


### PR DESCRIPTION
## Summary
Two real CaaS/Netris e2e dispatches (osac-test-infra) hit `helm upgrade osac` failures inside `refresh-after-snapshot.py`'s `adopt_resources_for_helm()`, both traced to this same function:

1. **[OSAC-2529](https://redhat.atlassian.net/browse/OSAC-2529)**: `helm upgrade` rejected pre-existing secrets (e.g. `vast-tenant-config-shared`) with "invalid ownership metadata; missing key app.kubernetes.io/managed-by". `_adopt()` only set the two `meta.helm.sh/*` annotations -- it never set the `app.kubernetes.io/managed-by=Helm` label Helm's ownership check also requires.
2. **[OSAC-2791](https://redhat.atlassian.net/browse/OSAC-2791)**: `helm upgrade osac` rejected a `postgres-server` Certificate as owned by the `fulfillment-db` release instead of `osac`. `adopt_resources_for_helm()`'s resource sweep (`oc get all,configmap,secret,route`) never covers `certificates.cert-manager.io` (a CRD, not part of `all`), so a Certificate created by `fulfillment-db`'s postgres chart earlier in the same refresh was never adopted into `osac` before its own upgrade tried to claim the identically-named resource.

## Fix
- Add the missing `oc label ... app.kubernetes.io/managed-by=Helm --overwrite` call alongside the existing annotate call in `_adopt()`.
- Add `certificate.cert-manager.io` to the resource types swept by `adopt_resources_for_helm()`.

## Test plan
- [x] `python3 -m py_compile scripts/refresh-after-snapshot.py`
- [x] pre-commit clean
- [ ] Real end-to-end CaaS/Netris dispatch (osac-test-infra) confirming `deploy-osac` no longer hits either ownership error, and osac-test-infra's `workaround-helm-adopt-vast-secret` Makefile workaround can subsequently be removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm resource adoption during snapshot refreshes.
  * Added support for adopting cert-manager certificate resources.
  * Ensured adopted resources receive the required Helm ownership label and annotations.
  * Expanded warning messages to identify ownership-label and adoption failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->