### PR TITLE
OSAC-2120: document cluster template publish timing and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ helm upgrade osac charts/osac/ \
   --wait
 ```
 
+The post-upgrade hook re-publishes cluster templates automatically. This is
+idempotent - existing templates are updated via PATCH while new templates
+are created via POST.
+
 #### Uninstalling
 
 ```bash
@@ -236,7 +240,9 @@ make sync-charts         # Update submodules + rebuild dependencies
 $ watch oc get -n <project-name> pods
 ```
 
-Once the `osac-aap-bootstrap` job completes, OSAC is ready for use.
+Once the `osac-aap-bootstrap` job completes, OSAC is ready for use. Cluster
+templates are published automatically by a post-install hook - Helm will not
+report success until templates are available in the catalog.
 
 ## OSAC CLI: Setup & Usage
 
@@ -368,6 +374,12 @@ The script removes resources in reverse order:
 1. **cert-manager not ready**: Ensure cert-manager operator is installed and running
 2. **Certificate issues**: Check cert-manager logs and certificate status
 3. **ImagePullBackOff errors**: Verify registry credentials and image string
+4. **Cluster templates not available**: Cluster templates are published automatically
+   by a Helm post-install hook (`osac-publish-templates`). If `osac get clustertemplates`
+   returns empty, check the hook pod logs:
+   `oc logs job/osac-publish-templates -n <project-name>`.
+   See [docs/helm-deployment-guide.md](docs/helm-deployment-guide.md#template-publish-hook-failing)
+   for details.
 
 ### Debug Commands
 

--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ make sync-charts         # Update submodules + rebuild dependencies
 $ watch oc get -n <project-name> pods
 ```
 
-Once the `osac-aap-bootstrap` job completes, OSAC is ready for use. Cluster
-templates are published automatically by a post-install hook - Helm will not
-report success until templates are available in the catalog.
+Once `helm install` completes successfully (including all post-install hooks),
+OSAC is ready for use. Cluster templates are published automatically by a
+post-install hook that runs after the AAP bootstrap job.
 
 ## OSAC CLI: Setup & Usage
 
@@ -374,9 +374,10 @@ The script removes resources in reverse order:
 1. **cert-manager not ready**: Ensure cert-manager operator is installed and running
 2. **Certificate issues**: Check cert-manager logs and certificate status
 3. **ImagePullBackOff errors**: Verify registry credentials and image string
