### PR TITLE
NO-ISSUE: Wait for AAP readiness before helm upgrade, not after

### DIFF
--- a/scripts/refresh-after-snapshot.py
+++ b/scripts/refresh-after-snapshot.py
@@ -798,15 +798,28 @@ def main() -> None:
     # Phase 3: Deploy + health check
     phase_start = time.time()
     print("[Phase 3] Deploying + waiting...")
+    # wait_aap_ready() must run BEFORE upgrade_osac(): the osac chart's
+    # publish-templates post-upgrade hook (charts/osac/templates/hooks/
+    # publish-templates.yaml) launches an AAP job template as part of
+    # `helm upgrade` itself (Helm blocks on hook completion) -- calling
+    # wait_aap_ready() only *after* upgrade_osac() returns is too late to
+    # help that hook, since by then it has already run (and can already
+    # have failed). Confirmed via a real dispatch on a fresh EC2 instance:
+    # AAP's operators (scaled up in Phase 1, but still needing a full,
+    # from-scratch image pull + CSV install on a box that's never run them
+    # before -- unlike a long-lived, pre-warmed debug box) were still mid-
+    # install (automation-controller-operator not yet available) when the
+    # hook tried to launch a job against it, so the job errored instantly
+    # (empty stdout) on every one of its 3 attempts until the hook's own
+    # backoffLimit was exhausted, failing `helm upgrade` outright.
+    wait_aap_ready(config)
     upgrade_osac(config)
-    run_parallel([
-        ("wait fulfillment", lambda: wait_fulfillment(config)),
-        ("wait AAP", lambda: wait_aap_ready(config)),
-    ])
+    wait_fulfillment(config)
     # Console-proxy hard-exits if its initial JWKS fetch returns non-200.
     # It CrashLoopBackOff's until grpc-server is serving. Normally recovers
-    # within ~70s (before the AAP wait above completes), so this adds ~0s.
-    # The 360s timeout covers worst-case backoff (300s cap) if timing is bad.
+    # within ~70s (before the fulfillment wait above completes), so this
+    # adds ~0s. The 360s timeout covers worst-case backoff (300s cap) if
+    # timing is bad.
     if oc_exists("deploy/fulfillment-console-proxy", config.namespace):
         print("  Waiting for console-proxy (depends on grpc-server)...")
         oc("rollout", "status", "deploy/fulfillment-console-proxy",


### PR DESCRIPTION
## Summary

The osac chart's `publish-templates` post-upgrade hook (`charts/osac/templates/hooks/publish-templates.yaml`) launches an AAP job template as part of `helm upgrade` itself — Helm blocks on hook completion, so the hook runs synchronously inside `upgrade_osac()`. `wait_aap_ready()` was being called only *after* `upgrade_osac()` returned, which is too late to help that hook: by then it has already run, and can already have failed.

## Root cause (found via a real CI dispatch, not guessed)

Confirmed via a real dispatch on a fresh EC2 instance: AAP's operators (scaled up in Phase 1, but still needing a full, from-scratch image pull + CSV install on a box that's never run them before — unlike a long-lived, pre-warmed debug box) were still mid-install (`automation-controller-operator` not yet available) when the hook tried to launch a job against it. The job errored instantly (empty stdout) on every one of its 3 attempts until the hook's own `backoffLimit` was exceeded, failing `helm upgrade` outright:

```
Error: UPGRADE FAILED: post-upgrade hooks failed: 1 error occurred:
    * job osac-publish-templates failed: BackoffLimitExceeded
```

Pod logs for the AAP job itself were completely empty — consistent with the job erroring before any ansible content could run, and the `aap-status` diagnostic snapshot captured at failure time showed the whole AAP operator stack still installing (`InstallWaiting: waiting for deployment automation-controller-operator-controller-manager to become ready`).

## Fix

Moved `wait_aap_ready(config)` to run before `upgrade_osac(config)` instead of after. Kept `wait_fulfillment(config)` where it was (sequential, after the upgrade) since `publish-templates.yaml`'s own init container already waits on fulfillment health independently — only the AAP-readiness gap needed fixing.

## Test plan

- [x] `python3 -m py_compile` and `ruff check` pass.
- [ ] Real dispatch validation pending — this fix targets a race that only reliably reproduces on a genuinely fresh EC2 instance where AAP's operator images have never been pulled before (a long-lived debug box doesn't hit it, since AAP is already warm there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Phase 3 deployment sequencing to verify AAP readiness before upgrading OSAC.
  * Updated post-upgrade checks to wait for fulfillment readiness in the correct order.
  * Reduced the risk of deployment readiness checks running prematurely or out of sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->