### PR TITLE
NO-ISSUE: fix bump-submodules using osac-ui SHA for bare-metal-fulfillment-operator

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -48,11 +48,13 @@ jobs:
           FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
           AAP=$(check_image osac-aap osac-aap)
           UI=$(check_image osac-ui osac-ui)
+          BMFO=$(check_image bare-metal-fulfillment-operator bare-metal-fulfillment-operator)
 
           echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
           echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
           echo "aap=${AAP}" >> "$GITHUB_OUTPUT"
           echo "ui=${UI}" >> "$GITHUB_OUTPUT"
+          echo "bmfo=${BMFO}" >> "$GITHUB_OUTPUT"
 
       - name: Update submodules
         id: update
@@ -83,7 +85,7 @@ jobs:
           update_submodule base/osac-fulfillment-service fulfillment-service "${{ steps.find.outputs.fulfillment }}"
           update_submodule base/osac-aap osac-aap "${{ steps.find.outputs.aap }}"
           update_submodule base/osac-ui osac-ui "${{ steps.find.outputs.ui }}"
-          update_submodule base/bare-metal-fulfillment-operator bare-metal-fulfillment-operator "${{ steps.find.outputs.ui }}"
+          update_submodule base/bare-metal-fulfillment-operator bare-metal-fulfillment-operator "${{ steps.find.outputs.bmfo }}"
 
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo -e "${summary}" > /tmp/bump-summary.txt


### PR DESCRIPTION
## Summary

PR #479 added `bare-metal-fulfillment-operator` to the bump-submodules workflow but referenced `steps.find.outputs.ui` instead of adding its own `check_image` call. This caused the workflow to checkout an osac-ui commit (`d74aaaf`) inside the bare-metal-fulfillment-operator submodule → `fatal: unable to read tree`.

- Add missing `check_image bare-metal-fulfillment-operator bare-metal-fulfillment-operator` call
- Wire output as `bmfo` and reference it in the correct `update_submodule` invocation

## Test plan

- [ ] Re-run the `Bump submodules and pinned refs` workflow after merge and verify it passes

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected automated submodule updates so the bare-metal fulfillment component is updated using its verified image version.
  * Improved image verification by checking for the corresponding container image before applying the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->