### PR TITLE
OSAC-869: Use qemu:///system connection for virsh and virt-install

### DIFF
--- a/scripts/setup-caas-agents.sh
+++ b/scripts/setup-caas-agents.sh
@@ -181,13 +181,13 @@ echo "Downloading discovery ISO..."
 curl -k -L --fail-with-body -o '${ISO_FILE}' '${ISO_URL}'
 
 # Create agent VM
-virsh destroy '${AGENT_VM_NAME}' 2>/dev/null || true
-virsh undefine '${AGENT_VM_NAME}' 2>/dev/null || true
+virsh --connect qemu:///system destroy '${AGENT_VM_NAME}' 2>/dev/null || true
+virsh --connect qemu:///system undefine '${AGENT_VM_NAME}' 2>/dev/null || true
 rm -f '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2'
 
 qemu-img create -f qcow2 '${AGENT_VM_STORAGE_DIR}/${AGENT_VM_NAME}.qcow2' '${AGENT_VM_DISK_SIZE}'
 
-virt-install \
+virt-install --connect qemu:///system \
   --name '${AGENT_VM_NAME}' \
   --memory '${AGENT_VM_MEMORY}' \
   --vcpus '${AGENT_VM_VCPUS}' \


### PR DESCRIPTION
## Summary
Non-root users (e.g. `github-runner` on CI) default to `qemu:///session` which
cannot see networks created by root via cluster-tool. Add `--connect qemu:///system`
to `virsh` and `virt-install` commands in the generated hypervisor script so the
agent VM can attach to the cluster network.

## Test plan
- [ ] Verify agent VM setup works as non-root user with libvirt group membership
- [ ] Verify agent VM setup still works as root (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine setup reliability by consistently using the system libvirt connection for VM creation, cleanup, disk management, and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->