### PR TITLE
OSAC-2356: Bumping the aap version to 2.6

### DIFF
--- a/charts/osac-operators/values.yaml
+++ b/charts/osac-operators/values.yaml
@@ -9,7 +9,7 @@ trustManager:
 
 aapOperator:
   enabled: true
-  channel: stable-2.5-cluster-scoped
+  channel: stable-2.6-cluster-scoped
 
 lvms:
   enabled: false

--- a/charts/osac-prereqs/values.yaml
+++ b/charts/osac-prereqs/values.yaml
@@ -20,7 +20,7 @@ keycloak:
 
 aapOperator:
   enabled: true
-  channel: stable-2.5-cluster-scoped
+  channel: stable-2.6-cluster-scoped
 
 lvms:
   enabled: false

--- a/prerequisites/aap-installation.yaml
+++ b/prerequisites/aap-installation.yaml
@@ -29,7 +29,7 @@ metadata:
   name: dev-ansible-automation-platform
   namespace: ansible-aap
 spec:
-  channel: stable-2.5-cluster-scoped
+  channel: stable-2.6-cluster-scoped
   installPlanApproval: Automatic
   name: ansible-automation-platform-operator
   source: redhat-operators


### PR DESCRIPTION
After failing with version 2.5, successfully
tested 2.6
Fixes https://issues.redhat.com/browse/OSAC-2356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Ansible Automation Platform Operator to the stable 2.6 cluster-scoped release channel.
  * Applied the channel update consistently across operator deployment and prerequisite configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->