### PR TITLE
OSAC-3054: wire osac-csi-driver into installer umbrella chart

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "base/osac-ui"]
 	path = base/osac-ui
 	url = https://github.com/osac-project/osac-ui.git
+[submodule "base/osac-csi-driver"]
+	path = base/osac-csi-driver
+	url = https://github.com/osac-project/osac-csi-driver.git

--- a/charts/osac/Chart.yaml
+++ b/charts/osac/Chart.yaml
@@ -35,3 +35,13 @@ dependencies:
     repository: "file://../../base/osac-ui/charts/ui"
     alias: ui
     condition: ui.enabled
+  - name: csi-driver
+    version: ">=0.0.0"
+    repository: "file://../../base/osac-csi-driver/charts/csi-driver"
+    alias: csiDriver
+    condition: csiDriver.enabled
+  - name: csi-backends
+    version: ">=0.0.0"
+    repository: "file://../../base/osac-csi-driver/charts/csi-backends"
+    alias: csiBackends
+    condition: csiDriver.enabled

--- a/charts/osac/ci/full-values.yaml
+++ b/charts/osac/ci/full-values.yaml
@@ -68,6 +68,9 @@ aap:
   configAsCode:
     importBcmAgentsEnabled: false
 
+csiDriver:
+  enabled: true
+
 validation:
   enabled: true
 

--- a/charts/osac/values.schema.json
+++ b/charts/osac/values.schema.json
@@ -1014,6 +1014,46 @@
         }
       }
     },
+    "csiDriver": {
+      "type": "object",
+      "description": "OSAC CSI driver configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy the OSAC CSI driver (opt-in)",
+          "default": false
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "CSI driver container image repository",
+              "default": "ghcr.io/osac-project/osac-csi-driver"
+            },
+            "tag": {
+              "type": "string",
+              "description": "CSI driver container image tag",
+              "default": "latest"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "description": "Image pull policy",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ],
+              "default": "Always"
+            }
+          }
+        }
+      }
+    },
+    "csiBackends": {
+      "type": "object",
+      "description": "Vendor CSI backend configuration (deployed with csiDriver)"
+    },
     "bmfCrds": {
       "type": "object",
       "description": "Bare Metal Fulfillment Operator CRDs configuration"

--- a/charts/osac/values.yaml
+++ b/charts/osac/values.yaml
@@ -204,6 +204,17 @@ ui:
   images:
     ui: ghcr.io/osac-project/osac-ui:latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
 
+# --- CSI Driver ---
+csiDriver:
+  enabled: false
+  image:
+    repository: ghcr.io/osac-project/osac-csi-driver
+    tag: latest  # PLACEHOLDER -- overwritten at release time by publish-charts.yaml
+    pullPolicy: Always
+
+# --- CSI Backends ---
+csiBackends: {}
+
 # --- Bare Metal Fulfillment Operator CRDs ---
 bmfCrds: {}
 


### PR DESCRIPTION
## Summary
- Add `osac-csi-driver` as a git submodule under `base/`
- Add `csi-driver` and `csi-backends` as Helm dependencies in the umbrella chart (`charts/osac/Chart.yaml`)
- Gate both subcharts with `csiDriver.enabled` (default: `false` — opt-in until the driver matures)
- Add `csiDriver` values, JSON schema, and CI test coverage (`full-values.yaml`)

## Test plan
- [x] `helm lint` passes with default values (CSI disabled)
- [x] `helm lint` passes with full values (CSI enabled)
- [x] `helm template` renders CSI resources only when `csiDriver.enabled: true`
- [x] `helm template` produces zero CSI resources when `csiDriver.enabled: false`

Resolves: [OSAC-3054](https://redhat.atlassian.net/browse/OSAC-3054)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CSI driver and backend components to the OSAC Helm chart.
  * Added configuration for enabling the CSI driver and customizing its container image and pull policy.
  * Added schema validation and default values for CSI-related settings.
  * Enabled CSI components in the full deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->