### PR TITLE
OSAC-3367: Isolate per-component failures in bot automation

### DIFF
--- a/.github/workflows/bump-submodules.yaml
+++ b/.github/workflows/bump-submodules.yaml
@@ -24,11 +24,22 @@ jobs:
         run: |
           set -euo pipefail
 
+          # A single component's repo becoming unreachable (renamed, archived
+          # off its expected name, or deleted as part of the mono-repo
+          # cutover) must only skip that component's bump, not abort the
+          # whole job -- this used to be a bare, unguarded call under
+          # `set -e`, so one 404 here killed every other component's bump
+          # too, every 3 hours, until someone noticed. `|| return 1` on the
+          # repo lookup plus `|| VAR=""` at each call site (below) keeps
+          # set -e from propagating past a single component's failure.
           check_image() {
             local repo=$1
             local image=$2
             local sha
-            sha=$(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=1" --jq '.[0].sha')
+            sha=$(gh api "repos/osac-project/${repo}/commits?sha=main&per_page=1" --jq '.[0].sha') || {
+              echo "::warning::${repo}: could not resolve latest main commit (repo missing/renamed/archived?) -- skipping this component's bump" >&2
+              return 1
+            }
             local tag="sha-${sha:0:7}"
             local token
             token=$(curl -sf "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
@@ -38,17 +49,17 @@ jobs:
               -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
               "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
             if [[ "${code}" != "200" ]]; then
-              echo "ERROR: ${repo} latest main commit ${sha:0:7} has no published image (tag ${tag})" >&2
+              echo "::warning::${repo} latest main commit ${sha:0:7} has no published image (tag ${tag}) -- skipping this component's bump" >&2
               return 1
             fi
             echo "${sha}"
           }
 
-          OPERATOR=$(check_image osac-operator osac-operator)
-          FULFILLMENT=$(check_image fulfillment-service fulfillment-service)
-          AAP=$(check_image osac-aap osac-aap)
-          UI=$(check_image osac-ui osac-ui)
-          BMFO=$(check_image bare-metal-fulfillment-operator bare-metal-fulfillment-operator)
+          OPERATOR=$(check_image osac-operator osac-operator) || OPERATOR=""
+          FULFILLMENT=$(check_image fulfillment-service fulfillment-service) || FULFILLMENT=""
+          AAP=$(check_image osac-aap osac-aap) || AAP=""
+          UI=$(check_image osac-ui osac-ui) || UI=""
+          BMFO=$(check_image bare-metal-fulfillment-operator bare-metal-fulfillment-operator) || BMFO=""
 
           echo "operator=${OPERATOR}" >> "$GITHUB_OUTPUT"
           echo "fulfillment=${FULFILLMENT}" >> "$GITHUB_OUTPUT"
@@ -66,6 +77,10 @@ jobs:
             local path=$1
             local name=$2
             local target=$3
+            if [[ -z "${target}" ]]; then
+              echo "${name}: skipping (no eligible commit found this run -- see check_image warning above)"
+              return
+            fi
             local current
             current=$(git -C "${path}" rev-parse HEAD)
             if [[ "${current}" == "${target}" ]]; then

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -62,6 +62,19 @@ jobs:
           local sha
           sha=$(git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=10 \
             ls-remote "https://github.com/osac-project/${repo}.git" refs/heads/main | cut -f1)
+          # A repo that's been renamed, archived off this name, or deleted
+          # as part of the mono-repo cutover resolves to an empty sha here
+          # (ls-remote against a 404 prints nothing) rather than failing
+          # loudly -- without this check that silently produced tag
+          # "sha-" below, which then just as silently 404s against ghcr and
+          # gets misreported as "no published image" instead of "repo is
+          # gone", making a real cutover event indistinguishable from the
+          # routine every-day case where a component simply hasn't
+          # published a new image yet.
+          if [[ -z "${sha}" ]]; then
+            echo "::warning::${repo}: could not resolve main HEAD (repo missing/renamed/archived?) -- keeping pinned submodule" >&2
+            return 1
+          fi
           local tag="sha-${sha:0:7}"
           local token
           token=$(curl -sf --max-time 15 "https://ghcr.io/token?scope=repository:osac-project/${image}:pull" | jq -r .token)
@@ -71,7 +84,7 @@ jobs:
             -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json" \
             "https://ghcr.io/v2/osac-project/${image}/manifests/${tag}")
           if [[ "${code}" != "200" ]]; then
-            echo "WARN: ${repo} main HEAD ${sha:0:7} has no published image (tag ${tag}), keeping pinned submodule" >&2
+            echo "::warning::${repo} main HEAD ${sha:0:7} has no published image (tag ${tag}) -- keeping pinned submodule" >&2
             return 1
           fi
           echo "${sha}"


### PR DESCRIPTION
## Summary

Investigated `bump-submodules.yaml`, `nightly-build.yaml`, and `scripts/sync-image-tags.sh` against their actual current behavior (not assumptions) ahead of the fulfillment-service/osac-operator -> osac mono-repo cutover, where each standalone repo will eventually be renamed/archived/removed.

### `bump-submodules.yaml` -- real, present-tense bug fixed

Its five `check_image()` calls ran under `set -euo pipefail` with no per-call guard, so a single component's repo becoming unreachable (404, rename, etc.) aborted the **entire step** -- and therefore every other component's bump too -- rather than just skipping that one component. This isn't hypothetical or tied to a specific future cutover date: a transient API hiccup on any one of the five repos already had this effect every 3 hours.

- Added a guarded fallback at each call site (`|| VAR=""`) plus an explicit `::warning::` when the repo lookup itself fails.
- Taught `update_submodule()` to skip cleanly when a component has no eligible commit this run, instead of trying to check out an empty target.

### `nightly-build.yaml` -- visibility gap fixed

Already had a `|| continue` around `check_image()` (so it doesn't share the job-wide-abort bug above), but a repo that's become completely unreachable resolved to an empty `sha` silently, which then produced a nonsensical `"sha-"` tag lookup and got misreported as "no published image" -- indistinguishable from the routine, harmless case of a component simply not having a new image yet.

- Added an explicit check + `::warning::` for the empty-sha case.
- Switched the existing plain `"WARN:"` text to the `::warning::` annotation format GitHub Actions actually surfaces in the run UI.

### `sync-image-tags.sh` / `check-image-tags.yaml` -- investigated, left unchanged

Both currently work correctly: `values/*/values.yaml` still reference `ghcr.io/osac-project/osac-operator` and `ghcr.io/osac-project/fulfillment-service`, which is exactly what those still-live, still-independently-published repos currently publish under (confirmed against the actual `ghcr.io` package listings, not assumed). Nothing to point anywhere else yet -- neither component's submodule, image name, or tag scheme has actually changed as part of the cutover so far, and [OSAC-3467/osac-project/osac#29](https://github.com/osac-project/osac/pull/29) (which will introduce component-scoped release tags within `osac-project/osac`) is still open/unmerged as of this PR. Per the ticket, this is intentional: update incrementally as each component's cutover actually happens, not speculatively ahead of it.

Part of [OSAC-1732](https://redhat.atlassian.net/browse/OSAC-1732) (Repository Consolidation mono-repo epic).

## Test plan
- [x] `pre-commit run` (trailing-whitespace, yamllint, etc.) passes on both touched files
- [x] `shellcheck` on the modified script blocks, diffed against the pre-change originals -- zero new findings introduced (the existing findings, e.g. GH Actions `${{ }}` expressions shellcheck can't parse, are pre-existing and unrelated)
- [x] Functionally simulated `bump-submodules.yaml`'s two modified steps with stubbed `gh`/`curl`/`jq`/`git`, forcing one component (`fulfillment-service`) to fail -- confirmed the step completes successfully with the other four components resolved correctly and the failed one cleanly skipped, instead of aborting
- [x] Functionally simulated `nightly-build.yaml`'s `check_image` loop the same way -- confirmed the warning fires and the loop continues to the next component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow handling for missing, inaccessible, or archived component repositories.
  * Nightly builds now retain the existing pinned component when the main branch cannot be resolved.
  * Added clearer warnings when commits or images cannot be found.
  * Prevented failed component checks from aborting the entire update or build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->