### PR TITLE
OSAC-3139: update osac-installer AI agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Helm-based deployment system for the OSAC platform. Component repos (fulfillment-service, osac-operator, osac-aap, bare-metal-fulfillment-operator) are aggregated as Git submodules under `base/` for version tracking. Deployment uses Helm charts under `charts/osac/`.
+Helm-based deployment system for the OSAC platform. Component repos (fulfillment-service, osac-operator, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-operators/` (Phase 1), `charts/osac-prereqs/` (Phase 2), `charts/osac/` (Phase 3).
 
 ## Common Commands
 
@@ -10,14 +10,22 @@ Helm-based deployment system for the OSAC platform. Component repos (fulfillment
 # Initialize submodules (required before sync-image-tags)
 git submodule update --init --recursive
 
-# Helm lint
-helm lint charts/osac/
+# Helm lint (all three charts)
+make helm-lint
 
-# Helm template render (dry-run validation)
-helm template osac charts/osac/ --values values/development/values.yaml
+# Helm template render (dry-run validation against all values files)
+make helm-validate
+
+# Sync submodules and rebuild chart dependencies
+make sync-charts
 
 # Deploy to OpenShift (three-phase Helm install)
 make install VALUES_FILE=values/<env>/values.yaml
+
+# Individual install phases
+make install-operators VALUES_FILE=values/<env>/values.yaml
+make install-prereqs VALUES_FILE=values/<env>/values.yaml
+make install-osac VALUES_FILE=values/<env>/values.yaml
 
 # Uninstall
 make uninstall
@@ -31,19 +39,35 @@ yamllint --strict .
 
 ## Architecture
 
-### Helm Chart
+### Helm Charts (Three-Phase Deployment)
 
 ```text
-charts/osac/                         # Umbrella chart
-  Chart.yaml                         # Dependencies on subchart repos
-  values.yaml                        # Default values
-  values.schema.json                 # JSON Schema for values validation
-  templates/                         # Deployment templates
+Phase 1: charts/osac-operators/         # OLM operator subscriptions
+  Installs: cert-manager, AAP, LVMS, CNV, MCE, MetalLB
+  Hook scripts wait for operators to be ready before proceeding
 
+Phase 2: charts/osac-prereqs/           # Cluster prerequisites
+  Configures: certificates (CA issuer, trust-manager), Keycloak,
+  operator CRs (HyperConverged, LVMCluster, MetalLB, MCE)
+  Hook scripts configure each operator after its CRD is ready
+
+Phase 3: charts/osac/                   # OSAC platform (umbrella chart)
+  Dependencies (from submodules via file:// references):
+    osac-operator-crds, osac-operator, fulfillment-service,
+    osac-aap, bare-metal-fulfillment-operator[-crds], osac-ui
+  Templates: bundled-postgres, hub-access, hooks (create-hub,
+    pre-install-validate, publish-templates, seed-cluster-versions)
+  values.schema.json validates all configuration
+```
+
+### Values Environments
+
+```text
 values/
-  development/values.yaml            # All controllers, latest images
-  vmaas-ci/values.yaml               # VMaaS CI: computeInstance + tenant + networking, pinned images
-  caas-ci/values.yaml                # CaaS CI: clusterOrder + tenant + networking, pinned images
+  development/values.yaml              # All controllers, latest images
+  vmaas-ci/values.yaml                 # VMaaS CI: computeInstance + tenant + networking
+  caas-ci/values.yaml                  # CaaS CI: clusterOrder + tenant + networking
+  bmaas-ci/values.yaml                 # BM-as-a-Service CI: bmf + storage + bareMetalInstance
 ```
 
 ### Submodules
@@ -56,11 +80,35 @@ Prerequisites are installed automatically by Phase 1 (`make install-operators`) 
 
 ### Scripts
 
-- **teardown.sh** -- Full teardown: uninstalls Helm release, removes operators and CRDs.
-- **sync-image-tags.sh** -- Syncs image tags in Helm values files to match submodule commits.
-- **setup-remote-cluster.sh** -- CI-only script for preparing a remote cluster (LVMS, CNV, service accounts).
-- **create-hub-access-kubeconfig.sh** -- Generates `kubeconfig.hub-access` from the hub-access ServiceAccount token.
-- **lib.sh** -- Shared shell functions: `retry_until` (retry with timeout) and `wait_for_resource` (wait for k8s resource condition).
+- **teardown.sh** -- Full teardown: uninstalls Helm releases, removes operators and CRDs
+- **sync-image-tags.sh** -- Syncs image tags in Helm values files to match submodule commits
+- **setup-remote-cluster.sh** -- CI-only: prepares a fresh remote cluster (LVMS, CNV, service accounts)
+- **create-hub-access-kubeconfig.sh** -- Generates `kubeconfig.hub-access` from the hub-access ServiceAccount token
+- **generate-chart-versions.sh** -- Computes nightly chart versions from latest release tags
+- **get-chart-version.sh** -- Looks up a field (version/source_tag/source_sha) from chart-versions.txt
+- **oc.sh** -- Wraps `oc` with `--as` impersonation when `OC_IMPERSONATE` is set
+- **refresh-after-snapshot.py** -- Refreshes Helm-deployed cluster after booting from cold snapshot
+- **setup-caas-agents.sh** -- Sets up CaaS agent infrastructure (InfraEnv + agent VM + label + approve)
+- **lib.sh** -- Shared shell functions: `retry_until`, `wait_for_resource`, `wait_for_namespace_cleanup`, `retry_command`, `http_retry`, `http_json`, `resolve_release_tag`, `check_postgres_prerequisites`
+
+### CI Workflows
+
+| Workflow | Purpose |
+|----------|---------|
+| `bump-submodules.yaml` | Automated submodule updates |
+| `check-image-tags.yaml` | Verifies image tags match submodule SHAs |
+| `cleanup-nightly-branches.yaml` | Cleans up old nightly branches |
+| `e2e-bmaas-full-install.yml` | BM-as-a-Service E2E tests |
+| `e2e-vmaas-full-install.yml` | VMaaS E2E tests |
+| `helm-lint.yaml` | Helm chart linting |
+| `integration-tests.yml` | Integration test suite |
+| `mirror-envoy.yaml` | Mirrors Envoy images |
+| `nightly-build.yaml` | Nightly chart build and publish |
+| `ok-to-test-label-cleanup.yml` | Removes ok-to-test label on new pushes |
+| `pre-commit.yaml` | Pre-commit hook checks |
+| `publish-charts.yaml` | Publishes Helm charts on release |
+| `secret-scanning.yaml` | Scans for leaked secrets |
+| `slash-command.yml` | Handles PR slash commands |
 
 ## Submodules and Local Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Helm-based deployment system for the OSAC platform. Component repos (fulfillment-service, osac-operator, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-operators/` (Phase 1), `charts/osac-prereqs/` (Phase 2), `charts/osac/` (Phase 3).
+Helm-based deployment system for the OSAC platform. Component repos (osac-operator, osac-fulfillment-service, osac-aap, bare-metal-fulfillment-operator, osac-ui) are aggregated as Git submodules under `base/` for version tracking. Deployment uses three Helm charts in sequence: `charts/osac-operators/` (Phase 1), `charts/osac-prereqs/` (Phase 2), `charts/osac/` (Phase 3).
 
 ## Common Commands
 
@@ -54,7 +54,9 @@ Phase 2: charts/osac-prereqs/           # Cluster prerequisites
 Phase 3: charts/osac/                   # OSAC platform (umbrella chart)
   Dependencies (from submodules via file:// references):
     osac-operator-crds, osac-operator, fulfillment-service,
-    osac-aap, bare-metal-fulfillment-operator[-crds], osac-ui
+    osac-aap, bare-metal-fulfillment-operator-crds,
+    bare-metal-fulfillment-operator (conditional: bmf.enabled),
+    osac-ui (conditional: ui.enabled)
   Templates: bundled-postgres, hub-access, hooks (create-hub,
     pre-install-validate, publish-templates, seed-cluster-versions)
   values.schema.json validates all configuration


### PR DESCRIPTION
## Summary
- Document all 3 Helm charts — was only `charts/osac/`, now includes `charts/osac-operators/` (Phase 1) and `charts/osac-prereqs/` (Phase 2)
- Document three-phase install flow (`install-operators` -> `install-prereqs` -> `install-osac`)
- Add missing `bmaas-ci` environment to values listing
- Add 5 undocumented scripts: `generate-chart-versions.sh`, `get-chart-version.sh`, `oc.sh`, `refresh-after-snapshot.py`, `setup-caas-agents.sh`
- Expand `lib.sh` function list (was 2, now 8)
- Add CI Workflows section documenting all 14 workflows
- Add individual Makefile phase targets and `make helm-validate`/`make sync-charts` to Common Commands

## Test plan
- [x] Verified all 10 scripts, 3 charts, 4 environments, and 14 CI workflows match actual repo contents
- [x] No content removed, only additions and corrections

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guidance to describe the three-phase Helm installation flow.
  * Added validation, template linting, dependency synchronization, and installation commands.
  * Expanded architecture documentation for operators, prerequisites, and umbrella charts.
  * Added environment guidance, including the `bmaas-ci` environment.
  * Expanded references for available scripts and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->