### PR TITLE
OSAC-3011: automatic local storage registration for developer environments

### DIFF
--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -15,7 +15,7 @@ done
 echo "Waiting for lvms-operator deployment..."
 oc wait --for=condition=Available deploy/lvms-operator -n openshift-storage --timeout=900s
 
-if oc get sc lvms-vg1 --ignore-not-found -o name | grep -q lvms-vg1; then
+if [[ -n "$(oc get sc lvms-vg1 --ignore-not-found -o name 2>/dev/null)" ]]; then
   echo "lvms-vg1 already exists, skipping LVMCluster creation."
 else
   echo "Applying LVMCluster configuration..."

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -28,7 +28,9 @@ else
   oc apply -f /config/config.yaml
 
   echo "Waiting for lvms-vg1 StorageClass..."
-  until [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name)" ]]; do
+  for _attempt in $(seq 1 120); do
+    [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name 2>/dev/null)" ]] && break
+    (( _attempt < 120 )) || { echo "ERROR: timed out waiting for lvms-vg1 StorageClass" >&2; exit 1; }
     sleep 5
   done
 

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -15,13 +15,17 @@ done
 echo "Waiting for lvms-operator deployment..."
 oc wait --for=condition=Available deploy/lvms-operator -n openshift-storage --timeout=900s
 
-echo "Applying LVMCluster configuration..."
-oc apply -f /config/config.yaml
+if oc get sc lvms-vg1 --ignore-not-found -o name | grep -q lvms-vg1; then
+  echo "lvms-vg1 already exists, skipping LVMCluster creation."
+else
+  echo "Applying LVMCluster configuration..."
+  oc apply -f /config/config.yaml
 
-echo "Waiting for lvms-vg1 StorageClass..."
-until [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name)" ]]; do
-  sleep 5
-done
+  echo "Waiting for lvms-vg1 StorageClass..."
+  until [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name)" ]]; do
+    sleep 5
+  done
+fi
 
 echo "Setting lvms-vg1 as default StorageClass..."
 oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 echo "Waiting for LVMS CSV to appear..."
-until oc get csv --no-headers -n openshift-storage | grep -q lvms; do
+until [[ "$(oc get csv --no-headers -n openshift-storage 2>/dev/null)" == *lvms* ]]; do
   sleep 10
 done
 LVMS_CSV=$(oc get csv --no-headers -n openshift-storage | awk '/lvms/ { print $1 }' | tail -1)
@@ -15,7 +15,9 @@ done
 echo "Waiting for lvms-operator deployment..."
 oc wait --for=condition=Available deploy/lvms-operator -n openshift-storage --timeout=900s
 
-if [[ -n "$(oc get sc lvms-vg1 --ignore-not-found -o name 2>/dev/null)" ]]; then
+_sc_output=$(oc get sc lvms-vg1 --ignore-not-found -o name 2>&1) \
+  || { echo "ERROR: failed to query StorageClasses: ${_sc_output}" >&2; exit 1; }
+if [[ -n "${_sc_output}" ]]; then
   echo "lvms-vg1 already exists, skipping LVMCluster creation."
 else
   echo "Applying LVMCluster configuration..."

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -29,7 +29,9 @@ else
 
   echo "Waiting for lvms-vg1 StorageClass..."
   for _attempt in $(seq 1 120); do
-    [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name 2>/dev/null)" ]] && break
+    _sc_query=$(oc get sc --ignore-not-found lvms-vg1 -o name 2>&1) \
+      || { echo "ERROR: oc get StorageClass failed: ${_sc_query}" >&2; exit 1; }
+    [[ -n "${_sc_query}" ]] && break
     (( _attempt < 120 )) || { echo "ERROR: timed out waiting for lvms-vg1 StorageClass" >&2; exit 1; }
     sleep 5
   done

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -25,9 +25,9 @@ else
   until [[ -n "$(oc get sc --ignore-not-found lvms-vg1 -o name)" ]]; do
     sleep 5
   done
-fi
 
-echo "Setting lvms-vg1 as default StorageClass..."
-oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+  echo "Setting lvms-vg1 as default StorageClass..."
+  oc annotate sc lvms-vg1 storageclass.kubernetes.io/is-default-class=true --overwrite
+fi
 
 echo "LVMS configuration complete."

--- a/charts/osac-prereqs/files/hooks/configure-lvms.sh
+++ b/charts/osac-prereqs/files/hooks/configure-lvms.sh
@@ -18,7 +18,11 @@ oc wait --for=condition=Available deploy/lvms-operator -n openshift-storage --ti
 _sc_output=$(oc get sc lvms-vg1 --ignore-not-found -o name 2>&1) \
   || { echo "ERROR: failed to query StorageClasses: ${_sc_output}" >&2; exit 1; }
 if [[ -n "${_sc_output}" ]]; then
