### PR TITLE
NO-ISSUE: Bump stale osac-aap submodule to pick up capi-provider-role fix

### DIFF
--- a/values/bmaas-ci/values.yaml
+++ b/values/bmaas-ci/values.yaml
@@ -129,15 +129,15 @@ aap:
       name: "osac-aap"
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:sha-ebd60f5
+    image: ghcr.io/osac-project/osac-aap:sha-31666f2
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"
     secret: "config-as-code-ig"
-    eeImage: "ghcr.io/osac-project/osac-aap:sha-ebd60f5"
+    eeImage: "ghcr.io/osac-project/osac-aap:sha-31666f2"
     projectGitUri: "https://github.com/osac-project/osac-aap"
-    projectGitBranch: "ebd60f5a98c2a22f1fed8c06a56017e3c6c89a7b"
+    projectGitBranch: "31666f2d09efc987d4ccd01b2c53ae4aa069bc23"
 
 # --- Validation ---
 validation:

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -116,15 +116,15 @@ aap:
       name: "osac-aap"
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:sha-ebd60f5
+    image: ghcr.io/osac-project/osac-aap:sha-31666f2
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"
     secret: "config-as-code-ig"
-    eeImage: "ghcr.io/osac-project/osac-aap:sha-ebd60f5"
+    eeImage: "ghcr.io/osac-project/osac-aap:sha-31666f2"
     projectGitUri: "https://github.com/osac-project/osac-aap"
-    projectGitBranch: "ebd60f5a98c2a22f1fed8c06a56017e3c6c89a7b"
+    projectGitBranch: "31666f2d09efc987d4ccd01b2c53ae4aa069bc23"
   instanceGroups:
     clusterFulfillment:
       enabled: true

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -131,15 +131,15 @@ aap:
       name: "osac-aap"
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:sha-ebd60f5
+    image: ghcr.io/osac-project/osac-aap:sha-31666f2
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"
     secret: "config-as-code-ig"
-    eeImage: "ghcr.io/osac-project/osac-aap:sha-ebd60f5"
+    eeImage: "ghcr.io/osac-project/osac-aap:sha-31666f2"
     projectGitUri: "https://github.com/osac-project/osac-aap"
-    projectGitBranch: "ebd60f5a98c2a22f1fed8c06a56017e3c6c89a7b"
+    projectGitBranch: "31666f2d09efc987d4ccd01b2c53ae4aa069bc23"
 
 # --- Validation ---
 validation:


### PR DESCRIPTION
## Summary
- `base/osac-aap` was pinned to `ebd60f5a` (PR #416), 180 commits behind `osac-aap` main and missing `f54004a8` ("Create capi-provider-role RBAC for Agent-platform HostedClusters", the fix from osac-aap PR #426).
- `scripts/sync-image-tags.sh` correctly syncs each CI values file's `configAsCode.projectGitBranch` to the exact submodule commit SHA (by design, for reproducibility) — but that means every AAP Project built from `bmaas-ci`/`caas-ci`/`vmaas-ci` values had its Controller `scm_branch` pinned to that fixed, stale SHA instead of a branch name. An SCM "update"/resync against a Project like that just re-fetches the identical commit forever — it can never pick up new commits.
- Confirmed live on a real CaaS/Netris e2e CI run: the AAP Project's `scm_revision` never advanced past `ebd60f5a`, so the `capi-provider-role` Role was never created and HostedCluster creation failed. Manually patching that Project's `scm_branch` to `main` and re-syncing picked up the fix immediately (`scm_revision` moved to `31666f2d`, current `osac-aap` main).

## Changes
- Bump `base/osac-aap` submodule to `osac-aap` main (`31666f2d`).
- Run `./scripts/sync-image-tags.sh --fix`, which updated `values/{bmaas-ci,caas-ci,vmaas-ci}/values.yaml`: `aap.bootstrap.image`, `aap.configAsCode.eeImage`, and `aap.configAsCode.projectGitBranch`.

## Verification
- Confirmed `ghcr.io/osac-project/osac-aap:sha-31666f2` already exists (built by osac-aap's own CI for that commit) via `skopeo inspect`.
- Diffed the 180 intervening `osac-aap` commits against playbook/job-template surface area (`playbook_osac_*.yml`, `config_as_code` job template registrations): all additions are new, additive job templates (ExternalIP/NAT gateway feature work); no renames or removals of anything the CaaS/VMaaS/BMaaS CI paths depend on (hosted-cluster, subnet, virtual-network, storage playbooks all present and byte-for-byte name-compatible).

## Test plan
- [ ] Dispatch `e2e-caas-netris-caller.yml` (osac-test-infra) against an environment built from these values and confirm the AAP Project's `scm_branch` is no longer pinned to a raw SHA, and that the `capi-provider-role` Role is created during HostedCluster provisioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - Updated the automation platform build across CI environments.
  - Aligned deployment configuration and supporting components to the latest validated revision.
  - Improved consistency of platform bootstrapping and configuration-as-code settings across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->