### PR TITLE
OSAC-3054: Wire osac-csi-driver into umbrella chart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "base/osac-ui"]
 	path = base/osac-ui
 	url = https://github.com/osac-project/osac-ui.git
+[submodule "base/osac-csi-driver"]
+	path = base/osac-csi-driver
+	url = https://github.com/osac-project/osac-csi-driver.git

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ The OSAC platform relies on four core components to deliver governed self-servic
    Ironic. It watches **BareMetalInstance** CRs (defined by the Bare Metal Fulfillment Operator)
    and reconciles power state with Ironic.
 
+6. **CSI Driver:**
+   An aggregating CSI meta-driver that presents a single CSI identity
+   (`csi.osac.openshift.io`) and routes storage requests to vendor-specific CSI
+   drivers (NetApp Trident, VAST, Pure Storage) based on storage tier resolution.
+   Deployed alongside a `csi-backends` chart that runs the vendor CSI controllers.
+
 ### Prerequisites & Setup
 
 > **System Requirements** This solution requires the following platforms to be installed

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -35,3 +35,13 @@ dependencies:
     repository: "file://../../base/osac-ui/charts/ui"
     alias: ui
     condition: ui.enabled
+  - name: csi-driver
+    version: ">=0.0.0"
+    repository: "file://../../base/osac-csi-driver/charts/csi-driver"
+    alias: csiDriver
+    condition: csiDriver.enabled
+  - name: csi-backends
+    version: ">=0.0.0"
+    repository: "file://../../base/osac-csi-driver/charts/csi-backends"
+    alias: csiBackends
+    condition: csiBackends.enabled

--- a/charts/osac/ci/default-values.yaml
+++ b/charts/osac/ci/default-values.yaml
@@ -1,6 +1,12 @@
 # Default scenario: validates that the chart renders with minimal overrides.
 # Only sets values that subcharts mark as required.
 
+csiDriver:
+  enabled: false
+
+csiBackends:
+  enabled: false
+
 ui:
   enabled: true
   api:

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1241,6 +1241,120 @@
           }
         }
       }
+    },
+    "csiDriver": {
+      "type": "object",
+      "description": "OSAC CSI meta-driver configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the CSI driver subchart",
+          "default": false
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "default": "ghcr.io/osac-project/osac-csi-driver"
+            },
+            "tag": {
+              "type": "string",
+              "default": "latest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "controller": {
+          "type": "object",
+          "properties": {
+            "replicas": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "fulfillmentEndpoint": {
+              "type": "string",
+              "description": "gRPC endpoint for the fulfillment service Volume API"
+            },
+            "vendorSockets": {
+              "type": "string",
+              "description": "Comma-separated backend=endpoint pairs for vendor CSI controllers"
+            },
+            "leaderElection": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
+        "node": {
+          "type": "object",
+          "properties": {
+            "vendorSockets": {
+              "type": "string",
+              "description": "Comma-separated backend=socketpath pairs for vendor CSI node plugins"
+            }
+          }
+        }
+      }
+    },
+    "csiBackends": {
+      "type": "object",
+      "description": "Vendor CSI backend controllers configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable or disable the CSI backends subchart",
+          "default": false
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace for vendor CSI controller deployments",
+          "default": "osac-csi-backends"
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "trident": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "vast": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "pure": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -233,6 +233,33 @@ bmf:
   env:
     aapInsecureSkipVerify: "true"
 
+# --- CSI Driver ---
+csiDriver:
+  enabled: false
+  image:
+    repository: ghcr.io/osac-project/osac-csi-driver
+    tag: latest
+    pullPolicy: IfNotPresent
+  controller:
+    replicas: 1
+    fulfillmentEndpoint: ""
+    vendorSockets: ""
+    leaderElection: true
+  node:
+    vendorSockets: ""
+
+# --- CSI Backends ---
+csiBackends:
+  enabled: false
+  namespace: osac-csi-backends
+  imagePullSecrets: []
+  trident:
+    enabled: false
+  vast:
+    enabled: false
+  pure:
+    enabled: false
+
 # --- Validation hooks ---
 validation:
   enabled: true


### PR DESCRIPTION
## Summary

- Add `base/osac-csi-driver` Git submodule
- Add `csi-driver` and `csi-backends` as umbrella chart dependencies (both disabled by default via `csiDriver.enabled` / `csiBackends.enabled`)
- Add values, schema, and CI defaults
- Add CSI driver to README components list

Depends on osac-csi-driver#6 (Helm charts PR — must merge first so the submodule ref on `main` has charts/).

## Test plan

- [x] `helm dependency build charts/osac/` succeeds
- [x] `helm lint charts/osac/ -f charts/osac/ci/default-values.yaml` passes
- [ ] Merge osac-csi-driver#6, then update submodule ref to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)