### PR TITLE
OSAC-2188: Reconcile overlay values with chart releases

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v6
       with:
-        persist-credentials: false
+        token: ${{ secrets.OSAC_BOT_PAT }}
 
     - name: Set up Helm
       uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
@@ -180,6 +180,15 @@ jobs:
         echo "--- Updated values.yaml image references ---"
         grep -E "tag:|image:" charts/osac/values.yaml
 
+    - name: Pin overlay values to released versions
+      env:
+        OPERATOR_VER: ${{ steps.versions.outputs.operator_ver }}
+        SERVICE_VER: ${{ steps.versions.outputs.service_ver }}
+        AAP_VER: ${{ steps.versions.outputs.aap_ver }}
+        BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
+        UI_VER: ${{ steps.versions.outputs.ui_ver }}
+      run: ./scripts/pin-release-tags.sh "${OPERATOR_VER}" "${SERVICE_VER}" "${AAP_VER}" "${BMF_VER}" "${UI_VER}"
+
     - name: Package chart
       env:
         VERSION: ${{ steps.versions.outputs.version }}
@@ -238,3 +247,39 @@ jobs:
           --repo "${{ github.repository }}" \
           --notes-file "$BODY"
         rm -f "$BODY"
+
+    - name: Create PR for overlay value pins
+      env:
+        VERSION: ${{ steps.versions.outputs.version }}
+        GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+        OPERATOR_VER: ${{ steps.versions.outputs.operator_ver }}
+        SERVICE_VER: ${{ steps.versions.outputs.service_ver }}
+        AAP_VER: ${{ steps.versions.outputs.aap_ver }}
+        BMF_VER: ${{ steps.versions.outputs.bmf_ver }}
+        UI_VER: ${{ steps.versions.outputs.ui_ver }}
+      run: |
+        BRANCH="auto/pin-release-v${VERSION}"
+        git config user.name "osac-dev-bot"
+        git config user.email "osac-dev-bot@users.noreply.github.com"
+        # Start fresh from latest main to avoid dirty tree from earlier steps
+        git fetch origin main
+        git checkout -f -B "${BRANCH}" origin/main
+        # Pin overlay values to released versions
+        ./scripts/pin-release-tags.sh "${OPERATOR_VER}" "${SERVICE_VER}" "${AAP_VER}" "${BMF_VER}" "${UI_VER}"
+        git add values/
+        if git diff --cached --quiet; then
+          echo "No overlay changes needed"
+          exit 0
+        fi
+        git commit -m "pin overlay values to v${VERSION} release"
+        git push origin "${BRANCH}" --force
+        EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number // empty')
+        if [[ -n "${EXISTING}" ]]; then
+          echo "Updated existing PR #${EXISTING}"
+        else
+          gh pr create \
+            --title "pin overlay values to v${VERSION} release" \
+            --body "Automated overlay reconciliation after osac v${VERSION} chart release. Pins all values/*/values.yaml image tags to released versions." \
+            --base main \
+            --head "${BRANCH}"
+        fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,18 @@ values/
 
 ### Submodules
 
