### PR TITLE
OSAC-3163: Increase publish-templates hook backoffLimit from 3 to 6

### DIFF
--- a/charts/osac/templates/hooks/publish-templates.yaml
+++ b/charts/osac/templates/hooks/publish-templates.yaml
@@ -11,7 +11,7 @@ metadata:
     "helm.sh/hook-weight": "20"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 3
+  backoffLimit: 6
   activeDeadlineSeconds: 1300
   template:
     metadata:

--- a/docs/helm-deployment-guide.md
+++ b/docs/helm-deployment-guide.md
@@ -195,8 +195,8 @@ oc logs job/osac-publish-templates -n ${NAMESPACE} -c publish-templates     # ma
 - **AAP job failure** - The hook logs include the AAP job stdout on failure.
   Check AAP for the job run details.
 
-The hook has `backoffLimit: 3` and `activeDeadlineSeconds: 1300`. After
-3 retries or 1300s, the Job fails and Helm reports the install as failed.
+The hook has `backoffLimit: 6` and `activeDeadlineSeconds: 1300`. After
+6 retries or 1300s, the Job fails and Helm reports the install as failed.
 
 ### Hook Job Failed
 


### PR DESCRIPTION
After a snapshot refresh, Phase 1/2 disrupts the AAP gateway (operator scaling, keycloak restart, cert rotation). The osac-publish-templates post-upgrade hook fires during Phase 3 before AAP fully recovers, causing transient 500 errors. With backoffLimit: 3, the job exhausts retries during the ~90s recovery window. Doubling to 6 gives sufficient margin.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for template publishing jobs by allowing additional retry attempts when failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->