-  echo "lvms-vg1 already exists, skipping LVMCluster creation."
+  # lvms-vg1 pre-exists (e.g. MOC, where it was installed by cluster admins).
+  # Skip both LVMCluster creation AND the default-class annotation: on shared clusters
+  # another StorageClass (e.g. Ceph) is already the intended default, and annotating
+  # lvms-vg1 here would silently override that.
+  echo "lvms-vg1 already exists, skipping LVMCluster creation and annotation."
 else
   echo "Applying LVMCluster configuration..."
   oc apply -f /config/config.yaml

--- a/charts/osac/templates/_helpers.tpl
+++ b/charts/osac/templates/_helpers.tpl
@@ -73,6 +73,10 @@ Uses .Values.cliImage for the container image.
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
     capabilities:
       drop: ["ALL"]
 {{- end }}

--- a/charts/osac/templates/hooks/register-local-storage.yaml
+++ b/charts/osac/templates/hooks/register-local-storage.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.lvms.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: register-local-storage
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "31"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "osac.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: admin
+      initContainers:
+      {{- include "osac.waitForFulfillment" . | nindent 6 }}
+      containers:
+      - name: register-storage
+        image: {{ .Values.cliImage }}
+        command:
+          - /bin/bash
+          - -euo
+          - pipefail
+          - -c
+          - |
+            AUTH_TOKEN=$(< /var/run/secrets/kubernetes.io/serviceaccount/token)
+            API="https://fulfillment-internal-api:8001/api/private/v1"
+
+            # Step 1: Create the local StorageBackend. Capture the ID whether
+            # this is the first install (2xx) or a re-install (409 = already exists).
+            BACKEND_RESP=$(mktemp)
+            BACKEND_CODE=$(curl -skS \
+              --connect-timeout 5 --max-time 30 \
+              -o "${BACKEND_RESP}" -w '%{http_code}' \
+              -X POST "${API}/storage_backends" \
+              -H "Authorization: Bearer ${AUTH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d '{"metadata":{"name":"local"},"spec":{"provider":"local_lvms","endpoint":"n/a","credentials":{"username":"n/a","password":"n/a"}}}')
+
+            case "${BACKEND_CODE}" in
+              2??)
+                BACKEND_ID=$(python3 -c "import sys,json; print(json.load(open('${BACKEND_RESP}'))['id'])")
+                echo "StorageBackend 'local' created (id: ${BACKEND_ID})."
+                ;;
+              409)
+                echo "StorageBackend 'local' already exists, fetching ID..."
+                LIST_RESP=$(mktemp)
+                curl -skS --connect-timeout 5 --max-time 30 \
+                  -o "${LIST_RESP}" \
+                  "${API}/storage_backends" \
+                  -H "Authorization: Bearer ${AUTH_TOKEN}"
+                BACKEND_ID=$(python3 -c "
+import sys, json
+items = json.load(open('${LIST_RESP}')).get('items', [])
+match = next((i for i in items if i.get('metadata', {}).get('name') == 'local'), None)
+if not match:
+    sys.exit('StorageBackend \"local\" not found in list after 409')
+print(match['id'])
+")
+                rm -f "${LIST_RESP}"
+                echo "StorageBackend 'local' already registered (id: ${BACKEND_ID})."
+                ;;
+              *)
+                echo "ERROR: Failed to create StorageBackend 'local' (HTTP ${BACKEND_CODE}):" >&2
+                cat "${BACKEND_RESP}" >&2
+                rm -f "${BACKEND_RESP}"
+                exit 1
+                ;;
+            esac
+            rm -f "${BACKEND_RESP}"
+
+            # Step 2: Create the local StorageTier referencing the backend by ID.
+            # Protocol 2 = STORAGE_PROTOCOL_BLOCK (LVMS provides block volumes).
+            TIER_RESP=$(mktemp)
+            TIER_CODE=$(curl -skS \
+              --connect-timeout 5 --max-time 30 \
+              -o "${TIER_RESP}" -w '%{http_code}' \
+              -X POST "${API}/storage_tiers" \
+              -H "Authorization: Bearer ${AUTH_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "{\"metadata\":{\"name\":\"local\"},\"spec\":{\"backends\":[{\"backend_id\":\"${BACKEND_ID}\",\"protocol\":2}]}}")
+
+            case "${TIER_CODE}" in
+              2??) echo "StorageTier 'local' created." ;;
+              409) echo "StorageTier 'local' already exists, skipping." ;;
+              *)
+                echo "ERROR: Failed to create StorageTier 'local' (HTTP ${TIER_CODE}):" >&2
+                cat "${TIER_RESP}" >&2
+                rm -f "${TIER_RESP}"
+                exit 1
+                ;;
+            esac
+            rm -f "${TIER_RESP}"
+
+            echo "Local storage registration complete."
+        env:
+        - name: HOME
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      restartPolicy: OnFailure
+{{- end }}

