### PR TITLE
OSAC-869: Support local execution of setup-caas-agents.sh

### DIFF
--- a/scripts/setup-caas-agents.sh
+++ b/scripts/setup-caas-agents.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Sets up CaaS agent infrastructure: InfraEnv + agent VM + label + approve.
-# Runs after setup.sh (MCE + AgentServiceConfig must be ready).
-# In CI, runs inside the installer container with SSH access to the bare metal host.
+# Runs after OSAC install (MCE + AgentServiceConfig must be ready).
+#
+# When SSH_CONFIG is set, privileged operations (DNS, VM creation) run on
+# a remote host via SSH. Otherwise they run locally (requires libvirt group
+# membership and either osac-hosts-entry or direct root access for DNS).
 
 set -o nounset
 set -o errexit
@@ -13,16 +16,33 @@ source "${SCRIPT_DIR}/lib.sh"
 INSTALLER_NAMESPACE=${INSTALLER_NAMESPACE:-"osac-e2e-ci"}
 AGENT_NAMESPACE=${AGENT_NAMESPACE:-"hardware-inventory"}
 AGENT_RESOURCE_CLASS=${AGENT_RESOURCE_CLASS:-"ci-worker"}
-AGENT_VM_NAME=${AGENT_VM_NAME:-"agent-worker-01"}
+AGENT_VM_NAME=${AGENT_VM_NAME:?"AGENT_VM_NAME must be set"}
 AGENT_VM_MEMORY=${AGENT_VM_MEMORY:-"16384"}
 AGENT_VM_VCPUS=${AGENT_VM_VCPUS:-"4"}
