### PR TITLE
OSAC-2527: move configure-lvms to pre-install to fix Keycloak PVC race

### DIFF
--- a/charts/osac-prereqs/templates/hooks-configmap.yaml
+++ b/charts/osac-prereqs/templates/hooks-configmap.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osac-prereqs.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   {{- range $path, $_ := .Files.Glob "files/hooks/*.sh" }}
   {{ $path | base }}: |

--- a/charts/osac-prereqs/templates/hooks/configure-lvms.yaml
+++ b/charts/osac-prereqs/templates/hooks/configure-lvms.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "osac-prereqs.hookLabels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "10"
 ---
@@ -19,7 +19,7 @@ metadata:
   labels:
     {{- include "osac-prereqs.hookLabels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "10"
 rules:
@@ -43,7 +43,7 @@ metadata:
   labels:
     {{- include "osac-prereqs.hookLabels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "10"
 roleRef:
@@ -63,7 +63,7 @@ metadata:
   labels:
     {{- include "osac-prereqs.hookLabels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "10"
 spec:

--- a/charts/osac-prereqs/templates/lvms.yaml
+++ b/charts/osac-prereqs/templates/lvms.yaml
@@ -5,6 +5,9 @@ metadata:
   name: osac-prereqs-lvms-config
   labels:
     {{- include "osac-prereqs.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 data:
   config.yaml: |
     apiVersion: lvm.topolvm.io/v1alpha1


### PR DESCRIPTION
## Summary

PR #404's Helm rewrite introduced an ordering regression: Keycloak's PVC is a normal resource (created at install time), but the default StorageClass only exists after `configure-lvms` finishes as a post-install hook. This causes `FailedBinding` on the PVC, delaying Keycloak startup and — under CI contention — permanent Liquibase corruption.

**Fix:** Promote `configure-lvms` and its two ConfigMap dependencies from `post-install` to `pre-install` so the default StorageClass exists before any normal resource is created. CNV/MCE/MetalLB hooks remain `post-install` at weight 10 — their parallelism is preserved.

## Test plan

- [ ] `helm lint` and `helm template` pass (verified locally)
- [ ] E2E install on SNO cluster succeeds with Keycloak PVC binding immediately
- [ ] Verify CNV/MCE/MetalLB hooks still run in parallel during post-install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prerequisite and storage configuration resources to run before Helm installations and upgrades.
  * Added cleanup behavior so previous hook resources are removed before new executions.
  * Improved deployment ordering and consistency for prerequisite setup during installs and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->