--- a/charts/osac/templates/hooks/register-local-storage.yaml
+++ b/charts/osac/templates/hooks/register-local-storage.yaml
@@ -51,20 +51,10 @@ spec:
                 ;;
               409)
                 echo "StorageBackend 'local' already exists, fetching ID..."
-                LIST_RESP=$(mktemp)
-                curl -skS --connect-timeout 5 --max-time 30 \
-                  -o "${LIST_RESP}" \
+                BACKEND_ID=$(curl -skS --connect-timeout 5 --max-time 30 \
                   "${API}/storage_backends" \
-                  -H "Authorization: Bearer ${AUTH_TOKEN}"
-                BACKEND_ID=$(python3 -c "
-import sys, json
-items = json.load(open('${LIST_RESP}')).get('items', [])
-match = next((i for i in items if i.get('metadata', {}).get('name') == 'local'), None)
-if not match:
-    sys.exit('StorageBackend \"local\" not found in list after 409')
-print(match['id'])
-")
-                rm -f "${LIST_RESP}"
+                  -H "Authorization: Bearer ${AUTH_TOKEN}" | \
+                  python3 -c "import sys,json; items=json.load(sys.stdin).get('items',[]); m=next((i for i in items if i.get('metadata',{}).get('name')=='local'),None); sys.exit('local backend not found') if not m else print(m['id'])")
                 echo "StorageBackend 'local' already registered (id: ${BACKEND_ID})."
                 ;;
               *)

--- a/charts/osac/templates/hooks/register-local-storage.yaml
+++ b/charts/osac/templates/hooks/register-local-storage.yaml
@@ -12,7 +12,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
-  activeDeadlineSeconds: 900
+  # waitForFulfillment polls up to 60 × (30s curl + 10s sleep) = 2400s worst case.
+  # This deadline must exceed that to avoid premature termination.
+  activeDeadlineSeconds: 3000
   template:
     metadata:
       labels:
@@ -68,6 +70,7 @@ spec:
 
             # Step 2: Create the local StorageTier referencing the backend by ID.
             # Protocol 2 = STORAGE_PROTOCOL_BLOCK (LVMS provides block volumes).
+            TIER_BODY=$(printf '{"metadata":{"name":"local"},"spec":{"backends":[{"backend_id":"%s","protocol":2}]}}' "${BACKEND_ID}")
             TIER_RESP=$(mktemp)
             TIER_CODE=$(curl -skS \
               --connect-timeout 5 --max-time 30 \
@@ -75,7 +78,7 @@ spec:
               -X POST "${API}/storage_tiers" \
               -H "Authorization: Bearer ${AUTH_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"metadata\":{\"name\":\"local\"},\"spec\":{\"backends\":[{\"backend_id\":\"${BACKEND_ID}\",\"protocol\":2}]}}")
+              -d "${TIER_BODY}")
 
             case "${TIER_CODE}" in
               2??) echo "StorageTier 'local' created." ;;

--- a/charts/osac/templates/hooks/register-local-storage.yaml
+++ b/charts/osac/templates/hooks/register-local-storage.yaml
@@ -12,7 +12,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 5
-  activeDeadlineSeconds: 300
+  activeDeadlineSeconds: 900
   template:
     metadata:
       labels:
@@ -106,6 +106,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
             drop: ["ALL"]
       volumes:

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1223,6 +1223,17 @@
         }
       }
     },
