### PR TITLE
OSAC-869: Add osImages support to AgentServiceConfig chart

### DIFF
--- a/charts/osac-prereqs/templates/mce.yaml
+++ b/charts/osac-prereqs/templates/mce.yaml
@@ -30,4 +30,8 @@ data:
         resources:
           requests:
             storage: 50Gi
+{{- if .Values.mce.osImages }}
+      osImages:
+{{ toYaml .Values.mce.osImages | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/osac-prereqs/values.yaml
+++ b/charts/osac-prereqs/values.yaml
@@ -37,3 +37,4 @@ cnv:
 mce:
   enabled: false
   channel: "stable-2.17"
+  osImages: []

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -17,6 +17,11 @@ cnv:
   enabled: false
 mce:
   enabled: true
+  osImages:
+    - openshiftVersion: "4.22"
+      version: "9.8.20260428-0"
+      url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.22/4.22.0/rhcos-4.22.0-x86_64-live-iso.x86_64.iso"
+      cpuArchitecture: "x86_64"
 
 # OSAC CaaS (Cluster-as-a-Service) CI Environment Values
 # CaaS CI values


### PR DESCRIPTION
Without osImages, MCE downloads RHCOS ISOs for every supported architecture and version, filling the 50Gi PVC and crashing the assisted-image-service. Add a conditional osImages field to the AgentServiceConfig template and define x86_64 4.22 in caas-ci values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OS image configuration support for generated agent service settings.
  * Added a preconfigured OpenShift 4.22 x86_64 live ISO image entry for CI environments.
  * OS image settings can now include the OpenShift version, image version, download URL, and CPU architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->