### PR TITLE
OSAC-1684: Temporarily mute Scan workflow logs Slack

### DIFF
--- a/.github/workflows/scan-workflow-logs.yml
+++ b/.github/workflows/scan-workflow-logs.yml
@@ -176,6 +176,14 @@ jobs:
           SCAN_OK: ${{ steps.scan.outputs.scan-ok }}
         run: |
           set -euo pipefail
+          # TEMP (post osac-test-infra#262 / OSAC-1684): mute Slack while e2e
+          # logs still commonly leak. Scan/purge + PR comments stay enabled
+          # (they run before this step). Keep should-alert.value accurate so
+          # job summary / annotations still surface the condition. Set
+          # MUTE_SLACK_ALERTS=false to re-enable Slack. Mirror of
+          # osac-test-infra PR #280.
+          MUTE_SLACK_ALERTS=true
+          echo "muted=${MUTE_SLACK_ALERTS}" >> "${GITHUB_OUTPUT}"
           # Alert on cancelled/skipped/missing outputs too -- only a fully
           # successful scan with an explicit scan-ok=true is quiet.
           if [[ "${SCAN_OUTCOME}" != "success" || "${LEAKS_FOUND}" == "true" || "${SCAN_OK}" != "true" ]]; then
@@ -183,9 +191,15 @@ jobs:
           else
             echo "value=false" >> "${GITHUB_OUTPUT}"
           fi
+          if [[ "${MUTE_SLACK_ALERTS}" == "true" ]]; then
+            echo "Slack alerts temporarily muted (MUTE_SLACK_ALERTS=true); scan/purge + PR comments unchanged"
+          fi
 
       - name: Read AppRole credentials
-        if: always() && steps.should-alert.outputs.value == 'true'
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true'
         id: approle
         run: |
           set -euo pipefail
@@ -204,6 +218,7 @@ jobs:
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           steps.approle.outcome == 'success'
         id: vault
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4
@@ -283,6 +298,7 @@ jobs:
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           steps.vault.outcome == 'success' &&
           steps.slack-payload.outcome == 'success'
         uses: osac-project/osac-test-infra/.github/actions/notify-slack@b1f29a958073a6271b37ce45f2093f07ba31b8fa  # main
@@ -296,11 +312,14 @@ jobs:
           commit-sha: ${{ github.event.workflow_run.head_sha }}
 
       # Vault/payload/notify failure: keep the security-relevant event visible
-      # via annotation + job summary so it is not silent.
+      # via annotation + job summary so it is not silent. Skip when Slack is
+      # intentionally muted -- the muted-summary step below covers that case
+      # without pretending Vault/notify failed.
       - name: Surface alert when Slack notify unavailable
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           (steps.vault.outcome != 'success' ||
            steps.slack-payload.outcome != 'success' ||
            steps.notify-slack.outcome != 'success')
@@ -321,4 +340,26 @@ jobs:
             echo "- **Reason:** ${reason}"
             echo "- **Alert:** ${alert}"
             echo "- **Upstream run:** ${WORKFLOW_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      # TEMP mute path: still record the alert in the job summary so a muted
+      # Slack channel does not also hide the condition from Actions UI.
+      - name: Surface alert while Slack muted
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted == 'true'
+        env:
+          FAILED_STEP: ${{ steps.slack-payload.outputs.failed-step }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          alert="${FAILED_STEP:-scan/leak alert condition met}"
+          echo "::notice::Slack muted (TEMP post osac-test-infra#262); alert still recorded: ${alert}. Run: ${WORKFLOW_URL}"
+          {
+            echo "## Slack muted (temporary)"
+            echo ""
+            echo "- **Alert:** ${alert}"
+            echo "- **Upstream run:** ${WORKFLOW_URL}"
+            echo "- **Re-enable:** set \`MUTE_SLACK_ALERTS=false\` in \`scan-workflow-logs.yml\`"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary
- Mirror of [osac-test-infra#280](https://github.com/osac-project/osac-test-infra/pull/280): temporarily mute Slack from **Scan workflow logs** after [osac-test-infra#262](https://github.com/osac-project/osac-test-infra/pull/262) flooded the channel.
- **Unchanged:** scan/purge and PR leak comments.
- `should-alert.value` stays accurate; AppRole/Vault/notify gated on `muted != true`. Muted alerts still land in the job summary / `::notice::`.
- Re-enable: set `MUTE_SLACK_ALERTS=false` in `.github/workflows/scan-workflow-logs.yml`.

## Test plan
- [ ] Confirm AppRole/Vault/Notify Slack are skipped when muted
- [ ] Confirm job summary shows **Slack muted (temporary)** on a leak/failure
- [ ] Confirm a completed e2e still runs scan/purge
- [ ] Confirm leak findings still get a PR comment when an open PR exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a temporary mute mode for Slack alerts.
  * When alerts are muted, detected issues are recorded in the job summary instead of sending Slack notifications.

* **Bug Fixes**
  * Prevented unnecessary credential retrieval and notification attempts while Slack alerts are muted.
  * Existing log and artifact scanning, cleanup, and pull request reporting remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->