+    "lvms": {
+      "type": "object",
+      "description": "LVMS local storage registration (dev/CI/Beaker only — not for production)",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Register a local StorageBackend and StorageTier backed by LVMS on the hub cluster",
+          "default": false
+        }
+      }
+    },
     "bundledPostgres": {
       "type": "object",
       "description": "Bundled PostgreSQL for CI/dev (ephemeral, not for production)",

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -257,6 +257,13 @@ metallb:
 hubAccess:
   enabled: false
 
+# --- LVMS (local storage) ---
+# When enabled, a post-install hook registers a local StorageBackend and
+# StorageTier in the fulfillment service, backed by LVMS on the hub cluster.
+# Set to true only on clusters where LVMS is pre-installed (dev/CI/Beaker).
+lvms:
+  enabled: false
+
 bundledPostgres:
   enabled: false
   database:

--- a/values/development/values.yaml
+++ b/values/development/values.yaml
@@ -10,7 +10,7 @@ keycloak:
 aapOperator:
   enabled: true
 lvms:
-  enabled: false
+  enabled: true
 metallb:
   enabled: false
 cnv:


### PR DESCRIPTION
## Summary

After this PR, every OSAC deployment with \`lvms.enabled: true\` automatically gets
a \`local\` StorageBackend and \`local\` StorageTier registered in the fulfillment
service — no manual post-install steps. Combined with the \`local_lvms_storage\` AAP
role (osac-aap#454), developers get LVMS-backed per-tenant storage out of the box.

**All four install paths already have \`lvms.enabled: true\` and benefit automatically:**

| Path | Values file | LVMS source |
|------|-------------|-------------|
| Beaker / CI SNO | \`vmaas-ci\` | Installed by \`configure-lvms.sh\` |
| CaaS CI | \`caas-ci\` | Installed by \`configure-lvms.sh\` |
| MOC (hypershift1) | \`development\` | Pre-existing on MOC physical nodes |
| Bare metal | \`bmaas-ci\` | Installed by \`configure-lvms.sh\` |

**Changes:**

**\`charts/osac/templates/hooks/register-local-storage.yaml\` (new)**
Post-install Helm hook (weight 31) that runs after the fulfillment service is ready:
- Registers a \`local\` StorageBackend (\`provider: local-lvms\`, no credentials)
- Registers a \`local\` StorageTier linked to the backend
- Idempotent: 409 on re-install treated as success
- Only rendered when \`lvms.enabled: true\`

**\`charts/osac-prereqs/files/hooks/configure-lvms.sh\` (updated)**
Makes LVMCluster installation idempotent: if \`lvms-vg1\` already exists, the
script skips both the LVMCluster creation and the default-class annotation
entirely, leaving the environment's storage configuration untouched. On a fresh
install where \`lvms-vg1\` does not yet exist, the script creates the LVMCluster
and annotates the resulting SC as the cluster default. This allows setting
\`lvms.enabled: true\` safely on MOC/hypershift1, where LVMS is pre-managed by
the platform (running \`oc apply\` on the LVMCluster config without this guard
would create a conflicting second LVMCluster).

**\`values/development/values.yaml\`**
Enable \`lvms.enabled: true\` for MOC/hypershift1. LVMS is pre-installed on MOC —
the idempotent \`configure-lvms.sh\` skips installation and annotation, and the
hook registers the StorageBackend pointing to the pre-existing \`lvms-vg1\`.

## Test plan
- [ ] Fresh \`make install\`: \`register-local-storage\` hook fires, StorageBackend \`local\` (READY) and StorageTier \`local\` (ACTIVE) visible
- [ ] Re-run \`make install-osac\`: hook is idempotent, no error on existing backend/tier
- [ ] MOC deploy: hook registers backend, \`configure-lvms.sh\` does NOT create second LVMCluster and does NOT annotate pre-existing \`lvms-vg1\`
- [ ] \`lvms.enabled: false\`: hook template not rendered
- [ ] E2E on beaker (SNO): full flow — install → storage registered → tenant onboarded → StorageClass created → PVC bound

## Dependencies
- osac-operator#354 + osac-operator#375 ([OSAC-3013](https://redhat.atlassian.net/browse/OSAC-3013): backend API routing, required for hook's private API calls)
- osac-aap#454 ([OSAC-3011](https://redhat.atlassian.net/browse/OSAC-3011): role that creates per-tenant StorageClasses)
- [OSAC-3013](https://redhat.atlassian.net/browse/OSAC-3013) AAP side (in progress) — required for \`storage_tier_definitions\` to flow from operator into playbooks

---
Generated-By: Claude Code (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional LVMS local storage registration for development and test environments.
  * When enabled, the platform runs a post-install/post-upgrade job to register a local storage backend and storage tier.
* **Bug Fixes**
  * Improved reliability of LVMS readiness detection and storage setup.
  * Made storage configuration idempotent to safely handle re-installs and pre-existing StorageClasses.
* **Security**
  * Hardened hook and init container runtime security with non-root execution and `RuntimeDefault` seccomp settings.
* **Configuration**
  * Enabled LVMS in development values and documented the new `lvms.enabled` option in the values schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->