### PR TITLE
OSAC-2920: Add BMaaS E2E caller workflow

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -1,0 +1,46 @@
+---
+name: E2E BMaaS Full Install
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
+  schedule:
+    - cron: "0 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (bmaas, or empty for all)"
+        required: false
+        default: "bmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e-bmaas-full-install:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'bmaas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+      notify-on-failure: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## [OSAC-2920](https://redhat.atlassian.net/browse/OSAC-2920): Add BMaaS E2E caller workflow

**Jira:** https://redhat.atlassian.net/browse/OSAC-2920

### Summary

Adds a cross-repo caller workflow that invokes the reusable BMaaS E2E workflow in
osac-test-infra. On PRs, tests the installer from the PR branch by passing
`installer-repo` and `installer-ref` to the reusable workflow, then runs the BMaaS
E2E test suite against a live cluster deployed with the PR's installer changes.

### Changes

- Add `.github/workflows/e2e-bmaas-full-install.yml` mirroring the existing VMaaS E2E caller
- Triggers: `pull_request`, `schedule` (every 2 hours), `workflow_dispatch`
- Uses `installer-repo`/`installer-ref` inputs (not component image overrides)
- Slack failure notifications on scheduled runs
- Fork PR authorization support

### Related PRs

- osac-project/fulfillment-service#940
- osac-project/osac-operator#370
- osac-project/osac-aap#433
- osac-project/bare-metal-fulfillment-operator#71

### Acceptance Criteria

- [x] Repos that can affect bare metal provisioning should at least optionally be able to run the BMaaS E2E tests