### PR TITLE
OSAC-2190: Mark floating image tags as placeholders, add CI guard

### DIFF
--- a/.github/scripts/check-floating-tags.sh
+++ b/.github/scripts/check-floating-tags.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Detect floating image tags (:latest, :main) in Helm values files that are
+# not marked with a PLACEHOLDER comment. Exit 1 if any unmarked floating tags
+# are found.
+set -euo pipefail
+
+if [ ! -d charts/ ]; then
+  echo "::error::charts/ directory not found -- cannot validate image tags"
+  exit 1
+fi
+
+rc=0
+while IFS= read -r -d '' f; do
+  lineno=0
+  prev_line=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    code_line="$(printf '%s\n' "$line" | sed -E 's/[[:space:]]+#.*$//')"
+    if printf '%s\n' "$code_line" | grep -qE "(^|[[:space:]])tag:[[:space:]]*['\"]?(latest|main)['\"]?([]},[:space:]]|$)|:(latest|main)['\"]?([]},[:space:]]|$)" && \
+       printf '%s\n' "$code_line" | grep -qvE '^[[:space:]]*#'; then
+      if printf '%s\n' "$prev_line" | grep -qE '(^|[[:space:]])#[[:space:]]PLACEHOLDER -- overwritten at release time([[:space:]]|$)' || \
+         printf '%s\n' "$line" | grep -qE '(^|[[:space:]])#[[:space:]]PLACEHOLDER -- overwritten at release time([[:space:]]|$)'; then
+        : # properly documented
+      else
+        tag_match="$(printf '%s\n' "$code_line" | grep -oE '\b(latest|main)\b' | head -1)"
+        echo "$f:$lineno: unmarked floating tag ':${tag_match}' found"
+        rc=1
+      fi
+    fi
+    prev_line="$line"
+  done < "$f"
+done < <(find charts/ -name 'values.yaml' -print0)
+
+if [ "$rc" -eq 0 ]; then
+  echo "No unmarked floating image tags found."
+fi
+exit "$rc"

--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -1,0 +1,51 @@
+name: Check Floating Image Tags
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**/values.yaml'
+      - '.github/scripts/check-floating-tags.sh'
+      - '.github/workflows/check-floating-tags.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-floating-tags-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-floating-tags:
+    name: Reject unmarked floating tags
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout trusted base branch script
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        persist-credentials: false
+        sparse-checkout: .github/scripts/check-floating-tags.sh
+        sparse-checkout-cone-mode: false
+        path: trusted
+
+    - name: Checkout PR
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
+        path: pr
+
+    - name: Check for unmarked floating image tags
+      env:
+        TRUSTED_SCRIPT: ../trusted/.github/scripts/check-floating-tags.sh
+        PR_SCRIPT: .github/scripts/check-floating-tags.sh
+      run: |
+        if [ -f "$TRUSTED_SCRIPT" ]; then
+          bash "$TRUSTED_SCRIPT"
+        elif [ -f "$PR_SCRIPT" ]; then
+          echo "::warning::Base branch has no check-floating-tags.sh; falling back to PR copy"
+          bash "$PR_SCRIPT"
+        else
+          echo "::error::No check-floating-tags.sh found in base or PR"
+          exit 1
+        fi
+      working-directory: pr

--- a/.github/workflows/check-floating-tags.yaml
+++ b/.github/workflows/check-floating-tags.yaml
@@ -19,33 +19,10 @@ jobs:
     name: Reject unmarked floating tags
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout trusted base branch script
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      with:
-        ref: ${{ github.event.pull_request.base.sha }}
-        persist-credentials: false
-        sparse-checkout: .github/scripts/check-floating-tags.sh
-        sparse-checkout-cone-mode: false
-        path: trusted
-
-    - name: Checkout PR
+    - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         persist-credentials: false
-        path: pr
 
     - name: Check for unmarked floating image tags
-      env:
-        TRUSTED_SCRIPT: ../trusted/.github/scripts/check-floating-tags.sh
-        PR_SCRIPT: .github/scripts/check-floating-tags.sh
-      run: |
-        if [ -f "$TRUSTED_SCRIPT" ]; then
-          bash "$TRUSTED_SCRIPT"
-        elif [ -f "$PR_SCRIPT" ]; then
-          echo "::warning::Base branch has no check-floating-tags.sh; falling back to PR copy"
-          bash "$PR_SCRIPT"
-        else
-          echo "::error::No check-floating-tags.sh found in base or PR"
-          exit 1
-        fi
-      working-directory: pr
+      run: bash .github/scripts/check-floating-tags.sh

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -9,7 +9,7 @@ operatorCrds:
 operator:
   image:
     repository: ghcr.io/osac-project/osac-operator
-    tag: latest
+    tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
     pullPolicy: Always
   replicaCount: 1
   resources:
@@ -49,7 +49,7 @@ service:
   # [REQUIRED] Hostname for the internal API Route (e.g. fulfillment-internal-api-osac.apps.mycluster.example.com)
   internalHostname: ""
   images:
-    service: ghcr.io/osac-project/fulfillment-service:latest
+    service: ghcr.io/osac-project/fulfillment-service:latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
     envoy: ghcr.io/osac-project/envoy:v1.33.0
   certs:
     issuerRef:
@@ -98,7 +98,7 @@ aap:
       imagePullPolicy: IfNotPresent
   bootstrap:
     enabled: true
-    image: ghcr.io/osac-project/osac-aap:latest
+    image: ghcr.io/osac-project/osac-aap:latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
     cliImage: quay.io/openshift/origin-cli:4.20.0
     backoffLimit: 15
     gateway:
@@ -201,7 +201,7 @@ ui:
   log:
     level: info
   images:
-    ui: ghcr.io/osac-project/osac-ui:latest
+    ui: ghcr.io/osac-project/osac-ui:latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
 
 # --- Bare Metal Fulfillment Operator CRDs ---
 bmfCrds: {}
@@ -211,7 +211,7 @@ bmf:
   enabled: true
   image:
     repository: ghcr.io/osac-project/bare-metal-fulfillment-operator
-    tag: latest
+    tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
     pullPolicy: Always
   replicaCount: 1
   resources:


### PR DESCRIPTION
Mark floating `:latest`/`:main` image tags in `charts/*/values.yaml` as placeholders with inline comments, and add a CI workflow (`check-floating-tags.yaml`) that rejects unmarked floating tags on PRs.

- Add `# PLACEHOLDER -- overwritten at release time by publish-charts.yaml` comment above each floating tag
- Add `.github/scripts/check-floating-tags.sh` lint script
- Add `.github/workflows/check-floating-tags.yaml` CI guard on PR

No change to release-publish behavior -- the `publish-charts.yaml` workflow still patches these values at release time.

Ref: [OSAC-2190](https://redhat.atlassian.net/browse/OSAC-2190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated pull request check that scans Helm `values.yaml` for unapproved “floating” container image tags (`latest`/`main`) and fails the PR when violations are detected.
  * Runs only when relevant files change, with concurrency to prevent overlapping checks for the same pull request.
* **Chores**
  * Added release-time override placeholder comments for selected OSAC component image tags in the OSAC Helm chart.
  * Updated referenced OSAC component versions via refreshed submodule commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->