+
+[[ "${AGENT_VM_MEMORY}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: AGENT_VM_MEMORY must be a positive integer: ${AGENT_VM_MEMORY}" >&2; exit 1; }
+[[ "${AGENT_VM_VCPUS}" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: AGENT_VM_VCPUS must be a positive integer: ${AGENT_VM_VCPUS}" >&2; exit 1; }
 AGENT_VM_DISK_SIZE=${AGENT_VM_DISK_SIZE:-"120G"}
 AGENT_VM_STORAGE_DIR=${AGENT_VM_STORAGE_DIR:-"/data/osac-storage"}
 LIBVIRT_NETWORK=${LIBVIRT_NETWORK:?"LIBVIRT_NETWORK must be set"}
-SSH_CONFIG=${SSH_CONFIG:-"${SHARED_DIR}/ssh_config"}
+SSH_CONFIG=${SSH_CONFIG:-""}
+
+# Validate inputs that are interpolated into the generated hypervisor script
+validate_safe() {
+    local name="$1" value="$2"
+    if [[ ! "$value" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+        echo "ERROR: ${name} contains unsafe characters: ${value}" >&2
+        exit 1
+    fi
+}
+[[ "${AGENT_VM_NAME}" =~ ^[a-zA-Z0-9._-]+$ ]] || { echo "ERROR: AGENT_VM_NAME contains unsafe characters (path separators not allowed): ${AGENT_VM_NAME}" >&2; exit 1; }
+validate_safe "AGENT_VM_STORAGE_DIR" "${AGENT_VM_STORAGE_DIR}"
+validate_safe "LIBVIRT_NETWORK" "${LIBVIRT_NETWORK}"
+validate_safe "AGENT_VM_DISK_SIZE" "${AGENT_VM_DISK_SIZE}"
 
 echo "=== Setting up CaaS agent infrastructure ==="
 echo "Agent namespace: ${AGENT_NAMESPACE}"
+echo "Agent VM name: ${AGENT_VM_NAME}"
 echo "Resource class: ${AGENT_RESOURCE_CLASS}"
 echo ""
 
@@ -107,31 +127,46 @@ retry_until 300 5 '[[ -n "$(oc get infraenv ${AGENT_NAMESPACE} -n ${AGENT_NAMESP
 ISO_URL=$(oc get infraenv "${AGENT_NAMESPACE}" -n "${AGENT_NAMESPACE}" -o jsonpath='{.status.isoDownloadURL}')
 echo "ISO URL: ${ISO_URL}"
 
-echo "[4/6] Configuring host DNS for ISO download..."
-timeout -s 9 2m ssh -F "${SSH_CONFIG}" ci_machine bash -s \
-    "${NODE_IP}" \
-    "${CLUSTER_DOMAIN}" \
-    <<'DNSEOF'
-set -euo pipefail
-NODE_IP="$1"
-CLUSTER_DOMAIN="$2"
+# --- Steps 4-5 run on the hypervisor (locally or via SSH) ---
 
-# The host needs to resolve *.apps for the ISO download (curl runs on host).
-# VMs resolve via the libvirt network's dnsmasq wildcard (set by cluster-tool).
-SLUG=$(echo "${CLUSTER_DOMAIN}" | sed 's/[^a-zA-Z0-9]/-/g')
-echo "address=/.${CLUSTER_DOMAIN}/${NODE_IP}" > "/etc/dnsmasq.d/${SLUG}.conf"
-systemctl restart dnsmasq
-echo "  *.${CLUSTER_DOMAIN} -> ${NODE_IP}"
-DNSEOF
+ISO_FILE="${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}-discovery.iso"
 
-echo "[5/6] Creating agent VM..."
-timeout -s 9 10m ssh -F "${SSH_CONFIG}" ci_machine bash -s <<SSHEOF
+# Shell function containing all hypervisor-level commands.
+# Runs either directly (local) or piped through SSH (remote).
+generate_hypervisor_script() {
+    cat <<HVEOF
 set -euo pipefail
 
-dnf install -y virt-install
+command -v virt-install >/dev/null || { echo "ERROR: virt-install not found" >&2; exit 1; }
+command -v virsh >/dev/null || { echo "ERROR: virsh not found" >&2; exit 1; }
+command -v qemu-img >/dev/null || { echo "ERROR: qemu-img not found" >&2; exit 1; }
+[[ -d "${AGENT_VM_STORAGE_DIR}" ]] || { echo "ERROR: ${AGENT_VM_STORAGE_DIR} does not exist" >&2; exit 1; }
 
-mkdir -p ${AGENT_VM_STORAGE_DIR}
+# DNS: resolve the assisted-image-service hostname to the cluster node IP
+ISO_HOST=\$(python3 -c "from urllib.parse import urlparse; import sys; print(urlparse(sys.argv[1]).hostname)" '${ISO_URL}')
+if command -v osac-hosts-entry >/dev/null 2>&1; then
+    sudo /usr/local/sbin/osac-hosts-entry add "\${ISO_HOST}" "${NODE_IP}"
+    trap 'sudo /usr/local/sbin/osac-hosts-entry remove "\${ISO_HOST}" 2>/dev/null || true' EXIT
+    echo "  \${ISO_HOST} -> ${NODE_IP} (via osac-hosts-entry)"
+else
+    SLUG=\$(echo "${CLUSTER_DOMAIN}" | sed 's/[^a-zA-Z0-9]/-/g')
+    CONF_ENTRY="address=/.${CLUSTER_DOMAIN}/${NODE_IP}"
+    NM_DNSMASQ_PID="/run/NetworkManager/dnsmasq.pid"
+    if [ -f "\${NM_DNSMASQ_PID}" ] && kill -0 "\$(cat "\${NM_DNSMASQ_PID}")" 2>/dev/null; then
+        CONF_FILE="/etc/NetworkManager/dnsmasq.d/\${SLUG}.conf"
+        echo "\${CONF_ENTRY}" > "\${CONF_FILE}"
+        systemctl reload NetworkManager
+        trap 'rm -f "\${CONF_FILE}"; systemctl reload NetworkManager 2>/dev/null || true' EXIT
+    else
+        CONF_FILE="/etc/dnsmasq.d/\${SLUG}.conf"
+        echo "\${CONF_ENTRY}" > "\${CONF_FILE}"
+        systemctl restart dnsmasq
+        trap 'rm -f "\${CONF_FILE}"; systemctl restart dnsmasq 2>/dev/null || true' EXIT
+    fi
+    echo "  *.${CLUSTER_DOMAIN} -> ${NODE_IP} (via dnsmasq)"
+fi
 
+# Wait for assisted-image-service
 echo "Waiting for assisted-image-service to be ready..."
 for attempt in \$(seq 1 30); do
     HTTP_CODE=\$(curl -k -s -o /dev/null -w "%{http_code}" -L '${ISO_URL}') || true
@@ -141,28 +176,41 @@ for attempt in \$(seq 1 30); do
 done
 [[ "\${HTTP_CODE}" != "200" ]] && { echo "ERROR: assisted-image-service not ready after 30 attempts (last HTTP \${HTTP_CODE})"; exit 1; }
 
+# Download discovery ISO
 echo "Downloading discovery ISO..."
-curl -k -L --fail-with-body -o ${AGENT_VM_STORAGE_DIR}/discovery.iso '${ISO_URL}'
+curl -k -L --fail-with-body -o '${ISO_FILE}' '${ISO_URL}'
 
-virsh destroy ${AGENT_VM_NAME} 2>/dev/null || true
-virsh undefine ${AGENT_VM_NAME} 2>/dev/null || true
-rm -f ${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2
+# Create agent VM
+virsh destroy '${AGENT_VM_NAME}' 2>/dev/null || true
+virsh undefine '${AGENT_VM_NAME}' 2>/dev/null || true
+rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
 
-qemu-img create -f qcow2 ${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2 ${AGENT_VM_DISK_SIZE}
+qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' '${AGENT_VM_DISK_SIZE}'
 
 virt-install \
-  --name ${AGENT_VM_NAME} \
-  --memory ${AGENT_VM_MEMORY} \
-  --vcpus ${AGENT_VM_VCPUS} \
-  --disk ${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2 \
-  --cdrom ${AGENT_VM_STORAGE_DIR}/discovery.iso \
-  --network network=${LIBVIRT_NETWORK} \
+  --name '${AGENT_VM_NAME}' \
+  --memory '${AGENT_VM_MEMORY}' \
+  --vcpus '${AGENT_VM_VCPUS}' \
+  --disk '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' \
+  --disk '${ISO_FILE},device=cdrom,readonly=on' \
+  --network network='${LIBVIRT_NETWORK}' \
   --os-variant rhel9.0 \
   --boot hd,cdrom \
+  --events on_poweroff=restart \
   --noautoconsole
 
 echo "Agent VM created and booting"
-SSHEOF
+HVEOF
+}
+
+echo "[4/6] Configuring host DNS for ISO download..."
+echo "[5/6] Creating agent VM..."
+
+if [[ -n "${SSH_CONFIG}" ]]; then
+    generate_hypervisor_script | timeout -s 9 10m ssh -F "${SSH_CONFIG}" ci_machine bash -s
+else
+    generate_hypervisor_script | bash -s
+fi
 
 echo "[6/6] Waiting for agent to register..."
 retry_until 600 10 '[[ $(oc get agent -n ${AGENT_NAMESPACE} --no-headers 2>/dev/null | wc -l) -gt 0 ]]' || {


### PR DESCRIPTION
## Summary
Rework `setup-caas-agents.sh` to support running locally on CI hosts
without SSH, while preserving the existing remote SSH path.

All hypervisor-level operations (DNS, ISO download, VM creation) are
consolidated into `generate_hypervisor_script()`. The only difference
between local and remote execution is how the script is invoked:
`bash -s` locally vs `ssh ci_machine bash -s` remotely.

### Changes
- Extract hypervisor operations into `generate_hypervisor_script()` — eliminates duplication between local/SSH paths
- `SSH_CONFIG` is the sole branch point: set → SSH, unset → local
- DNS auto-detects method inside the generated script: `osac-hosts-entry` when available, dnsmasq fallback otherwise
- Register `osac-hosts-entry` cleanup trap on EXIT
- Fix concurrency: per-VM ISO filename (`${AGENT_VM_NAME}-discovery.iso`), require `AGENT_VM_NAME`
- Use `--disk device=cdrom` instead of `--cdrom` (preserves `--boot hd,cdrom` order)
- Add `--events on_poweroff=restart` (VM restarts after assisted-installer poweroff)
- Fail-fast checks for `virt-install`, `virsh`, `qemu-img`, and storage dir inside the generated script
- Strict numeric validation for `AGENT_VM_MEMORY` and `AGENT_VM_VCPUS`
- `AGENT_VM_NAME` rejects path separators

## Test plan
- [ ] Verify local execution on CI host (no `SSH_CONFIG`, `osac-hosts-entry` available)
- [ ] Verify remote execution still works (`SSH_CONFIG` set)
- [ ] Verify concurrent runs with different `AGENT_VM_NAME`s don't collide
- [ ] Verify VM boots from installed disk after poweroff (not discovery ISO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified agent setup behavior: the hypervisor workflow now runs locally when no SSH configuration is provided, or via SSH when it is.
  * Strengthened configuration validation to reject unsafe characters and require key environment settings.
  * Streamlined the hypervisor workflow into a single self-contained process, including prerequisite checks, DNS wildcard setup, assisted-image-service readiness polling, disk recreation, and VM provisioning.
  * Ensured DNS wildcard mappings created for the workflow are cleaned up after remote execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->