### PR TITLE
NO-ISSUE: Increase AgentServiceConfig imageStorage from 50Gi to 100Gi

### DIFF
--- a/charts/osac-prereqs/templates/mce.yaml
+++ b/charts/osac-prereqs/templates/mce.yaml
@@ -29,5 +29,5 @@ data:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 100Gi
 {{- end }}


### PR DESCRIPTION
## Summary
- `assisted-image-service`'s default `OS_IMAGES` ConfigMap entry lists RHCOS ISOs for every OCP version/architecture MCE knows about (47 entries currently). At ~1.2-1.5Gi per ISO, the full default set needs 60Gi+ and can never fully fit in the chart's current 50Gi `imageStorage` request.
- Confirmed directly on a live cluster: `assisted-image-service-0` crash-looped with `no space left on device` partway through downloading the default image set, blocking any consumer that installs MCE via this chart without pre-filtering `OS_IMAGES`.
- Bumps `imageStorage` from 50Gi to 100Gi in `charts/osac-prereqs/templates/mce.yaml` for headroom. This is a defense-in-depth improvement, not a full fix on its own — the unfiltered default set still exceeds 100Gi, so consumers with tight storage budgets (e.g. `osac-test-infra`'s CaaS/Netris e2e flow) should still filter `OS_IMAGES` down to the version(s)/architecture they actually need after MCE install.

## Test plan
- [x] `helm lint charts/osac-prereqs/` passes
- [x] Root cause confirmed live: `assisted-image-service` PVC was at 48G/50Gi (95%) used, pod logs showed a fatal crash on `no space left on device` while downloading one of the 47 default RHCOS ISOs