-4. **Cluster templates not available**: Cluster templates are published automatically
-   by a Helm post-install hook (`osac-publish-templates`). If `osac get clustertemplates`
-   returns empty, check the hook pod logs:
+4. **Cluster templates missing or incomplete**: Cluster templates are published
+   automatically by a Helm post-install hook (`osac-publish-templates`). If
+   `osac get clustertemplates` returns missing or unexpected results, check the
+   hook pod logs:
    `oc logs job/osac-publish-templates -n <project-name>`.
    See [docs/helm-deployment-guide.md](docs/helm-deployment-guide.md#template-publish-hook-failing)
    for details.

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -54,8 +54,35 @@ and template resources.
 ### Phase 3: `make install-osac`
 
 Installs OSAC: operator, fulfillment-service, AAP bootstrap, UI. All
-prerequisites are ready — certificates issued, secrets created, CRDs
+prerequisites are ready - certificates issued, secrets created, CRDs
 registered.
+
+### Post-Install Hooks
+
+After Phase 3, Helm runs post-install (and post-upgrade) hooks that
+finalize the deployment:
+
+| Hook | Weight | What it does |
+|------|--------|-------------|
+| `osac-publish-templates` | 20 | Publishes cluster templates to the fulfillment service catalog |
+
+**Cluster template publishing** (`osac-publish-templates`): An init
+container waits for the fulfillment REST gateway to be healthy (up to
+600s), then launches the `osac-publish-templates` AAP job template and
+polls until it completes. Helm blocks until this hook succeeds, so
+`helm install` and `helm upgrade` will not report success until cluster
+templates are available. The underlying Ansible role uses a PATCH/POST
+pattern, making re-publish on upgrade safe and idempotent.
+
+This hook is enabled by default (`aap.instanceGroups.publishTemplates.enabled: true`).
+To disable it (e.g., in environments without CaaS):
+
+```yaml
+aap:
+  instanceGroups:
+    publishTemplates:
+      enabled: false
+```
 
 ## Values Files
 
@@ -137,6 +164,37 @@ The AAP bootstrap hook can take 10-40 minutes. Monitor with:
 ```bash
 oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
 ```
+
+### Template Publish Hook Failing
+
+The `osac-publish-templates` post-install hook must complete for Helm to
+report success. If it fails, cluster templates will not be available and
+`osac get clustertemplates` will return an empty list.
+
+**Check hook pod status and logs:**
+
+```bash
+oc get pods -n ${NAMESPACE} | grep publish-templates
+oc logs job/osac-publish-templates -n ${NAMESPACE} -c wait-for-fulfillment  # init container
+oc logs job/osac-publish-templates -n ${NAMESPACE} -c publish-templates     # main container
+```
+
+**Common causes:**
+
+- **Fulfillment service not ready** - The init container polls
+  `https://fulfillment-rest-gateway:8000/healthz` for up to 600s. If it
+  times out, check that the fulfillment service pods are running and the
+  `fulfillment-rest-gateway` Service exists.
+- **AAP token missing** - The main container reads the `osac-aap-api-token`
+  Secret. Verify it exists: `oc get secret osac-aap-api-token -n ${NAMESPACE}`.
+- **AAP job template not found** - The `osac-publish-templates` job template
+  must exist in AAP. Verify via AAP UI or API after the bootstrap job
+  completes.
+- **AAP job failure** - The hook logs include the AAP job stdout on failure.
+  Check AAP for the job run details.
+
+The hook has `backoffLimit: 3` and `activeDeadlineSeconds: 1300`. After
+3 retries or 1300s, the Job fails and Helm reports the install as failed.
 
 ### Hook Job Failed
 

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -168,8 +168,8 @@ oc logs -f job/osac-aap-bootstrap -n ${NAMESPACE}
 ### Template Publish Hook Failing
 
 The `osac-publish-templates` post-install hook must complete for Helm to
-report success. If it fails, cluster templates will not be available and
-`osac get clustertemplates` will return an empty list.
+report success. If it fails, cluster templates may be missing or incomplete
+(on upgrade, previously published templates may still exist).
 
 **Check hook pod status and logs:**
 
@@ -185,8 +185,10 @@ oc logs job/osac-publish-templates -n ${NAMESPACE} -c publish-templates     # ma
   `https://fulfillment-rest-gateway:8000/healthz` for up to 600s. If it
   times out, check that the fulfillment service pods are running and the
   `fulfillment-rest-gateway` Service exists.
-- **AAP token missing** - The main container reads the `osac-aap-api-token`
-  Secret. Verify it exists: `oc get secret osac-aap-api-token -n ${NAMESPACE}`.
+- **AAP token missing or empty** - The main container reads the `osac-aap-api-token`
+  Secret and fails if the token is absent or empty. Verify the secret exists
+  and contains a valid token:
+  `oc get secret osac-aap-api-token -n ${NAMESPACE} -o jsonpath='{.data.token}' | base64 -d`.
 - **AAP job template not found** - The `osac-publish-templates` job template
   must exist in AAP. Verify via AAP UI or API after the bootstrap job
   completes.


### PR DESCRIPTION
## Summary

- Document the `osac-publish-templates` Helm post-install/post-upgrade hook behavior in the deployment guide
- Add troubleshooting section for template publish failures (common causes, debug commands)
- Note upgrade idempotency (PATCH/POST pattern) in the README upgrading section
- Add cluster template availability entry to README common issues

Closes https://redhat.atlassian.net/browse/OSAC-2120 (documentation gap - functional fix landed in PR #404)

## Test plan

- [x] Verify markdown renders correctly on GitHub
- [x] Confirm anchor link from README to helm-deployment-guide troubleshooting section works

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that cluster templates are automatically published after installation and upgrades, with updates handled idempotently.
  * Documented that Helm readiness depends on templates becoming available in the catalog.
  * Added guidance for disabling the template publishing hook when needed.
  * Expanded troubleshooting instructions with commands for checking hook jobs and logs, common failure causes, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->