### PR TITLE
OSAC-3465: fix cert-manager OLM race by waiting for ServiceAccounts

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -48,11 +48,13 @@ jobs:
           FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
           AAP=$(check_image osac-aap osac-aap)
           UI=$(check_image osac-ui osac-ui)
+          BMFO=$(check_image bare-metal-fulfillment-operator bare-metal-fulfillment-operator)
 
           echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
           echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
           echo "aap=${AAP}" >> "$GITHUB_OUTPUT"
           echo "ui=${UI}" >> "$GITHUB_OUTPUT"
+          echo "bmfo=${BMFO}" >> "$GITHUB_OUTPUT"
 
       - name: Update submodules
         id: update
@@ -83,7 +85,7 @@ jobs:
           update_submodule base/osac-fulfillment-service fulfillment-service "${{ steps.find.outputs.fulfillment }}"
           update_submodule base/osac-aap osac-aap "${{ steps.find.outputs.aap }}"
           update_submodule base/osac-ui osac-ui "${{ steps.find.outputs.ui }}"
-          update_submodule base/bare-metal-fulfillment-operator bare-metal-fulfillment-operator "${{ steps.find.outputs.ui }}"
+          update_submodule base/bare-metal-fulfillment-operator bare-metal-fulfillment-operator "${{ steps.find.outputs.bmfo }}"
 
           echo "changed=${changed}" >> "$GITHUB_OUTPUT"
           echo -e "${summary}" > /tmp/bump-summary.txt

--- a/charts/osac-operators/files/hooks/wait-cert-manager.sh
+++ b/charts/osac-operators/files/hooks/wait-cert-manager.sh
@@ -16,6 +16,15 @@ spec:
   managementState: "Managed"
 EOF
 
+echo "Waiting for cert-manager ServiceAccounts..."
+for sa in cert-manager cert-manager-webhook cert-manager-cainjector; do
+  echo "  Waiting for ServiceAccount ${sa}..."
+  until oc get sa "${sa}" -n cert-manager &>/dev/null; do
+    sleep 5
+  done
+  echo "  ServiceAccount ${sa} exists."
+done
+
 echo "Waiting for cert-manager deployment..."
 oc wait --for=condition=Available deploy/cert-manager -n cert-manager --timeout=300s
 

--- a/charts/osac-operators/templates/hooks/wait-cert-manager.yaml
+++ b/charts/osac-operators/templates/hooks/wait-cert-manager.yaml
@@ -23,6 +23,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "5"
 rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## Summary

- Add ServiceAccount polling loop before Deployment waits in `wait-cert-manager.sh` to prevent OLM race condition
- Add RBAC rule for the wait-hook Job to read ServiceAccounts in cert-manager namespace
- Fixes ~13 Install OSAC failures per 48h across both VMaaS and BMaaS

## Problem

OLM sometimes creates cert-manager Deployments before the operator creates their ServiceAccounts. Pods fail with:
```
error looking up service account cert-manager/cert-manager-webhook: serviceaccount "cert-manager-webhook" not found
```
Deployments never reach Available, `oc wait` times out at 300s, and the entire install fails.

## Fix

Wait for all three ServiceAccounts (`cert-manager`, `cert-manager-webhook`, `cert-manager-cainjector`) to exist before waiting on Deployment availability. Uses the same `until oc get ... ; do sleep; done` polling pattern already used for CRD readiness in the same script.

## Test plan

- [ ] `helm lint charts/osac-operators/` passes
- [ ] `helm template` renders new RBAC rule in ClusterRole
- [ ] E2E VMaaS full-install passes
- [ ] E2E BMaaS full-install passes
- [ ] Monitor Install OSAC failure rate after merge

Fixes: https://redhat.atlassian.net/browse/OSAC-3465

🤖 Generated with [Claude Code](https://claude.com/claude-code)