### PR TITLE
OSAC-2161: Seed ClusterVersion entries on deployment

### DIFF
--- a/charts/osac/templates/_helpers.tpl
+++ b/charts/osac/templates/_helpers.tpl
@@ -30,3 +30,49 @@ app.kubernetes.io/part-of: osac
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Wait-for-fulfillment init container.
+Uses .Values.cliImage for the container image.
+*/}}
+{{- define "osac.waitForFulfillment" -}}
+{{- $url := "https://fulfillment-rest-gateway:8000/healthz" -}}
+- name: wait-for-fulfillment
+  image: {{ .Values.cliImage }}
+  command:
+    - /bin/bash
+    - -euo
+    - pipefail
+    - -c
+    - |
+      echo "Waiting for fulfillment REST gateway..."
+      for i in $(seq 1 60); do
+        echo "Attempt ${i}: checking {{ $url }}"
+        if curl -skf --connect-timeout 5 --max-time 30 {{ $url }}; then
+          echo ""
+          echo "Fulfillment service is ready."
+          exit 0
+        fi
+        sleep 10
+      done
+      echo "ERROR: Fulfillment service not ready after 600s"
+      exit 1
+  env:
+  - name: HOME
+    value: /tmp
+  volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: ["ALL"]
+{{- end }}

--- a/charts/osac/templates/hooks/create-hub.yaml
+++ b/charts/osac/templates/hooks/create-hub.yaml
@@ -57,47 +57,10 @@ spec:
     spec:
       serviceAccountName: admin
       initContainers:
-      - name: wait-for-fulfillment
-        image: {{ .Values.hubAccess.cliImage | default "quay.io/openshift/origin-cli:4.20.0" }}
-        command:
-          - /bin/bash
-          - -euo
-          - pipefail
-          - -c
-          - |
-            echo "Waiting for fulfillment REST gateway..."
-            for i in $(seq 1 60); do
-              echo "Attempt ${i}: checking https://fulfillment-rest-gateway:8000/healthz"
-              if curl -skf https://fulfillment-rest-gateway:8000/healthz; then
-                echo ""
-                echo "Fulfillment service is ready."
-                exit 0
-              fi
-              sleep 10
-            done
-            echo "ERROR: Fulfillment service not ready after 600s"
-            exit 1
-        env:
-        - name: HOME
-          value: /tmp
-        volumeMounts:
-        - name: tmp
-          mountPath: /tmp
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+      {{- include "osac.waitForFulfillment" . | nindent 6 }}
       containers:
       - name: create-hub
-        image: {{ .Values.hubAccess.cliImage | default "quay.io/openshift/origin-cli:4.20.0" }}
+        image: {{ .Values.cliImage }}
         command:
           - /bin/bash
           - -euo

--- a/charts/osac/templates/hooks/pre-install-validate.yaml
+++ b/charts/osac/templates/hooks/pre-install-validate.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: {{ include "osac.fullname" . }}-validate
       containers:
       - name: validate
-        image: {{ .Values.validation.image }}
+        image: {{ .Values.cliImage }}
         command:
         - /bin/sh
         - -c

--- a/charts/osac/templates/hooks/publish-templates.yaml
+++ b/charts/osac/templates/hooks/publish-templates.yaml
@@ -19,47 +19,10 @@ spec:
         {{- include "osac.labels" . | nindent 8 }}
     spec:
       initContainers:
-      - name: wait-for-fulfillment
-        image: {{ .Values.aap.bootstrap.cliImage }}
-        command:
-          - /bin/bash
-          - -euo
-          - pipefail
-          - -c
-          - |
-            echo "Waiting for fulfillment REST gateway..."
-            for i in $(seq 1 60); do
-              echo "Attempt ${i}: checking https://fulfillment-rest-gateway:8000/healthz"
-              if curl -skf https://fulfillment-rest-gateway:8000/healthz; then
-                echo ""
-                echo "Fulfillment service is ready."
-                exit 0
-              fi
-              sleep 10
-            done
-            echo "ERROR: Fulfillment service not ready after 600s"
-            exit 1
-        env:
-        - name: HOME
-          value: /tmp
-        volumeMounts:
-        - name: tmp
-          mountPath: /tmp
-        resources:
-          requests:
-            cpu: 50m
-            memory: 128Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop: ["ALL"]
+      {{- include "osac.waitForFulfillment" . | nindent 6 }}
       containers:
       - name: publish-templates
