### PR TITLE
OSAC-1313: Add agentless_net.steps to NETWORK_STEPS_COLLECTION schema enum

### DIFF
--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -631,7 +631,8 @@
                         "osac.steps",
                         "netris.steps",
                         "ci.steps",
-                        "nico.steps"
+                        "nico.steps",
+                        "agentless_net.steps"
                       ]
                     },
                     "DNS_CLASS": {


### PR DESCRIPTION
The agentless_net.steps backend is a fully implemented network steps collection in osac-aap (with l2, l3, ipam, and steps collections), but was missing from the values schema enum. This causes helm upgrade to fail with a schema validation error when configuring the agentless networking backend.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring `agentless_net.steps` as a network steps collection.
  * This option is now available alongside the existing `osac.steps`, `netris.steps`, `ci.steps`, and `nico.steps` values when configuring cluster fulfillment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->