-Submodules under `base/` (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are pinned snapshots used for version tracking. Image tags in `values/*/values.yaml` must match submodule commit SHAs. CI enforces this via `scripts/sync-image-tags.sh`.
+Submodules under `base/` (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are pinned snapshots used for version tracking. `scripts/sync-image-tags.sh` syncs image tags in `values/*/values.yaml` to match submodule commit SHAs. With `--fix`, it rewrites `sha-`, stable `vX.Y.Z`, and `latest` tags; default (check) mode reports `sha-` mismatches and skips non-SHA pins.
+
+### Image Tag Lifecycle
+
+Two automated workflows manage image tags in overlay values files (`values/*/values.yaml`):
+
+1. **Between releases** -- `bump-submodules.yaml` (every 3 hours) advances overlays to `sha-` tags tracking each component's latest main commit. It runs `sync-image-tags.sh --fix`, which rewrites `sha-`, stable `vX.Y.Z`, and `latest` (not digests, prerelease tags, or arbitrary strings). This keeps CI/dev environments testing the newest code.
+2. **At release time** -- `publish-charts.yaml` calls `scripts/pin-release-tags.sh` to replace `sha-`, stable `vX.Y.Z`, and `latest` with released version tags (e.g. `v0.0.8`), then opens a PR to merge the pins into main. This reconciles overlays with the official chart release.
+
+After a release PR is merged, overlays match the released versions exactly. As new commits land on component repos, `bump-submodules.yaml` advances them again until the next release pins them.
+
+**To check drift:** compare image tags in `values/*/values.yaml` against the latest [GitHub release](https://github.com/osac-project/osac-installer/releases). If tags are `sha-` prefixed, the environment is running ahead of the last release. If tags are `v`-prefixed, compare each component's exact version against the release notes to confirm alignment. If tags are `latest`, the overlay is tracking an unpinned moving tag — check the release PR or the last GitHub release to determine the expected pinned version.
 
 ### Prerequisites
 
@@ -84,6 +95,7 @@ Prerequisites are installed automatically by Phase 1 (`make install-operators`) 
 
 - **teardown.sh** -- Full teardown: uninstalls Helm releases, removes operators and CRDs
 - **sync-image-tags.sh** -- Syncs image tags in Helm values files to match submodule commits
+- **pin-release-tags.sh** -- Pins overlay values files to released versioned image tags (called by `publish-charts.yaml` at release time)
 - **setup-remote-cluster.sh** -- CI-only: prepares a fresh remote cluster (LVMS, CNV, service accounts)
 - **create-hub-access-kubeconfig.sh** -- Generates `kubeconfig.hub-access` from the hub-access ServiceAccount token
 - **generate-chart-versions.sh** -- Computes nightly chart versions from latest release tags

--- a/scripts/pin-release-tags.sh
+++ b/scripts/pin-release-tags.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Pin overlay values files to released versioned image tags.
+# Called by publish-charts.yaml after a chart release to reconcile
+# CI/dev overlays with the officially released component versions.
+#
+# Usage: pin-release-tags.sh <operator_ver> <service_ver> <aap_ver> <bmf_ver> <ui_ver>
+# Example: pin-release-tags.sh 0.0.8 0.0.64 0.0.3 0.0.1 0.0.1
+
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "Usage: $0 <operator_ver> <service_ver> <aap_ver> <bmf_ver> <ui_ver>" >&2
+  exit 1
+fi
+
+OPERATOR_VER="$1"
+SERVICE_VER="$2"
+AAP_VER="$3"
+BMF_VER="$4"
+UI_VER="$5"
+
+STABLE_VERSION_RE='^[0-9]+\.[0-9]+\.[0-9]+$'
+for version in "${OPERATOR_VER}" "${SERVICE_VER}" "${AAP_VER}" "${BMF_VER}" "${UI_VER}"; do
+  if ! [[ "${version}" =~ ${STABLE_VERSION_RE} ]]; then
+    echo "Invalid stable release version: ${version}" >&2
+    exit 1
+  fi
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
+  [[ ! -f "${values_file}" ]] && continue
+  name=$(basename "$(dirname "${values_file}")")
+
+  # Skip files that have no OSAC component image references at all
+  if ! grep -q "ghcr.io/osac-project/" "${values_file}"; then
+    continue
+  fi
+
+  echo "--- Updating ${name} ---"
+
+  # operator: tag field
+  if grep -q "repository: ghcr.io/osac-project/osac-operator$" "${values_file}"; then
+    sed -i "/repository: ghcr.io\/osac-project\/osac-operator$/{n;s|tag: .*|tag: v${OPERATOR_VER}|}" "${values_file}"
+    echo "  osac-operator: v${OPERATOR_VER}"
+  fi
+
+  # fulfillment-service: inline image reference
+  sed -i -E "s#fulfillment-service:(sha-[a-f0-9]{7}|v[0-9][0-9.]*|latest)#fulfillment-service:v${SERVICE_VER}#g" "${values_file}"
+  echo "  fulfillment-service: v${SERVICE_VER}"
+
+  # osac-aap: inline image reference
+  sed -i -E "s#osac-aap:(sha-[a-f0-9]{7}|v[0-9][0-9.]*|latest)#osac-aap:v${AAP_VER}#g" "${values_file}"
+  echo "  osac-aap: v${AAP_VER}"
+
+  # bare-metal-fulfillment-operator: tag field
+  if grep -q "repository: ghcr.io/osac-project/bare-metal-fulfillment-operator$" "${values_file}"; then
+    sed -i "/repository: ghcr.io\/osac-project\/bare-metal-fulfillment-operator$/{n;s|tag: .*|tag: v${BMF_VER}|}" "${values_file}"
+    echo "  bare-metal-fulfillment-operator: v${BMF_VER}"
+  fi
+
+  # osac-ui: inline image reference
+  sed -i -E "s#osac-ui:(sha-[a-f0-9]{7}|v[0-9][0-9.]*|latest)#osac-ui:v${UI_VER}#g" "${values_file}"
+  echo "  osac-ui: v${UI_VER}"
+
+  # Pin projectGitBranch to the AAP release tag so git content matches the EE image
+  if grep -q "projectGitBranch:" "${values_file}"; then
+    sed -i "s|projectGitBranch: .*|projectGitBranch: \"v${AAP_VER}\"|" "${values_file}"
+    echo "  projectGitBranch: v${AAP_VER}"
+  fi
+done
+
+echo ""
+echo "Overlay values files pinned to release versions."

--- a/scripts/sync-image-tags.sh
+++ b/scripts/sync-image-tags.sh
@@ -19,7 +19,7 @@ ui_tag="sha-$(git -C "${REPO_ROOT}" submodule status base/osac-ui | awk '{print 
 for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
   [[ ! -f "${values_file}" ]] && continue
   name=$(basename "$(dirname "${values_file}")")
-  grep -q "sha-" "${values_file}" || continue
+  grep -q "sha-\|ghcr.io/osac-project/" "${values_file}" || continue
 
   for pair in \
     "osac-operator:tag ${operator_tag}" \
@@ -42,21 +42,25 @@ for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
       elif [[ "${1:-}" == "--fix" ]]; then
         sed -i "/repository: ghcr.io\/osac-project\/${component}$/{n;s|tag: .*|tag: ${expected}|}" "${values_file}"
         echo "${name} ${component}: FIXED ${current} -> ${expected}"
-      else
+      elif [[ "${current}" == sha-* ]]; then
         echo "${name} ${component}: MISMATCH current=${current} expected=${expected}"
         errors=$((errors + 1))
+      else
+        echo "${name} ${component}: SKIP (pinned to ${current}, not a sha- tag)"
       fi
     else
-      current=$(grep -o "${component}:sha-[a-f0-9]\{7\}" "${values_file}" | head -1 | sed "s/${component}://" || true)
+      current=$(grep -oE "osac-project/${component}:(sha-[a-f0-9]{7}|v[0-9][0-9.]*|latest)" "${values_file}" | head -1 | sed "s#osac-project/${component}:##" || true)
       [[ -z "${current}" ]] && continue
       if [[ "${current}" == "${expected}" ]]; then
         echo "${name} ${component}: OK (${expected})"
       elif [[ "${1:-}" == "--fix" ]]; then
-        sed -i "s|${component}:sha-[a-f0-9]\{7\}|${component}:${expected}|g" "${values_file}"
+        sed -i -E "s#(osac-project/${component}):(sha-[a-f0-9]{7}|v[0-9][0-9.]*|latest)#\1:${expected}#g" "${values_file}"
         echo "${name} ${component}: FIXED ${current} -> ${expected}"
-      else
+      elif [[ "${current}" == sha-* ]]; then
         echo "${name} ${component}: MISMATCH current=${current} expected=${expected}"
         errors=$((errors + 1))
+      else
+        echo "${name} ${component}: SKIP (pinned to ${current}, not a sha- tag)"
       fi
     fi
   done
@@ -71,9 +75,11 @@ for values_file in "${REPO_ROOT}"/values/*/values.yaml; do
   elif [[ "${1:-}" == "--fix" ]]; then
     sed -i "s|projectGitBranch: .*|projectGitBranch: \"${aap_full_commit}\"|" "${values_file}"
     echo "${name} projectGitBranch: FIXED ${current_branch} -> ${aap_full_commit}"
-  else
+  elif [[ "${current_branch}" =~ ^[0-9a-f]{40}$ ]]; then
     echo "${name} projectGitBranch: MISMATCH current=${current_branch} expected=${aap_full_commit}"
     errors=$((errors + 1))
+  else
+    echo "${name} projectGitBranch: SKIP (pinned to ${current_branch}, not a commit SHA)"
   fi
 done
 


### PR DESCRIPTION
## Summary
- Add `scripts/pin-release-tags.sh` to pin all overlay values files to released versions at chart publish time
- Extend `publish-charts.yaml` to call the script and open a PR with pinned values after each release
- Update `sync-image-tags.sh` to handle `v`-prefixed and `latest` tags so bump-submodules advances overlays post-release

Depends on [osac-aap#412.](https://github.com/osac-project/osac-aap/pull/412)

## Test plan
- [x] `pin-release-tags.sh` correctly replaces `sha-`, `v`-prefixed, and `latest` tags across all overlays
- [x] `sync-image-tags.sh` verify mode skips non-`sha-` tags (no false CI failures)
- [x] `sync-image-tags.sh --fix` replaces pinned `v`-tags back to `sha-` tags
- [x] Round-trip tested: pin -> verify (0 errors) -> fix (all 20 tags replaced)
- [x] `actionlint` and `bash -n` pass

Fixes [OSAC-2188](https://redhat.atlassian.net/browse/OSAC-2188).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release-time automation that pins overlay image tags and app versions to the resolved released chart versions.
  * After publishing a release, the workflow creates or force-updates a branch and opens/updates a PR to replace `latest`/unversioned tags with versioned tags.
* **Bug Fixes**
  * Improved image-tag synchronization reporting by clearly distinguishing true mismatches from intentionally pinned non-SHA values, and better skipping of unrelated entries.
* **Documentation**
  * Expanded image tag lifecycle and drift-check guidance, including the new release-time pinning helper script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->