-        image: {{ .Values.aap.bootstrap.cliImage }}
+        image: {{ .Values.cliImage }}
         command:
           - /bin/bash
           - -euo

--- a/charts/osac/templates/hooks/seed-cluster-versions.yaml
+++ b/charts/osac/templates/hooks/seed-cluster-versions.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.clusterVersions.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: seed-cluster-versions
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "30"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 900
+  template:
+    metadata:
+      labels:
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: admin
+      initContainers:
+      {{- include "osac.waitForFulfillment" . | nindent 6 }}
+      containers:
+      - name: seed-versions
+        image: {{ .Values.cliImage }}
+        command:
+          - /bin/bash
+          - -euo
+          - pipefail
+          - -c
+          - |
+            AUTH_TOKEN=$(< /var/run/secrets/kubernetes.io/serviceaccount/token)
+            API="https://fulfillment-internal-api:8001/api/private/v1/cluster_versions"
+
+            create_version() {
+              local version="$1"
+              local payload="$2"
+              local response="/tmp/cv-response.json"
+              local code
+
+              code=$(curl -skS \
+                --connect-timeout 5 \
+                --max-time 30 \
+                -o "${response}" \
+                -w '%{http_code}' \
+                -X POST \
+                -H "Authorization: Bearer ${AUTH_TOKEN}" \
+                -H "Content-Type: application/json" \
+                --data-binary "${payload}" \
+                "${API}")
+
+              case "${code}" in
+                2??)
+                  echo "Created ClusterVersion ${version}."
+                  ;;
+                409)
+                  echo "ClusterVersion ${version} already exists, skipping."
+                  ;;
+                *)
+                  echo "ERROR: Failed to create ${version} (HTTP ${code})" >&2
+                  cat "${response}" >&2
+                  return 1
+                  ;;
+              esac
+            }
+
+            {{- range .Values.clusterVersions.versions }}
+            create_version \
+              {{ .version | quote }} \
+              {{ dict "metadata" (dict "name" (.version | replace "." "-")) "spec" (dict
+                  "version" .version
+                  "image" .image
+                  "enabled" true
+                  "is_default" (.default | default false)
+                ) | toJson | quote }}
+            {{- end }}
+        env:
+        - name: HOME
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/osac/values-example.yaml
+++ b/charts/osac/values-example.yaml
@@ -240,8 +240,6 @@ aap:
     enabled: true
     # Bootstrap job container image.
     image: ghcr.io/osac-project/osac-aap:latest
-    # CLI image for oc/kubectl commands during bootstrap.
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     # Number of retries for the bootstrap job. AAP takes time to start,
     # so a high backoff limit is normal.
     backoffLimit: 15
@@ -445,7 +443,6 @@ validation:
   # Run pre-install checks (cert-manager CRDs, default StorageClass).
   # Catches missing prerequisites before deployment starts.
   enabled: true
-  image: quay.io/openshift/origin-cli:4.20.0
 
 # ---------------------
 # Database Migration

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -4,6 +4,10 @@
   "description": "Configuration values for Open Sovereign AI Cloud deployment",
   "type": "object",
   "properties": {
+    "cliImage": {
+      "type": "string",
+      "description": "Default OpenShift CLI image used by hook jobs"
+    },
     "operatorCrds": {
       "type": "object",
       "description": "OSAC Operator CRDs configuration",
@@ -452,10 +456,6 @@
             "image": {
               "type": "string",
               "description": "Bootstrap job container image"
-            },
-            "cliImage": {
-              "type": "string",
-              "description": "OpenShift CLI image used by bootstrap jobs"
             },
             "backoffLimit": {
               "type": "integer",
@@ -1153,10 +1153,6 @@
           "type": "boolean",
           "description": "Run pre-install validation checks",
           "default": true
-        },
-        "image": {
-          "type": "string",
-          "description": "Container image for the validation hook job"
         }
       }
     },
