### PR TITLE
OSAC-870: Add CaaS E2E caller workflow

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -1,0 +1,43 @@
+---
+name: E2E CaaS Full Install
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (caas, or empty for all)"
+        required: false
+        default: "caas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-caas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e-caas-full-install:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'caas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      installer-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      installer-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
## [OSAC-870](https://redhat.atlassian.net/browse/OSAC-870): Add CaaS E2E caller workflow

**Jira:** https://redhat.atlassian.net/browse/OSAC-870

### Summary

Adds a cross-repo caller workflow that invokes the reusable CaaS E2E workflow in
osac-test-infra. Same pattern as the BMaaS presubmit jobs.

### Related PRs

- osac-project/fulfillment-service — CaaS E2E caller
- osac-project/osac-operator — CaaS E2E caller
- osac-project/osac-aap — CaaS E2E caller
- osac-project/osac-installer — CaaS E2E caller

### Testing

- [ ] Trigger `workflow_dispatch` from the branch to validate the workflow runs

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated end-to-end testing for full installation scenarios.
  * Tests now run automatically for relevant pull requests and can also be started manually with selectable test options.
  * In-progress pull request test runs are canceled when superseded by newer runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->