### PR TITLE
OSAC-3221: add osac-ui Keycloak client and make KC_HOSTNAME configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,14 @@ wait-for-prereqs-namespaces: ## Wait for the keycloak namespace left Terminating
 .PHONY: install-prereqs
 install-prereqs: wait-for-prereqs-namespaces ## Phase 2: Configure prerequisites (certificates, keycloak, operator CRs)
 	$(eval OCP_VERSION := $(shell oc get clusterversion version -o jsonpath='{.status.desired.version}' | cut -d. -f1,2))
+	$(eval DOMAIN := $(shell oc get ingresses.config/cluster -o jsonpath='{.spec.domain}'))
 	helm upgrade --install osac-prereqs charts/osac-prereqs/ \
 		--namespace osac-prereqs --create-namespace \
 		--values $(VALUES_FILE) \
 		--set osacNamespace=$(INSTALLER_NAMESPACE) \
 		--set lvms.channel=stable-$(OCP_VERSION) \
+		$(if $(DOMAIN),--set keycloak.hostname=https://keycloak-keycloak.$(DOMAIN)) \
+		$(if $(DOMAIN),--set keycloak.route.hostname=keycloak-keycloak.$(DOMAIN)) \
 		--timeout 30m --wait-for-jobs
 
 AAP_LICENSE_FILE ?= $(dir $(VALUES_FILE))license.zip
@@ -85,6 +88,7 @@ install-osac: helm-deps install-secrets check-postgres ## Phase 3: Install OSAC
 		--values $(VALUES_FILE) \
 		--set service.externalHostname=fulfillment-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
 		--set service.internalHostname=fulfillment-internal-api-$(INSTALLER_NAMESPACE).$(DOMAIN) \
+		--set service.auth.issuerUrl=https://keycloak-keycloak.$(DOMAIN)/realms/osac \
 		--timeout 40m --wait
 
 .PHONY: uninstall

--- a/charts/osac-prereqs/files/realm.json
+++ b/charts/osac-prereqs/files/realm.json
@@ -116,6 +116,7 @@
     ],
     "client": {
       "osac-cli": [],
+      "osac-ui": [],
       "realm-management": [
         {
           "id": "6a539c7b-9c68-499a-8eaf-ac1f5cca678b",
@@ -1007,6 +1008,57 @@
         "standard.token.exchange.enabled": "false",
         "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "true",
+        "pkce.code.challenge.method": "S256",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "groups",
+        "basic",
+        "username",
+        "organization",
+        "roles",
+        "osac-api"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
+      "clientId": "osac-ui",
+      "name": "OSAC UI",
+      "description": "OSAC web console",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
         "pkce.code.challenge.method": "S256",
         "backchannel.logout.revoke.offline.tokens": "false"
       },

--- a/charts/osac-prereqs/templates/keycloak/resources.yaml
+++ b/charts/osac-prereqs/templates/keycloak/resources.yaml
@@ -202,6 +202,9 @@ spec:
   dnsNames:
   - keycloak
   - keycloak.keycloak.svc.cluster.local
+  {{- if .Values.keycloak.route.hostname }}
+  - {{ .Values.keycloak.route.hostname }}
+  {{- end }}
   secretName: keycloak-tls-cert
   privateKey:
     rotationPolicy: Always
@@ -397,10 +400,6 @@ spec:
           value: admin
         - name: KEYCLOAK_ADMIN_PASSWORD
           value: admin
-        - name: KC_HOSTNAME_STRICT
-          value: "true"
-        - name: KC_HOSTNAME_STRICT_HTTPS
-          value: "true"
         - name: KC_HTTP_ENABLED
           value: "false"
         - name: KC_HTTPS_ENABLED
@@ -412,7 +411,7 @@ spec:
         - name: KC_HTTPS_CERTIFICATE_KEY_FILE
           value: "/secrets/tls/tls.key"
         - name: KC_HOSTNAME
-          value: "keycloak.keycloak.svc.cluster.local"
+          value: {{ .Values.keycloak.hostname | quote }}
         - name: KC_DB
           value: "postgres"
         - name: KC_DB_URL
@@ -459,6 +458,9 @@ metadata:
   labels:
     {{- include "osac-prereqs.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.keycloak.route.hostname }}
+  host: {{ .Values.keycloak.route.hostname }}
+  {{- end }}
   to:
     kind: Service
     name: keycloak

--- a/charts/osac-prereqs/values.yaml
+++ b/charts/osac-prereqs/values.yaml
@@ -14,6 +14,9 @@ caIssuer:
 keycloak:
   enabled: true
   realmOverwrite: true
+  hostname: "keycloak.keycloak.svc.cluster.local"
+  route:
+    hostname: ""
   images:
     keycloak: quay.io/keycloak/keycloak:26.6.4
     postgres: quay.io/sclorg/postgresql-18-c10s@sha256:6be2c9d855f06fb665257a6b0911676a38d740be7022cc61acee1c99a832b1b2

--- a/prerequisites/keycloak/service/files/realm.json
+++ b/prerequisites/keycloak/service/files/realm.json
@@ -116,6 +116,7 @@
     ],
     "client": {
       "osac-cli": [],
+      "osac-ui": [],
       "realm-management": [
         {
           "id": "6a539c7b-9c68-499a-8eaf-ac1f5cca678b",
@@ -1007,6 +1008,57 @@
         "standard.token.exchange.enabled": "false",
         "post.logout.redirect.uris": "+",
         "oauth2.device.authorization.grant.enabled": "true",
+        "pkce.code.challenge.method": "S256",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "groups",
+        "basic",
+        "username",
+        "organization",
+        "roles",
+        "osac-api"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "d4e5f6a7-b8c9-4d0e-1f2a-3b4c5d6e7f80",
+      "clientId": "osac-ui",
+      "name": "OSAC UI",
+      "description": "OSAC web console",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
         "pkce.code.challenge.method": "S256",
         "backchannel.logout.revoke.offline.tokens": "false"
       },


### PR DESCRIPTION
## Summary
- Add `osac-ui` public Keycloak client to both realm.json files (authorization code flow + PKCE S256, same scopes as osac-cli)
- Make `KC_HOSTNAME` configurable via `keycloak.hostname` Helm value, remove deprecated v1 `KC_HOSTNAME_STRICT`/`KC_HOSTNAME_STRICT_HTTPS` env vars
- Add `keycloak.route.hostname` for TLS cert dnsName and Route host configuration
- Dynamically set `keycloak.hostname`, `keycloak.route.hostname`, and `service.auth.issuerUrl` in Makefile install targets using cluster domain

## Jira
https://redhat.atlassian.net/browse/OSAC-3221

## Test plan
- [x] `helm lint charts/osac-prereqs/` passes
- [x] `helm template` renders correctly with default values (internal hostname, no Route host)
- [x] `helm template` renders correctly with overrides (external URL hostname, Route host in cert dnsNames)
- [x] Deploy on cluster and verify osac-ui login reaches Keycloak login page
- [x] Verify OIDC discovery endpoints return external URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)