### PR TITLE
NO-ISSUE: Fix stale osac-test-infra pin breaking nightly E2E, auto-bump pins

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -1,4 +1,4 @@
-name: Bump submodules
+name: Bump submodules and pinned refs
 
 on:
   schedule:
@@ -89,8 +89,40 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         run: ./scripts/sync-image-tags.sh --fix
 
+      - name: Bump pinned osac-test-infra reusable-workflow SHA(s)
+        id: pins
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+        run: |
+          set -euo pipefail
+
+          LATEST=$(gh api repos/osac-project/osac-test-infra/commits?sha=main\&per_page=1 --jq '.[0].sha')
+          echo "Latest osac-test-infra main: ${LATEST}"
+
+          # osac-test-infra publishes no tags/releases, so Dependabot's github-actions
+          # ecosystem has nothing to track — these SHA pins (used for supply-chain
+          # hardening) need bumping here instead, or they silently go stale.
+          # Matches: osac-project/osac-test-infra/.github/workflows/<name>.yml@<40-char-sha>
+          FILES=$(grep -lRE 'osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@[0-9a-f]{40}' .github/workflows/ || true)
+
+          changed=false
+          summary=""
+          for f in ${FILES}; do
+            CURRENT=$(grep -oE "osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@[0-9a-f]{40}" "${f}" | head -1 | grep -oE '[0-9a-f]{40}')
+            if [[ -z "${CURRENT}" || "${CURRENT}" == "${LATEST}" ]]; then
+              continue
+            fi
+            sed -i -E "s#(osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@)[0-9a-f]{40}#\1${LATEST}#g" "${f}"
+            changed=true
+            summary="${summary}- **osac-test-infra pin** (\`${f}\`): ${CURRENT:0:7} → ${LATEST:0:7}\n"
+            echo "${f}: ${CURRENT:0:7} -> ${LATEST:0:7}"
+          done
+
+          echo "changed=${changed}" >> "$GITHUB_OUTPUT"
+          echo -e "${summary}" >> /tmp/bump-summary.txt
+
       - name: Create or update PR
-        if: steps.update.outputs.changed == 'true'
+        if: steps.update.outputs.changed == 'true' || steps.pins.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
         run: |
@@ -108,15 +140,17 @@ jobs:
             exit 0
           fi
 