@@ -1236,6 +1232,40 @@
                   "type": "string",
                   "description": "Memory request"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "clusterVersions": {
+      "type": "object",
+      "description": "Seed ClusterVersion records in the fulfillment-service after install",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Run the seed-cluster-versions hook job",
+          "default": false
+        },
+        "versions": {
+          "type": "array",
+          "description": "ClusterVersion records to seed",
+          "items": {
+            "type": "object",
+            "required": ["version", "image"],
+            "properties": {
+              "version": {
+                "type": "string",
+                "description": "SemVer version string (e.g. 4.20.8)"
+              },
+              "image": {
+                "type": "string",
+                "description": "OCI release image pullspec"
+              },
+              "default": {
+                "type": "boolean",
+                "description": "Mark as the default cluster version",
+                "default": false
               }
             }
           }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -1,6 +1,8 @@
 # Open Sovereign AI Cloud - Unified Helm Values
 # This values file configures all OSAC components via the umbrella chart.
 
+cliImage: quay.io/openshift/origin-cli:4.20.0
+
 # --- Operator CRDs ---
 operatorCrds:
   install: true
@@ -99,7 +101,6 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:latest
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
     gateway:
       hostname: ""
@@ -236,7 +237,6 @@ bmf:
 # --- Validation hooks ---
 validation:
   enabled: true
-  image: quay.io/openshift/origin-cli:4.20.0
 
 # --- MetalLB Address Pool ---
 metallb:
@@ -258,3 +258,15 @@ bundledPostgres:
     requests:
       cpu: 50m
       memory: 128Mi
+
+clusterVersions:
+  enabled: false
+  versions: []
+  # Example:
+  # enabled: true
+  # versions:
+  # - version: "4.20.0"
+  #   image: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+  # - version: "4.22.0"
+  #   image: "quay.io/openshift-release-dev/ocp-release:4.22.0-multi"
+  #   default: true

--- a/values/bmaas-ci/values.yaml
+++ b/values/bmaas-ci/values.yaml
@@ -130,7 +130,6 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:sha-775461f
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"

--- a/values/caas-ci/values.yaml
+++ b/values/caas-ci/values.yaml
@@ -122,7 +122,6 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:sha-775461f
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"
@@ -151,6 +150,16 @@ bmf:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
     tag: sha-d28b3ca
     pullPolicy: Always
+
+# --- Cluster Versions ---
+clusterVersions:
+  enabled: true
+  versions:
+  - version: "4.20.0"
+    image: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+  - version: "4.22.0"
+    image: "quay.io/openshift-release-dev/ocp-release:4.22.0-multi"
+    default: true
 
 # --- CI/dev only ---
 # Hub access: registers local cluster as a hub. Only for environments

--- a/values/development/values.yaml
+++ b/values/development/values.yaml
@@ -126,7 +126,6 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:latest
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   instanceGroups:
     clusterFulfillment:
@@ -152,3 +151,13 @@ aap:
 # --- Validation ---
 validation:
   enabled: true
+
+# --- ClusterVersion Seeding ---
+clusterVersions:
+  enabled: true
+  versions:
+  - version: "4.20.0"
+    image: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+  - version: "4.22.0"
+    image: "quay.io/openshift-release-dev/ocp-release:4.22.0-multi"
+    default: true

--- a/values/vmaas-ci/values.yaml
+++ b/values/vmaas-ci/values.yaml
@@ -132,7 +132,6 @@ aap:
   bootstrap:
     enabled: true
     image: ghcr.io/osac-project/osac-aap:sha-775461f
-    cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
   configAsCode:
     manifestSecret: "config-as-code-manifest-ig"


### PR DESCRIPTION
## Summary
Add a Helm post-install hook that seeds ClusterVersion records via the private API (idempotent via 409 handling), and extract the duplicated wait-for-fulfillment init container into a reusable `osac.waitForFulfillment` helper.

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cluster version seeding as a post-install/post-upgrade hook, including support for choosing a default version.
  * Hook jobs now share a unified readiness check that waits for the fulfillment service to become healthy before continuing.
* **Improvements**
  * Centralized hook CLI image configuration via a top-level chart value (with chart schema and example updates).
  * Strengthened security hardening and resource settings for hook containers.
  * Updated CI environment bootstrap configurations to use the pinned AAP image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->