-          git commit -m "bump submodules to latest with published images"
+          git commit -m "bump submodules and pinned osac-test-infra refs"
           git push origin "HEAD:${BRANCH}" --force
 
           BODY=$(cat <<BODY_EOF
-          ## Automated submodule bump
+          ## Automated submodule and pinned-ref bump
 
           $(cat /tmp/bump-summary.txt)
 
-          Only bumps to commits that have a published container image in GHCR.
+          Submodule bumps only move to commits that have a published container
+          image in GHCR. \`osac-test-infra\` pin bumps track its \`main\` branch
+          directly, since that repo publishes no tags for Dependabot to track.
           Runs every 3 hours via [bump-submodules workflow](../actions/workflows/bump-submodules.yaml).
           BODY_EOF
           )
@@ -127,7 +161,7 @@ jobs:
             echo "Updated existing PR #${EXISTING}"
           else
             gh pr create \
-              --title "bump submodules" \
+              --title "bump submodules and pinned refs" \
               --body "${BODY}" \
               --base main \
               --head "${BRANCH}"

--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -5,6 +5,8 @@ on:
     - cron: '17 */3 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   bump:
     runs-on: ubuntu-latest
@@ -99,23 +101,30 @@ jobs:
           LATEST=$(gh api repos/osac-project/osac-test-infra/commits?sha=main\&per_page=1 --jq '.[0].sha')
           echo "Latest osac-test-infra main: ${LATEST}"
 
+          if ! [[ "${LATEST}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "ERROR: could not resolve a valid osac-test-infra main SHA (got: '${LATEST}')" >&2
+            exit 1
+          fi
+
           # osac-test-infra publishes no tags/releases, so Dependabot's github-actions
           # ecosystem has nothing to track — these SHA pins (used for supply-chain
           # hardening) need bumping here instead, or they silently go stale.
           # Matches: osac-project/osac-test-infra/.github/workflows/<name>.yml@<40-char-sha>
-          FILES=$(grep -lRE 'osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@[0-9a-f]{40}' .github/workflows/ || true)
+          PIN_RE='osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@[0-9a-f]{40}'
+          FILES=$(grep -lRE "${PIN_RE}" .github/workflows/ || true)
 
           changed=false
           summary=""
           for f in ${FILES}; do
-            CURRENT=$(grep -oE "osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@[0-9a-f]{40}" "${f}" | head -1 | grep -oE '[0-9a-f]{40}')
-            if [[ -z "${CURRENT}" || "${CURRENT}" == "${LATEST}" ]]; then
-              continue
-            fi
-            sed -i -E "s#(osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@)[0-9a-f]{40}#\1${LATEST}#g" "${f}"
-            changed=true
-            summary="${summary}- **osac-test-infra pin** (\`${f}\`): ${CURRENT:0:7} → ${LATEST:0:7}\n"
-            echo "${f}: ${CURRENT:0:7} -> ${LATEST:0:7}"
+            # Check every distinct pin in the file, not just the first, so a
+            # file with multiple references gets fully updated in one pass.
+            while read -r CURRENT; do
+              [[ -z "${CURRENT}" || "${CURRENT}" == "${LATEST}" ]] && continue
+              sed -i -E "s#(osac-test-infra/\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml@)${CURRENT}#\1${LATEST}#g" "${f}"
+              changed=true
+              summary="${summary}- **osac-test-infra pin** (\`${f}\`): ${CURRENT:0:7} → ${LATEST:0:7}\n"
+              echo "${f}: ${CURRENT:0:7} -> ${LATEST:0:7}"
+            done < <(grep -oE "${PIN_RE}" "${f}" | grep -oE '[0-9a-f]{40}' | sort -u)
           done
 
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -170,7 +170,6 @@ jobs:
       installer-ref: ${{ needs.prepare.outputs.temp-branch }}
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: main
-    secrets: inherit
 
   # -------------------------------------------------------------------
   # Job 3: Publish charts (only if E2E passes)

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -163,7 +163,7 @@ jobs:
     needs: prepare
     permissions:
       contents: read
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@2f7c8d6335f057d55426846a6e5b5880c0ea77ab  # main
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@cf738faa86961fd8509697d2caa9613310a921a6  # main
     with:
       test-suite: vmaas
       installer-repo: ${{ github.repository }}


### PR DESCRIPTION
## Summary

The nightly build's E2E job (run [29470268672](https://github.com/osac-project/osac-installer/actions/runs/29470268672/job/87532001190)) failed on the "Install infrastructure operators" step with:

```
bash: scripts/setup.sh: No such file or directory
##[error]Process completed with exit code 127.
```

Root cause: `nightly-build.yaml` pins the `e2e-vmaas-full-install.yml` reusable workflow to an `osac-test-infra` commit (`2f7c8d6`, from Jul 1) that predates [`osac-test-infra#183`](https://github.com/osac-project/osac-test-infra/pull/183) ("[OSAC-1934](https://redhat.atlassian.net/browse/OSAC-1934): use make install instead of setup.sh"). That fix updated the reusable workflow to call `make install-operators`/`make install-prereqs`/`make install-osac` instead of `bash scripts/setup.sh`, matching the Helm/Makefile restructuring from #404 (which deleted `scripts/setup.sh` entirely). Because the pin was never bumped, the nightly job kept running the old, now-broken workflow version.

- `osac-installer`'s own PR/cron-triggered `e2e-vmaas-full-install.yml` caller uses `@main` unpinned, so it wasn't affected.
- `osac-test-infra` publishes no tags/releases, so Dependabot's `github-actions` ecosystem has nothing to resolve updates against for this pin — it can go stale indefinitely without anyone noticing.

## Changes

- Bump the pin in `nightly-build.yaml` to `osac-test-infra`'s current `main` tip.
- Extend `bump-submodules.yaml` (renamed to "Bump submodules and pinned refs") to also detect and bump any SHA-pinned `osac-test-infra` reusable-workflow reference to current `main`, on the same schedule/PR as the existing submodule bumps, so this can't silently drift again.

## Test plan

- [ ] Confirm `nightly-build.yaml` YAML parses and the `e2e-test` job resolves to the new SHA.
- [ ] Manually trigger `bump-submodules` (`workflow_dispatch`) once merged and confirm it no-ops cleanly when pins are already current.
- [ ] Watch the next nightly build run past the "Install infrastructure operators" step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated maintenance of submodules and pinned reusable-workflow references, including validation and automatic updating of tracked `osac-test-infra` `main` SHAs.
  * Updated nightly end-to-end testing to use the latest approved reusable-workflow revision.
  * Enhanced automated pull request creation with clearer titles, commit messages, and descriptions reflecting both submodule and pinned ref updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->